### PR TITLE
Add Point and Millimeter types to UnitFloatType

### DIFF
--- a/src/psd_tools/constants.py
+++ b/src/psd_tools/constants.py
@@ -358,6 +358,8 @@ class UnitFloatType(Enum):
     NONE = b'#Nne' # coerced
     PERCENT = b'#Prc' # unit value
     PIXELS = b'#Pxl' # tagged unit value
+    POINTS = b'#Pnt' # points
+    MILLIMETERS = b'#Mlm' # millimeters
 
 class SectionDivider(Enum):
     OTHER = 0


### PR DESCRIPTION
See http://forums.adobe.com/message/5399877#5399877
# Pnt and #Mlm can occur as Unit Float types.

Unfortunately I'm unable to supply an example PSD b/c I don't have Photoshop and can't distribute the PSD I encountered #Pnt in, but this makes the library work for me. I threw in #Mlm because why not :)
