### PR TITLE
First pass at bitmap mask support

### DIFF
--- a/src/psd_tools/user_api/pil_support.py
+++ b/src/psd_tools/user_api/pil_support.py
@@ -20,6 +20,15 @@ try:
 except ImportError:
     ImageCms = None
 
+orig_frombytes = frombytes
+def frombytes(mode, size, *args, **kwargs):
+    # PIL chokes if we ask for a (0,0) image, which are valid layers in PSDs.  Convert them
+    # to 1,1 layers with a value of 0.  That's not quite the same, but if the layer has an alpha
+    # mask it'll come out the same.
+    if size == (0, 0):
+        return Image.new(mode, (1,1), 0)
+
+    return orig_frombytes(mode, size, *args, **kwargs)
 
 def extract_layer_image(decoded_data, layer_index):
     """


### PR DESCRIPTION
This is functional but shouldn't be merged as-is.  I'm sending a PR because it's been sitting around in a "good enough for now" state for a while and I want to make it available if anyone wants to work on it (or use it as-is), rather than having it be lost on my drive.

This implements bitmap masks, which applies a layer's mask to the bitmap when it's converted to an image.  It doesn't provide any interface to read or manipulate the mask directly, but it's enough to handle the common case where you just want to get the flattened layer pixels.  Note that the mask enabled flag is ignored; masks are always applied.

This only looks at ChannelID.USER_LAYER_MASK.  I don't know what REAL_USER_LAYER_MASK is, so I left it unhandled.

This is missing:
- extract_composite_image support.  The data flow here is different from extract_layer_image, and I haven't looked at what to do here.
- There are no tests.
