### PR TITLE
Fix incorrect conditional when attempting to decode references.

### DIFF
--- a/src/psd_tools/decoder/actions.py
+++ b/src/psd_tools/decoder/actions.py
@@ -110,7 +110,7 @@ def decode_ref(key, fp):
         ostype = fp.read(4)
 
         decode_ostype = get_reference_ostype_decode_func(ostype)
-        if decode_ostype:
+        if not decode_ostype:
             raise UnknownOSType('Unknown reference item of type %r' % ostype)
 
         value = decode_ostype(key, fp)


### PR DESCRIPTION
The interaction I ran into involved smart objects and smart filters, but I couldn't manage to reproduce the problem in a fresh PSD. I've uploaded a rather large failing PSD here as an example.

Failing PSD: [test_enum.psd.zip](https://github.com/psd-tools/psd-tools/files/52968/test_enum.psd.zip)

  