### PR TITLE
namedtuple's verbose argument changed to keyword-only in Python 3.6

### DIFF
--- a/src/psd_tools/debug.py
+++ b/src/psd_tools/debug.py
@@ -36,7 +36,7 @@ def pretty_namedtuple(typename, field_names, verbose=False):
     Return a namedtuple class that knows how to pretty-print itself
     using IPython.lib.pretty library.
     """
-    cls = namedtuple(typename, field_names, verbose)
+    cls = namedtuple(typename, field_names, verbose=verbose)
     PrettyMixin = _get_pretty_mixin(typename)
     cls = type(str(typename), (PrettyMixin, cls), {})
 


### PR DESCRIPTION
The `verbose` argument for Python's `collections.namedtuple()` changed to keyword-only in >= Python3.6 (see https://docs.python.org/3/library/collections.html#collections.namedtuple)

This PR changes `debug.py` to reflect that.