### PR TITLE
added support for merging layer masks when using as_PIL()

### DIFF
--- a/src/psd_tools/reader/layers.py
+++ b/src/psd_tools/reader/layers.py
@@ -31,7 +31,7 @@ MaskParameters = pretty_namedtuple('MaskParameters', 'user_mask_density user_mas
                                                      'vector_mask_density vector_mask_feather')
 LayerBlendingRanges = pretty_namedtuple('LayerBlendingRanges', 'composite_ranges channel_ranges')
 _Block = pretty_namedtuple('Block', 'key data')
-_ChannelData = pretty_namedtuple('ChannelData', 'compression data')
+_ChannelData = pretty_namedtuple('ChannelData', 'compression data mask_data')
 GlobalMaskInfo = pretty_namedtuple('GlobalMaskInfo', 'overlay_color opacity kind')
 
 
@@ -90,9 +90,9 @@ class Block(_Block):
 
 class ChannelData(_ChannelData):
     def __repr__(self):
-        return "ChannelData(compression=%r %s, len(data)=%r)" % (
+        return "ChannelData(compression=%r %s, len(data)=%r, mask_data=%r)" % (
             self.compression, Compression.name_of(self.compression),
-            len(self.data) if self.data is not None else None
+            len(self.data) if self.data is not None else None, self.mask_data
         )
 
     def _repr_pretty_(self, p, cycle):
@@ -406,7 +406,7 @@ def _read_channel_image_data(fp, layer, depth):
             if data is None:
                 return []
 
-            channel_data.append(ChannelData(compress_type, data))
+            channel_data.append(ChannelData(compress_type, data, layer.mask_data))
 
         remaining_length = channel.length - (fp.tell() - start_pos)
         if remaining_length > 0:
@@ -477,6 +477,6 @@ def read_image_data(fp, header):
 
         if data is None:
             return []
-        channel_data.append(ChannelData(compress_type, data))
+        channel_data.append(ChannelData(compress_type, data, None))
 
     return channel_data


### PR DESCRIPTION
Hi,

I need to export layers from a PSD file and some of them have to have a layer mask (I can't change this requirement on my project). So I adjusted psd_tools code to multiply the alpha channel with the mask channel and then merge it all together when returning a PIL object.
it works good for me so far, so I'd like to share the code.

The code ain't great, some things could probably be done better, plus I may have not covered all situations due to my unfamiliarity with psd-tools codebase. However, I think it's a good start from which we can improve these commits and merge into psd-tools if you approve this approach.
The functionality could maybe be controlled by a global flag if someone doesn't want to merge layer masks?