### PR TITLE
Remove verbose keyword argument in namedtuple

### DIFF
--- a/src/psd_tools/debug.py
+++ b/src/psd_tools/debug.py
@@ -31,12 +31,12 @@ def debug_view(fp, txt="", max_back=20):
     print(txt, repr(pre), "--->.<---", repr(post))
 
 
-def pretty_namedtuple(typename, field_names, verbose=False):
+def pretty_namedtuple(typename, field_names):
     """
     Return a namedtuple class that knows how to pretty-print itself
     using IPython.lib.pretty library.
     """
-    cls = namedtuple(typename, field_names, verbose=verbose)
+    cls = namedtuple(typename, field_names)
     PrettyMixin = _get_pretty_mixin(typename)
     cls = type(str(typename), (PrettyMixin, cls), {})
 


### PR DESCRIPTION
 Closes #86
The "verbose" argument to namedtuple was removed in Python 3.7, so this package is currently incompatible with versions of Python >3.6

None of the other calls to `pretty_namedtuple` in the package use the optional `verbose` argument, so I removed it from the function signature as well.
