### PR TITLE
Delete duplicate definition of has_mask function

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -132,10 +132,6 @@ class Layer(object):
     def blend_mode(self, value):
         self._record.blend_mode = BlendMode(value)
 
-    def has_mask(self):
-        """Returns True if the layer has a mask."""
-        return self._record.mask_data is not None
-
     @property
     def left(self):
         """


### PR DESCRIPTION
There is duplicate definition of has_mask function.

In Python, the earlier function definition is overwritten by the later function definition.

Unnecessary functions should be removed to avoid confusion.

I provide the modified source code.