### PR TITLE
Check if a layer has vector mask before rendering strokes

### DIFF
--- a/src/psd_tools/composite/__init__.py
+++ b/src/psd_tools/composite/__init__.py
@@ -334,7 +334,7 @@ class Compositor(object):
             color = self._apply_clip_layers(layer, color, alpha)
 
         # Apply stroke if any.
-        if layer.has_stroke() and layer.stroke.enabled:
+        if layer.has_vector_mask() and layer.has_stroke() and layer.stroke.enabled:
             color_s, shape_s, alpha_s = self._get_stroke(layer)
             compositor = Compositor(self._viewport, color, alpha)
             compositor._apply_source(


### PR DESCRIPTION
This PR is to fix #299.
There is sometimes a layer in PSD with `stroke` but without `vector_mask`, which result in an error when attributes of `layer.vector_mask` are accessed in `layer.composite()`. We just skip rendering strokes when the layer has no vector mask.
