### PR TITLE
add readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
- Add readthedocs configuration file (fix #304)

See https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install