### PR TITLE
Update actions packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_BEFORE_BUILD: pip install cython
-          CIBW_TEST_REQUIRES: pytest numpy ipython "traitlets<5.2.1"
+          CIBW_TEST_REQUIRES: pytest numpy ipython
           CIBW_TEST_COMMAND: pytest {project}/tests
           # aggdraw 1.3.12 only supports <cp39
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *_aarch64 *-musllinux* cp39-manylinux_i686 cp310-manylinux_i686 cp310-win32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_BEFORE_BUILD: pip install cython
-          CIBW_TEST_REQUIRES: pytest numpy ipython traitlets<5.2.1
+          CIBW_TEST_REQUIRES: pytest numpy ipython "traitlets<5.2.1"
           CIBW_TEST_COMMAND: pytest {project}/tests
           # aggdraw 1.3.12 only supports <cp39
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *_aarch64 *-musllinux* cp39-manylinux_i686 cp310-manylinux_i686 cp310-win32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_BEFORE_BUILD: pip install cython
-          CIBW_TEST_REQUIRES: pytest numpy ipython
+          CIBW_TEST_REQUIRES: pytest numpy ipython traitlets<5.2.1
           CIBW_TEST_COMMAND: pytest {project}/tests
           # aggdraw 1.3.12 only supports <cp39
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *_aarch64 *-musllinux* cp39-manylinux_i686 cp310-manylinux_i686 cp310-win32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
 
@@ -62,7 +62,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.5.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ARCHS_LINUX: auto aarch64
@@ -71,7 +71,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest numpy ipython
           CIBW_TEST_COMMAND: pytest {project}/tests
           # aggdraw 1.3.12 only supports <cp39
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-musllinux* cp39-manylinux_i686 cp310-manylinux_i686 cp310-win32"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *_aarch64 *-musllinux* cp39-manylinux_i686 cp310-manylinux_i686 cp310-win32"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -88,7 +88,7 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,8 @@ build:
 
 sphinx:
    configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+    - path: .


### PR DESCRIPTION
- Update `cibuildwheel` to v2.5.0
- Skip slow `aarch64` tests on QEMU
- Update `gh-action-pypi-publish` to `release/v1`