### PR TITLE
Emit warning only when LayerAndMaskInformation is broken

### DIFF
--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -56,7 +56,10 @@ class LayerAndMaskInformation(BaseElement):
             self = cls()
         else:
             self = cls._read_body(fp, end_pos, encoding, version)
-        assert fp.tell() <= end_pos
+        if fp.tell() > end_pos:
+            logger.warning(
+                'LayerAndMaskInformation is broken: current fp=%d, expected=%d' % (
+                    fp.tell(), end_pos))
         fp.seek(end_pos, 0)
         return self
 


### PR DESCRIPTION
Workaround for the assertion error (fix #316)

Changes:
- Emit warning instead of assertion error for a broken PSD file