### PR TITLE
Accept other classId in Stroke constructor

### DIFF
--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -164,7 +164,7 @@ class Stroke(object):
 
     def __init__(self, data):
         self._data = data
-        assert self._data.classID == b'strokeStyle'
+        assert self._data.classID == b'strokeStyle' or self._data.classID == b'Strk'
 
     @property
     def enabled(self):

--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 import logging
 
 from psd_tools.psd.vector import Subpath, InitialFillRule, ClipboardRecord
+from psd_tools.terminology import Event
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +165,8 @@ class Stroke(object):
 
     def __init__(self, data):
         self._data = data
-        assert self._data.classID == b'strokeStyle' or self._data.classID == b'Strk'
+        if self._data.classID not in (b'strokeStyle', Event.Stroke):
+            logger.warning("Unknown class ID found: {}".format(self._data.classID))
 
     @property
     def enabled(self):


### PR DESCRIPTION
# Context
I have see a user-uploaded file that psd-tools can't read. This file was produced by Affinity Photo 1.10.4 and exported as PSD.

The file was failing in the `Stroke` constructor at `assert self._data.classID == b"strokeStyle"`. Instead the `classId` is `Strk`

Photoshop doesn't have a problem opening this file, and does so without warning. So the classId check can be either relaxed (accept 2 values) or removed entirely.

Just wondering if it is best to allow 2 values here, or to remove the assert altogether?

