### PR TITLE
fix missing arguments when calling draw_solid_color_fill

### DIFF
--- a/src/psd_tools/composite/__init__.py
+++ b/src/psd_tools/composite/__init__.py
@@ -440,7 +440,7 @@ class Compositor(object):
 
     def _apply_color_overlay(self, layer, color, shape, alpha):
         for effect in layer.effects.find('coloroverlay'):
-            color, shape_e = draw_solid_color_fill(layer.bbox, effect.value)
+            color, shape_e = draw_solid_color_fill(layer.bbox, layer._psd.color_mode, effect.value)
             color = paste(self._viewport, layer.bbox, color, 1.)
             if shape_e is None:
                 shape_e = np.ones((self.height, self.width, 1),

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -20,7 +20,7 @@ def draw_stroke_effect(viewport, shape, desc, psd):
 
     paint = desc.get(Key.PaintType).enum
     if paint == Enum.SolidColor:
-        color, _ = draw_solid_color_fill(viewport, desc)
+        color, _ = draw_solid_color_fill(viewport, psd.color_mode, desc)
     elif paint == Enum.Pattern:
         color, _ = draw_pattern_fill(viewport, psd, desc)
     elif paint == Enum.GradientFill:


### PR DESCRIPTION
In my last PR [here](https://github.com/psd-tools/psd-tools/pull/361).

I missed a couple of call sites when adding an argument to `draw_solid_color_fill`.

This causes the following error:
```
TypeError: draw_solid_color_fill() missing 1 required positional argument: 'desc'
```

Sorry if anyone was affected by this bug in the 1.9.29 release (4 days old)

cc: @kyamagu 