### PR TITLE
Fix merged preview image having transparency when it shouldn't

### DIFF
--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -124,6 +124,8 @@ def has_transparency(psd):
         alpha_ids = psd.image_resources.get_data(Resource.ALPHA_IDENTIFIERS)
         if alpha_ids and all(x > 0 for x in alpha_ids):
             return False
+        if(psd._record.layer_and_mask_information.layer_info is not None and psd._record.layer_and_mask_information.layer_info.layer_count > 0):
+            return False
         return True
     return False
 


### PR DESCRIPTION
This fixes the case when a PSD has alpha channels that aren't transparency and this isn't indicated in one of the other ways `has_transparency` checks. The spec says if layer count is negative it indicates the merged preview image has a transparent alpha channel, otherwise it does not.

From https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_16000:
> Layer count. If it is a negative number, its absolute value is the number of layers and the first alpha channel contains the transparency data for the merged result.

Closes #369