### PR TITLE
Added new Sheet Colors

### DIFF
--- a/src/psd_tools/constants.py
+++ b/src/psd_tools/constants.py
@@ -487,3 +487,7 @@ class SheetColorType(IntEnum):
     BLUE = 5
     VIOLET = 6
     GRAY = 7
+    SEAFOAM = 8
+    INDIGO = 9
+    MAGENTA = 10
+    FUSCHIA = 11


### PR DESCRIPTION
Photoshop introduced new colors, a total of 11.
Saved the file, tried to open with new sheet color, found the missing number, added it to the list. did it for all of them.
<img width="177" alt="Screenshot 2023-12-21 at 2 13 17 p m" src="https://github.com/psd-tools/psd-tools/assets/57231302/369368f7-781d-4efe-a7a1-5a5717066ced">
