### PR TITLE
fix: include pyx file in build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/psd_tools/compression/_rle.pyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ psd-tools = "psd_tools.__main__:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-mypkg = ["*.pyx"]
+psd_tools = ["*.pyx"]
 
 [tool.setuptools.dynamic]
 version = { attr = "psd_tools.version.__version__" }


### PR DESCRIPTION
v1.9.29 is broken as the pyx file is not included in the build