### PR TITLE
reworked packbits/rle algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # C extensions
 *.so
 *.c
+*.cpp
 
 # Distribution / packaging
 .Python

--- a/src/psd_tools/compression/_rle.pyx
+++ b/src/psd_tools/compression/_rle.pyx
@@ -1,128 +1,100 @@
-from libc.stdlib cimport malloc, free
-from libc.string cimport memcpy, memset
-from cpython.version cimport PY_MAJOR_VERSION
+# distutils: language=c++
+# cython: wraparound=False, binding=False
+
+from libcpp.string cimport string
 
 
-def decode(const unsigned char[:] data, Py_ssize_t size):
-    cdef unsigned char* result = <unsigned char*> malloc(size * sizeof(char))
-    cdef int src = 0
-    cdef int dst = 0
-
-    if not result:
-        raise MemoryError()
-
-    try:
-        while src < data.shape[0]:
-            header = data[src]
-            if header > 127:
-                header -= 256
-            src += 1
-
-            if 0 <= header <= 127:
-                length = header + 1
-                if src + length <= data.shape[0] and dst + length <= size:
-                    memcpy(&result[dst], &data[src], length)
-                    src += length
-                    dst += length
-                else:
-                    raise ValueError('Invalid RLE compression')
-            elif header == -128:
-                pass
-            else:
-                length = 1 - header
-                if src + 1 <= data.shape[0] and dst + length <= size:
-                    memset(&result[dst], data[src], length)
-                    src += 1
-                    dst += length
-                else:
-                    raise ValueError('Invalid RLE compression')
-        if dst < size:
-            raise ValueError('Expected %d bytes but decoded only %d bytes' % (
-                size, dst))
-
-        py_result = result[:size]
-    finally:
-        free(result)
-
-    return py_result
+class PackBitsDecodeError(Exception):
+    def __init__(self, result, *args: object) -> None:
+        self.result = result
+        super().__init__(*args)
 
 
-cdef enum State:
-    RAW
-    RLE
+def decode(const unsigned char[:] data, Py_ssize_t size) -> string:
+    """decode(data, size) -> bytes
 
+    Apple PackBits RLE decoder.
+    """
 
-def encode(const unsigned char[:] data):
-    length = data.shape[0]
-    if length == 0:
-        if PY_MAJOR_VERSION < 3:
-            return bytes(bytearray(data))
-        return bytes(data)
+    cdef int i = 0
+    cdef int length = len(data)
+    cdef unsigned char bit
+    cdef string result
+
+    result.resize(size)
+
     if length == 1:
-        if PY_MAJOR_VERSION < 3:
-            return bytes(b'\x00' + bytearray(data))
-        return b'\x00' + data
+        if data[0] != 128:
+            raise ValueError('Invalid RLE compression')
+        return result
 
-    cdef int pos = 0
-    cdef int repeat_count = 0
-    cdef int MAX_LENGTH = 127
-    result = bytearray()
-    buf = bytearray()
+    while i < length and (result.size() < <unsigned long>size):
+        i, bit = i+1, data[i]
+        if bit > 128:
+            bit = 256 - bit
+            result.append(1+bit, <char>data[i])
+            i+=1
+        elif bit < 128:
+            if i+bit > length:
+                raise ValueError('Invalid RLE compression')
+            result.append(<char*>&data[i], 1+bit)
+            i+=bit + 1
 
-    # we can safely start with RAW as empty RAW sequences
-    # are handled by finish_raw(buf, result)
-    cdef State state = State.RAW
+    if size and (result.size() != <unsigned long>size):
+        raise PackBitsDecodeError(result, 'Expected %d bytes but decoded %d bytes' % (size, result.size()))
 
-    while pos < length - 1:
-        current_byte = data[pos]
+    return result
 
-        if data[pos] == data[pos+1]:
-            if state == State.RAW:
-                # end of RAW data
-                finish_raw(buf, result)
-                state = State.RLE
-                repeat_count = 1
-            elif state == State.RLE:
-                if repeat_count == MAX_LENGTH:
-                    # restart the encoding
-                    finish_rle(result, repeat_count, data, pos)
-                    repeat_count = 0
-                # move to next byte
-                repeat_count += 1
 
+def encode(const unsigned char[:] data) -> string:
+    """encode(data) -> bytes
+
+    Apple PackBits RLE encoder.
+    """
+
+    cdef unsigned char MAX_LEN = 0xFF >> 1
+    cdef int length = len(data)
+    cdef int i = 0
+    cdef int j = 0
+    cdef string result
+
+    if length == 0:
+        return data
+    if length == 1:
+        result.push_back(0)
+        result.push_back(data[0])
+        return result
+
+    while i < length:
+        if j + 1 < length and data[j] == data[j+1]:
+            while j < length:
+                if j - i >= MAX_LEN:
+                    break
+                if j + 1 >= length or data[j] != data[j+1]:
+                    break
+                j += 1
+            result.push_back(- (j - i))
+            result.push_back(<char>data[i])
+            i = j = j + 1
         else:
-            if state == State.RLE:
-                repeat_count += 1
-                finish_rle(result, repeat_count, data, pos)
-                state = State.RAW
-                repeat_count = 0
-            elif state == State.RAW:
-                if len(buf) == MAX_LENGTH:
-                    # restart the encoding
-                    finish_raw(buf, result)
-
-                buf.append(current_byte)
-
-        pos += 1
-
-    if state == State.RAW:
-        buf.append(data[pos])
-        finish_raw(buf, result)
-    else:
-        repeat_count += 1
-        finish_rle(result, repeat_count, data, pos)
-
-    return bytes(result)
-
-
-def finish_raw(buf, result):
-    if len(buf) == 0:
-        return
-    result.append(len(buf)-1)
-    result.extend(buf)
-    buf[:] = bytearray()
-
-
-def finish_rle(result, repeat_count, data, pos):
-    result.append(256-(repeat_count - 1))
-    result.append(data[pos])
+            while j < length:
+                if j - i >= MAX_LEN:
+                    break
+                if j+1 < length and (data[j] != data[j+1]):
+                    pass
+                # NOTE: There's no space saved from encoding length 2 repetitions.
+                #: So we only swap back once we see more than 2, or when
+                #: we need to reset our counter soon anyway. For example:
+                #  A  B  C  D  D  E  F  G  G  G  G  G  G  H  I  J  J  K
+                #: could be encoded as either of the following:
+                # +2  A  B  C -1  D +1  E  F -5  G +1  H  I -1  J +0  K
+                # +6  A  B  C  D  D  E  F -5  G +3  H  I  J  J  K
+                elif ((j+2 == length) or (MAX_LEN - (j - i) <= 4)) and (data[j] == data[j+1]):
+                    break
+                elif j+2 < length and (data[j] == data[j+1] == data[j+2]):
+                    break
+                j += 1
+            result.push_back(j - i - 1)
+            result.append(<char*>&data[i], j - i)
+            i = j
+    return result

--- a/src/psd_tools/compression/rle.py
+++ b/src/psd_tools/compression/rle.py
@@ -1,9 +1,3 @@
-class PackBitsDecodeError(Exception):
-    def __init__(self, result, *args: object) -> None:
-        self.result = result
-        super().__init__(*args)
-
-
 def decode(data: bytes, size: int) -> bytes:
     """decode(data, size) -> bytes
 
@@ -35,7 +29,7 @@ def decode(data: bytes, size: int) -> bytes:
             i+=bit + 1
 
     if size and (len(result) != size):
-        raise PackBitsDecodeError(result, 'Expected %d bytes but decoded %d bytes' % (size, result_len))
+        raise ValueError('Expected %d bytes but decoded %d bytes' % (size, result_len))
 
     return bytes(result)
 

--- a/src/psd_tools/compression/rle.py
+++ b/src/psd_tools/compression/rle.py
@@ -76,7 +76,7 @@ def encode(data: bytes) -> bytes:
                 #: could be encoded as either of the following:
                 # +2  A  B  C -1  D +1  E  F -5  G +1  H  I -1  J +0  K
                 # +6  A  B  C  D  D  E  F -5  G +3  H  I  J  J  K
-                elif ((j+2 == length) or (MAX_LEN - (j - i) <= 4)) and (data[j] == data[j+1]):
+                elif ((j+2 == length) or (MAX_LEN - (j - i) <= 2)) and (data[j] == data[j+1]):
                     break
                 elif j+2 < length and (data[j] == data[j+1] == data[j+2]):
                     break

--- a/src/psd_tools/compression/rle.py
+++ b/src/psd_tools/compression/rle.py
@@ -1,113 +1,92 @@
-def decode(data, size):
+class PackBitsDecodeError(Exception):
+    def __init__(self, result, *args: object) -> None:
+        self.result = result
+        super().__init__(*args)
+
+
+def decode(data: bytes, size: int) -> bytes:
+    """decode(data, size) -> bytes
+
+    Apple PackBits RLE decoder.
     """
-    Decodes RLE encoded data.
-    """
-    data = bytearray(data)  # <- python 2/3 compatibility fix
-    result = bytearray(size)
-    src = 0
-    dst = 0
-    while src < len(data):
-        header = data[src]
-        if header > 127:
-            header -= 256
-        src += 1
 
-        if 0 <= header <= 127:
-            length = header + 1
-            if src + length <= len(data) and dst + length <= size:
-                result[dst : dst + header + 1] = data[src : src + length]
-                src += length
-                dst += length
-            else:
-                raise ValueError("Invalid RLE compression")
-        elif header == -128:
-            pass
-        else:
-            length = 1 - header
-            if src + 1 <= len(data) and dst + length <= size:
-                result[dst : dst + length] = [data[src]] * length
-                src += 1
-                dst += length
-            else:
-                raise ValueError("Invalid RLE compression")
-    if dst < size:
-        raise ValueError("Expected %d bytes but decoded only %d bytes" % (size, dst))
-
-    return bytes(result)
-
-
-def encode(data):
-    """
-    Encodes data using RLE encoding.
-    """
-    if len(data) == 0:
-        return data
-
-    if len(data) == 1:
-        return b"\x00" + data
-
+    i = 0
     data = bytearray(data)
+    length = len(data)
+    result, result_len = bytearray(), 0
 
-    result = bytearray()
-    buf = bytearray()
-    pos = 0
-    repeat_count = 0
-    MAX_LENGTH = 127
+    if length == 1:
+        if data[0] != 128:
+            raise ValueError('Invalid RLE compression')
+        return result
 
-    # we can safely start with RAW as empty RAW sequences
-    # are handled by finish_raw(buf, result)
-    state = "RAW"
+    while i < length and (result_len < size):
+        i, bit = i+1, data[i]
+        if bit > 128:
+            bit = 256 - bit
+            result.extend((data[i:i+1])*(1+bit))
+            result_len += 1+bit
+            i+=1
+        elif bit < 128:
+            if i+bit > length:
+                raise ValueError('Invalid RLE compression')
+            result.extend(data[i: i+1+bit])
+            result_len += 1+bit
+            i+=bit + 1
 
-    while pos < len(data) - 1:
-        current_byte = data[pos]
-
-        if data[pos] == data[pos + 1]:
-            if state == "RAW":
-                # end of RAW data
-                finish_raw(buf, result)
-                state = "RLE"
-                repeat_count = 1
-            elif state == "RLE":
-                if repeat_count == MAX_LENGTH:
-                    # restart the encoding
-                    finish_rle(result, repeat_count, data, pos)
-                    repeat_count = 0
-                # move to next byte
-                repeat_count += 1
-
-        else:
-            if state == "RLE":
-                repeat_count += 1
-                finish_rle(result, repeat_count, data, pos)
-                state = "RAW"
-                repeat_count = 0
-            elif state == "RAW":
-                if len(buf) == MAX_LENGTH:
-                    # restart the encoding
-                    finish_raw(buf, result)
-
-                buf.append(current_byte)
-
-        pos += 1
-
-    if state == "RAW":
-        buf.append(data[pos])
-        finish_raw(buf, result)
-    else:
-        repeat_count += 1
-        finish_rle(result, repeat_count, data, pos)
+    if size and (len(result) != size):
+        raise PackBitsDecodeError(result, 'Expected %d bytes but decoded %d bytes' % (size, result_len))
 
     return bytes(result)
 
 
-def finish_raw(buf, result):
-    if len(buf) == 0:
-        return
-    result.append(len(buf) - 1)
-    result.extend(buf)
-    buf[:] = bytearray()
+def encode(data: bytes) -> bytes:
+    """encode(data) -> bytes
 
+    Apple PackBits RLE encoder.
+    """
 
-def finish_rle(result, repeat_count, data, pos):
-    result.append(256 - (repeat_count - 1))
-    result.append(data[pos])
+    MAX_LEN = 0xFF >> 1
+    length = len(data)
+    i = 0
+    j = 0
+    result = bytearray()
+
+    if length == 0:
+        return data
+    if length == 1:
+        result.extend((0, data[0]))
+        return result
+
+    while i < length:
+        if j + 1 < length and data[j] == data[j+1]:
+            while j < length:
+                if j - i >= MAX_LEN:
+                    break
+                if j + 1 >= length or data[j] != data[j+1]:
+                    break
+                j += 1
+            result.extend((256 - (j - i), data[i]))
+            i = j = j + 1
+        else:
+            while j < length:
+                if j - i >= MAX_LEN:
+                    break
+                if j+1 < length and (data[j] != data[j+1]):
+                    pass
+                # NOTE: There's no space saved from encoding length 2 repetitions.
+                #: So we only swap back once we see more than 2, or when
+                #: we need to reset our counter soon anyway. For example:
+                #  A  B  C  D  D  E  F  G  G  G  G  G  G  H  I  J  J  K
+                #: could be encoded as either of the following:
+                # +2  A  B  C -1  D +1  E  F -5  G +1  H  I -1  J +0  K
+                # +6  A  B  C  D  D  E  F -5  G +3  H  I  J  J  K
+                elif ((j+2 == length) or (MAX_LEN - (j - i) <= 4)) and (data[j] == data[j+1]):
+                    break
+                elif j+2 < length and (data[j] == data[j+1] == data[j+2]):
+                    break
+                j += 1
+            result.append(j - i - 1)
+            result.extend(data[i:j])
+            i = j
+    return bytes(result)


### PR DESCRIPTION
Hi! Thanks for developing this awesome tool. 

I've been looking for ways to compress PSDs while still having them natively readable by Photoshop, and I came up with a slightly more space efficient PackBits encoding algorithm. It admittedly only saves a tiny amount of space compared to Photoshop's implementation, but I thought it was still worth making a PR here.

I also took the time to refactor the rest of the RLE module here, since it was possible to simplify and optimise the code a bit. Most of the performance gains are from removing the overhead of calling extra Python functions.

You'll also notice that I swapped out raw C strings for C++ strings in the Cython code, this just makes it far easier to sit back and let Cython and C++ manage the memory and type conversions. If you'd prefer to use raw C strings, I could refactor this to do that instead.

In terms of speed, I ran some tests with `timeit`:
```python
timeit.timeit(
    'm.encode(t)',
    setup='import {module} as m; t=bytes.fromhex("aaaaaa80002aaaaaaaaa80002a22aaaaaaaaaaaaaaaaaaaa")',
    number=10_000_000
)
timeit.timeit(
    'm.decode(t, 24)',
    setup='import {module} as m; t=bytes.fromhex("feaa0280002afdaa0380002a22f7aa")',
    number=10_000_000
)
```

(Running on an M1 MacBook Pro)

| Module | Encode Time (s) | Decode Time (s) |
|--------|--------|--------|
| `.py` old | 50.8301086375 | 22.117071729000052 |
| `.py` new | 42.34482602520001 |16.344653579000003 |
| `.pyx` old | 15.525218291600003 | 4.582728499999973 |
| `.pyx` new | 1.6874734792 |  1.6621730334000002 | 

In terms of space saved, tested on an 1024x1024 image with 1 layer consisting of a unique rendered cloud on each channel, and some Lorem Ipsum text over the top.
For psd_tools RLE and new RLE, the result is the length returned by `image_data.set_data`
Ps RLE is `len(psd.image_data.data)` where `psd.image_data.compression == Compression.RLE` 

|Ps RLE|psd_tools RLE|new RLE| 
|--------|--------|--------|
|2836621|2951643|2816249|

Which translates to about a 4.58% decrease in file size compared to psd-tools' previous algorithm, and a 0.72% decrease compared to Ps' implementation

Let me know if you have any feedback. 
