### PR TITLE
Fix #338: correct layer kind for PSDs containing dividers with SectionDivider.OTHER

### DIFF
--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -604,7 +604,14 @@ class PSDImage(GroupMixin):
             layer = None
             divider = blocks.get_data(Tag.SECTION_DIVIDER_SETTING, None)
             divider = blocks.get_data(Tag.NESTED_SECTION_DIVIDER_SETTING, divider)
-            if divider is not None:
+            if (
+                divider is not None and
+
+                # Some PSDs contain dividers with SectionDivider.OTHER.
+                # Ignoring them, allows the correct categorization of the layer.
+                # Issue : https://github.com/psd-tools/psd-tools/issues/338
+                divider.kind is not SectionDivider.OTHER
+                ):
                 if divider.kind == SectionDivider.BOUNDING_SECTION_DIVIDER:
                     layer = Group(self, None, None, current_group)
                     group_stack.append(layer)


### PR DESCRIPTION
Some PSDs contain dividers with SectionDivider.OTHER. Ignoring the dividers, allows the correct categorization of the layer.