### PR TITLE
New PSDImage method to set the logging level

### DIFF
--- a/src/psd_tools/api/__init__.py
+++ b/src/psd_tools/api/__init__.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 import functools
 import warnings
+import logging
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
 
 def deprecated(func):
     @functools.wraps(func)

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -602,7 +602,7 @@ class PSDImage(GroupMixin):
         Default logging level is WARNING.
         """
         if log_level in ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"):
-            logging.basicConfig(level=log_level)
+            logger.parent.setLevel(log_level)
         else:
             logging.warning(f"Logging level '{log_level}' is not valid.")
 

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -593,6 +593,19 @@ class PSDImage(GroupMixin):
 
         rec_helper(self)
 
+    def set_log_level(self, log_level):
+        """
+        Set the logging level.
+
+        :param log_level: string of the desired logging level 'CRITICAL', 'ERROR', 'WARNING', 'INFO' or 'DEBUG'.
+
+        Default logging level is WARNING.
+        """
+        if log_level in ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"):
+            logging.basicConfig(level=log_level)
+        else:
+            logging.warning(f"Logging level '{log_level}' is not valid.")
+
     def _init(self):
         """Initialize layer structure."""
         group_stack = [self]


### PR DESCRIPTION
Prior to these changes, the logging level could only be set when running psd-tools from the command line.

Now, it is possible to set the logging level when using psd-tools as a module.