### PR TITLE
Add new property text_type for TypeLayer

### DIFF
--- a/docs/reference/psd_tools.constants.rst
+++ b/docs/reference/psd_tools.constants.rst
@@ -107,3 +107,10 @@ Tag
 .. autoclass:: psd_tools.constants.Tag
     :members:
     :undoc-members:
+
+TextType
+--------
+
+.. autoclass:: psd_tools.constants.TextType
+    :members:
+    :undoc-members:

--- a/src/psd_tools/constants.py
+++ b/src/psd_tools/constants.py
@@ -507,3 +507,12 @@ class SheetColorType(IntEnum):
     INDIGO = 9
     MAGENTA = 10
     FUSCHIA = 11
+
+
+class TextType(IntEnum):
+    """
+    Type of text
+    """
+
+    POINT = 0
+    PARAGRAPH = 1


### PR DESCRIPTION
Type layers can contain texts of 2 types : point (character) or paragraph (area).
The information is stored in EngineDict and this PR introduces a new property `text_type` for TypeLayer. 
It also introduces a new TextType constant.