### PR TITLE
Conversion issue fix, Layer metadata refactor, effect pattern transfer

### DIFF
--- a/src/psd_tools/api/effects.py
+++ b/src/psd_tools/api/effects.py
@@ -119,6 +119,9 @@ class _Effect(object):
         """Layer effect opacity in percentage."""
         return self.value.get(Key.Opacity).value
 
+    def has_patterns(self):
+        return isinstance(self, _PatternMixin) and self.pattern is not None
+
     def __repr__(self):
         return self.__class__.__name__
 

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -569,8 +569,6 @@ class Layer(object):
         self.parent.remove(self)
         self.parent.insert(newindex, self)
 
-        self.parent._update_psd_record()
-
         return self
 
     def move_down(self, offset = 1):
@@ -608,11 +606,12 @@ class Layer(object):
             
             psd_global_blocks.get(Tag.PATTERNS1).data.extend(
                 [
-                    pattern for pattern, pattern_id in zip(sourcePatterns, pattern_ids) if 
-                        pattern_id == pattern.pattern_id and 
-                        pattern_id not in [targetPattern.pattern_id for targetPattern in psd_global_blocks.get(Tag.PATTERNS1).data]
+                    pattern for pattern in sourcePatterns if 
+                        pattern.pattern_id in pattern_ids and 
+                        pattern.pattern_id not in [targetPattern.pattern_id for targetPattern in psd_global_blocks.get(Tag.PATTERNS1).data]
                 ]
             )
+
 
 class GroupMixin(object):
     @property
@@ -787,6 +786,7 @@ class GroupMixin(object):
 
                 layer._psd = _psd
 
+        for layer in self._layers[:]:
             layer._parent = self
 
     def _update_psd_record(self):
@@ -1111,7 +1111,6 @@ class PixelLayer(Layer):
         """
 
         assert pil_im
-        assert psd_file.kind == "psdimage"
 
         if pil_im.mode == "1":
             pil_im = pil_im.convert("L")

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -603,7 +603,7 @@ class Layer(object):
             for tag in (Tag.PATTERNS1, Tag.PATTERNS2, Tag.PATTERNS3):
                 if tag in self._psd.tagged_blocks:
                     sourcePatterns.extend(self._psd.tagged_blocks.get(Tag.PATTERNS1).data)
-            
+                        
             psd_global_blocks.get(Tag.PATTERNS1).data.extend(
                 [
                     pattern for pattern in sourcePatterns if 
@@ -612,7 +612,7 @@ class Layer(object):
                 ]
             )
 
-
+            
 class GroupMixin(object):
     @property
     def left(self):
@@ -831,7 +831,7 @@ class GroupMixin(object):
             if layer.name == name:
                 return layer
 
-    def find_all(self, name):
+    def findall(self, name):
         """
         Return a generator to iterate over all layers with the given name.
 

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -580,7 +580,7 @@ class Layer(object):
 
         return self.move_up(-1 * offset)
 
-    def _fetch_patterns(self, target_psd):
+    def _fetch_tagged_blocks(self, target_psd):
         
         # Retrieve the patterns contained in the layer current ._psd and add them to the target psd
         _psd = target_psd
@@ -782,7 +782,7 @@ class GroupMixin(object):
                 if layer.kind == "pixel":
                     layer._convert(_psd)
             
-                layer._fetch_patterns(_psd)
+                layer._fetch_tagged_blocks(_psd)
 
                 layer._psd = _psd
 
@@ -827,9 +827,8 @@ class GroupMixin(object):
         :param name:
         """
 
-        for layer in self.descendants():
-            if layer.name == name:
-                return layer
+        for layer in self.findall(name):
+            return layer
 
     def findall(self, name):
         """


### PR DESCRIPTION
Hi, 

I made the fix for the conversion issue mentioned in https://github.com/psd-tools/psd-tools/issues/433, i went with the composite() function.

I refactored the functions for layer validity verification and metadata update.
In the latter i added something to retrieve the effect patterns from a psd to add to the new one when moving a layer around. As i encountered an issue for psd opening concerning this. There may be other things to consider in this case, I guess those will be found along the way.

I also added functions for searching layers by name. Yielding either the first match, or a generator of all of them.