### PR TITLE
Artboard lacking the bounding record/channels fix.

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -1041,6 +1041,7 @@ class Artboard(Group):
     def _move(kls, group):
         self = kls(group._psd, group._record, group._channels, group._parent)
         self._layers = group._layers
+        self._set_bounding_records(group._bounding_record, group._bounding_channels)
         for layer in self._layers:
             layer._parent = self
         for index in range(len(self.parent)):

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from psd_tools.api.layers import Group, PixelLayer, ShapeLayer
+from psd_tools.api.layers import Group, PixelLayer, ShapeLayer, Artboard
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.constants import BlendMode, Tag, SectionDivider
 
@@ -528,3 +528,12 @@ def test_count(group, pixel_layer, type_layer, smartobject_layer, fill_layer):
     group.append(pixel_layer)
 
     assert group.count(pixel_layer) == 3
+
+def test_artboard_move(group):
+
+    artboard = Artboard._move(group)
+
+    assert artboard._channels is group._channels
+    assert artboard._record is group._record
+    assert artboard._bounding_channels is group._bounding_channels
+    assert artboard._bounding_record is group._bounding_record


### PR DESCRIPTION
Fix for issue https://github.com/psd-tools/psd-tools/issues/437.

The artboard _move function will set the _bounding_records, _bounding_channels.