### PR TITLE
Add type annotation to high-level packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ readme = "README.rst"
 keywords = ["photoshop", "psd"]
 license = { text = "MIT License" }
 dependencies = [
+    "typing-extensions;python_version<'3.11'",
     "docopt>=0.6.0",
     "attrs>=23.0.0",
     "Pillow>=10.0.0",
@@ -28,11 +29,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Multimedia :: Graphics :: Viewers",
     "Topic :: Multimedia :: Graphics :: Graphics Conversion",

--- a/src/psd_tools/api/__init__.py
+++ b/src/psd_tools/api/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import functools
 import warnings
 

--- a/src/psd_tools/api/adjustments.py
+++ b/src/psd_tools/api/adjustments.py
@@ -10,12 +10,12 @@ Example::
         print(layer.gradient_kind)
 """
 
-from __future__ import absolute_import
-
 import logging
 
 from psd_tools.api.layers import AdjustmentLayer, FillLayer
 from psd_tools.constants import Tag
+from psd_tools.psd.adjustments import Curves, Levels, LevelRecord
+from psd_tools.psd.descriptor import DescriptorBlock
 from psd_tools.utils import new_registry
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ class SolidColorFill(FillLayer):
     """Solid color fill."""
 
     @property
-    def data(self):
+    def data(self) -> DescriptorBlock:
         """Color in Descriptor(RGB)."""
         return self._data.get(b"Clr ")
 
@@ -38,7 +38,7 @@ class PatternFill(FillLayer):
     """Pattern fill."""
 
     @property
-    def data(self):
+    def data(self) -> DescriptorBlock:
         """Pattern in Descriptor(PATTERN)."""
         return self._data.get(b"Ptrn")
 
@@ -48,11 +48,11 @@ class GradientFill(FillLayer):
     """Gradient fill."""
 
     @property
-    def angle(self):
+    def angle(self) -> float:
         return float(self._data.get(b"Angl"))
 
     @property
-    def gradient_kind(self):
+    def gradient_kind(self) -> str:
         """
         Kind of the gradient, one of the following:
 
@@ -65,7 +65,7 @@ class GradientFill(FillLayer):
         return self._data.get(b"Type").get_name()
 
     @property
-    def data(self):
+    def data(self) -> DescriptorBlock:
         """Gradient in Descriptor(GRADIENT)."""
         return self._data.get(b"Grad")
 
@@ -77,31 +77,31 @@ class BrightnessContrast(AdjustmentLayer):
     # Tag.BRIGHTNESS_AND_CONTRAST is obsolete.
 
     @property
-    def brightness(self):
+    def brightness(self) -> int:
         return int(self._data.get(b"Brgh", 0))
 
     @property
-    def contrast(self):
+    def contrast(self) -> int:
         return int(self._data.get(b"Cntr", 0))
 
     @property
-    def mean(self):
+    def mean(self) -> int:
         return int(self._data.get(b"means", 0))
 
     @property
-    def lab(self):
+    def lab(self) -> bool:
         return bool(self._data.get(b"Lab ", False))
 
     @property
-    def use_legacy(self):
+    def use_legacy(self) -> bool:
         return bool(self._data.get(b"useLegacy", False))
 
     @property
-    def vrsn(self):
+    def vrsn(self) -> int:
         return int(self._data.get(b"Vrsn", 1))
 
     @property
-    def automatic(self):
+    def automatic(self) -> bool:
         return bool(self._data.get(b"auto", False))
 
 
@@ -112,7 +112,7 @@ class Curves(AdjustmentLayer):
     """
 
     @property
-    def data(self):
+    def data(self) -> Curves:
         """
         Raw data.
 
@@ -132,7 +132,7 @@ class Exposure(AdjustmentLayer):
     """
 
     @property
-    def exposure(self):
+    def exposure(self) -> float:
         """Exposure.
 
         :return: `float`
@@ -140,7 +140,7 @@ class Exposure(AdjustmentLayer):
         return float(self._data.exposure)
 
     @property
-    def offset(self):
+    def offset(self) -> float:
         """Offset.
 
         :return: `float`
@@ -148,7 +148,7 @@ class Exposure(AdjustmentLayer):
         return float(self._data.offset)
 
     @property
-    def gamma(self):
+    def gamma(self) -> float:
         """Gamma.
 
         :return: `float`
@@ -166,7 +166,7 @@ class Levels(AdjustmentLayer):
     """
 
     @property
-    def data(self):
+    def data(self) -> Levels:
         """
         List of level records. The first record is the master.
 
@@ -175,7 +175,7 @@ class Levels(AdjustmentLayer):
         return self._data
 
     @property
-    def master(self):
+    def master(self) -> LevelRecord:
         """Master record."""
         return self.data[0]
 
@@ -185,7 +185,7 @@ class Vibrance(AdjustmentLayer):
     """Vibrance adjustment."""
 
     @property
-    def vibrance(self):
+    def vibrance(self) -> int:
         """Vibrance.
 
         :return: `int`
@@ -193,7 +193,7 @@ class Vibrance(AdjustmentLayer):
         return int(self._data.get(b"vibrance", 0))
 
     @property
-    def saturation(self):
+    def saturation(self) -> int:
         """Saturation.
 
         :return: `int`
@@ -210,7 +210,7 @@ class HueSaturation(AdjustmentLayer):
     """
 
     @property
-    def data(self):
+    def data(self) -> list:
         """
         List of Hue/Saturation records.
 
@@ -219,7 +219,7 @@ class HueSaturation(AdjustmentLayer):
         return self._data.items
 
     @property
-    def enable_colorization(self):
+    def enable_colorization(self) -> int:
         """Enable colorization.
 
         :return: `int`
@@ -227,7 +227,7 @@ class HueSaturation(AdjustmentLayer):
         return int(self._data.enable)
 
     @property
-    def colorization(self):
+    def colorization(self) -> tuple:
         """Colorization.
 
         :return: `tuple`
@@ -235,7 +235,7 @@ class HueSaturation(AdjustmentLayer):
         return self._data.colorization
 
     @property
-    def master(self):
+    def master(self) -> tuple:
         """Master record.
 
         :return: `tuple`
@@ -248,7 +248,7 @@ class ColorBalance(AdjustmentLayer):
     """Color balance adjustment."""
 
     @property
-    def shadows(self):
+    def shadows(self) -> tuple:
         """Shadows.
 
         :return: `tuple`
@@ -256,7 +256,7 @@ class ColorBalance(AdjustmentLayer):
         return self._data.shadows
 
     @property
-    def midtones(self):
+    def midtones(self) -> tuple:
         """Mid-tones.
 
         :return: `tuple`
@@ -264,7 +264,7 @@ class ColorBalance(AdjustmentLayer):
         return self._data.midtones
 
     @property
-    def highlights(self):
+    def highlights(self) -> tuple:
         """Highlights.
 
         :return: `tuple`
@@ -272,7 +272,7 @@ class ColorBalance(AdjustmentLayer):
         return self._data.highlights
 
     @property
-    def luminosity(self):
+    def luminosity(self) -> int:
         """Luminosity.
 
         :return: `int`
@@ -285,31 +285,31 @@ class BlackAndWhite(AdjustmentLayer):
     """Black and white adjustment."""
 
     @property
-    def red(self):
+    def red(self) -> int:
         return self._data.get(b"Rd  ", 40)
 
     @property
-    def yellow(self):
+    def yellow(self) -> int:
         return self._data.get(b"Yllw", 60)
 
     @property
-    def green(self):
+    def green(self) -> int:
         return self._data.get(b"Grn ", 40)
 
     @property
-    def cyan(self):
+    def cyan(self) -> int:
         return self._data.get(b"Cyn ", 60)
 
     @property
-    def blue(self):
+    def blue(self) -> int:
         return self._data.get(b"Bl  ", 20)
 
     @property
-    def magenta(self):
+    def magenta(self) -> int:
         return self._data.get(b"Mgnt", 80)
 
     @property
-    def use_tint(self):
+    def use_tint(self) -> bool:
         return bool(self._data.get(b"useTint", False))
 
     @property
@@ -317,11 +317,11 @@ class BlackAndWhite(AdjustmentLayer):
         return self._data.get(b"tintColor")
 
     @property
-    def preset_kind(self):
+    def preset_kind(self) -> int:
         return self._data.get(b"bwPresetKind", 1)
 
     @property
-    def preset_file_name(self):
+    def preset_file_name(self) -> str:
         value = self._data.get(b"blackAndWhitePresetFileName", "") + ""
         return value.strip("\x00")
 
@@ -331,7 +331,7 @@ class PhotoFilter(AdjustmentLayer):
     """Photo filter adjustment."""
 
     @property
-    def xyz(self):
+    def xyz(self) -> bool:
         """xyz.
 
         :return: `bool`
@@ -387,7 +387,7 @@ class Posterize(AdjustmentLayer):
     """Posterize adjustment."""
 
     @property
-    def posterize(self):
+    def posterize(self) -> int:
         """Posterize value.
 
         :return: `int`
@@ -400,7 +400,7 @@ class Threshold(AdjustmentLayer):
     """Threshold adjustment."""
 
     @property
-    def threshold(self):
+    def threshold(self) -> int:
         """Threshold value.
 
         :return: `int`
@@ -450,7 +450,7 @@ class GradientMap(AdjustmentLayer):
         return self._data.expansion
 
     @property
-    def interpolation(self):
+    def interpolation(self) -> float:
         """Interpolation between 0.0 and 1.0."""
         return self._data.interpolation / 4096.0
 

--- a/src/psd_tools/api/adjustments.py
+++ b/src/psd_tools/api/adjustments.py
@@ -10,6 +10,8 @@ Example::
         print(layer.gradient_kind)
 """
 
+from __future__ import annotations
+
 import logging
 
 from psd_tools.api.layers import AdjustmentLayer, FillLayer

--- a/src/psd_tools/api/effects.py
+++ b/src/psd_tools/api/effects.py
@@ -2,6 +2,8 @@
 Effects module.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Any, Iterator
 

--- a/src/psd_tools/api/mask.py
+++ b/src/psd_tools/api/mask.py
@@ -2,6 +2,8 @@
 Mask module.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 

--- a/src/psd_tools/api/mask.py
+++ b/src/psd_tools/api/mask.py
@@ -2,11 +2,13 @@
 Mask module.
 """
 
-from __future__ import absolute_import, unicode_literals
-
 import logging
+from typing import Any
+
+from PIL.Image import Image as PILImage
 
 from psd_tools.constants import ChannelID
+from psd_tools.psd.layer_and_mask import MaskData, MaskFlags
 
 logger = logging.getLogger(__name__)
 
@@ -20,72 +22,72 @@ class Mask(object):
     real mask.
     """
 
-    def __init__(self, layer):
+    def __init__(self, layer: Any):  # TODO: Circular import
         self._layer = layer
-        self._data = layer._record.mask_data
+        self._data: MaskData = layer._record.mask_data
 
     @property
-    def background_color(self):
+    def background_color(self) -> int:
         """Background color."""
         if self._has_real():
             return self._data.real_background_color
         return self._data.background_color
 
     @property
-    def bbox(self):
+    def bbox(self) -> tuple[int, int, int, int]:
         """BBox"""
         return self.left, self.top, self.right, self.bottom
 
     @property
-    def left(self):
+    def left(self) -> int:
         """Left coordinate."""
         if self._has_real():
             return self._data.real_left
         return self._data.left
 
     @property
-    def right(self):
+    def right(self) -> int:
         """Right coordinate."""
         if self._has_real():
             return self._data.real_right
         return self._data.right
 
     @property
-    def top(self):
+    def top(self) -> int:
         """Top coordinate."""
         if self._has_real():
             return self._data.real_top
         return self._data.top
 
     @property
-    def bottom(self):
+    def bottom(self) -> int:
         """Bottom coordinate."""
         if self._has_real():
             return self._data.real_bottom
         return self._data.bottom
 
     @property
-    def width(self):
+    def width(self) -> int:
         """Width."""
         return self.right - self.left
 
     @property
-    def height(self):
+    def height(self) -> int:
         """Height."""
         return self.bottom - self.top
 
     @property
-    def size(self):
+    def size(self) -> tuple[int, int]:
         """(Width, Height) tuple."""
         return self.width, self.height
 
     @property
-    def disabled(self):
+    def disabled(self) -> bool:
         """Disabled."""
         return self._data.flags.mask_disabled
 
     @property
-    def flags(self):
+    def flags(self) -> MaskFlags:
         """Flags."""
         return self._data.flags
 
@@ -95,15 +97,15 @@ class Mask(object):
         return self._data.parameters
 
     @property
-    def real_flags(self):
+    def real_flags(self) -> MaskFlags | None:
         """Real flag."""
         return self._data.real_flags
 
-    def _has_real(self):
+    def _has_real(self) -> bool:
         """Return True if the mask has real flags."""
         return self.real_flags is not None and self.real_flags.parameters_applied
 
-    def topil(self, real=True, **kwargs):
+    def topil(self, real: bool=True, **kwargs: Any) -> PILImage | None:
         """
         Get PIL Image of the mask.
 
@@ -116,7 +118,7 @@ class Mask(object):
             channel = ChannelID.USER_LAYER_MASK
         return self._layer.topil(channel, **kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s(offset=(%d,%d) size=%dx%d)" % (
             self.__class__.__name__,
             self.left,

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Literal
 
 import numpy as np
 
@@ -18,15 +19,15 @@ EXPECTED_CHANNELS = {
 }
 
 
-def get_array(layer, channel, **kwargs):
+def get_array(
+    layer: Any, channel: str, **kwargs: Any
+) -> np.ndarray:  # TODO: Circular import
     if layer.kind == "psdimage":
         return get_image_data(layer, channel)
-    else:
-        return get_layer_data(layer, channel, **kwargs)
-    return None
+    return get_layer_data(layer, channel, **kwargs)
 
 
-def get_image_data(psd, channel):
+def get_image_data(psd: Any, channel: str) -> np.ndarray:  # TODO: Circular import
     if (channel == "mask") or (channel == "shape" and not has_transparency(psd)):
         return np.ones((psd.height, psd.width, 1), dtype=np.float32)
 
@@ -53,7 +54,7 @@ def get_image_data(psd, channel):
     return data
 
 
-def get_layer_data(layer, channel, real_mask=True):
+def get_layer_data(layer: Any, channel: str, real_mask: bool = True) -> np.ndarray:
     def _find_channel(layer, width, height, condition):
         depth, version = layer._psd.depth, layer._psd.version
         iterator = zip(layer._record.channel_info, layer._channels)
@@ -98,7 +99,7 @@ def get_layer_data(layer, channel, real_mask=True):
     return np.concatenate([color, shape], axis=2)
 
 
-def get_pattern(pattern):
+def get_pattern(pattern) -> np.ndarray:
     """Get pattern array."""
     height, width = pattern.data.rectangle[2], pattern.data.rectangle[3]
     return np.stack(
@@ -111,7 +112,7 @@ def get_pattern(pattern):
     ).reshape((height, width, -1))
 
 
-def has_transparency(psd):
+def has_transparency(psd: Any) -> bool:
     keys = (
         Tag.SAVING_MERGED_TRANSPARENCY,
         Tag.SAVING_MERGED_TRANSPARENCY16,
@@ -132,7 +133,7 @@ def has_transparency(psd):
     return False
 
 
-def get_transparency_index(psd):
+def get_transparency_index(psd: Any) -> int:
     alpha_ids = psd.image_resources.get_data(Resource.ALPHA_IDENTIFIERS)
     if alpha_ids:
         try:
@@ -143,7 +144,9 @@ def get_transparency_index(psd):
     return -1  # Assume the last channel is the transparency
 
 
-def _parse_array(data, depth, lut=None):
+def _parse_array(
+    data: bytes | bytearray, depth: Literal[1, 8, 16, 32], lut: bool = None
+) -> np.ndarray:
     if depth == 8:
         parsed = np.frombuffer(data, ">u1")
         if lut is not None:
@@ -159,7 +162,7 @@ def _parse_array(data, depth, lut=None):
         raise ValueError("Unsupported depth: %g" % depth)
 
 
-def _remove_background(data, psd):
+def _remove_background(data: np.ndarray, psd: Any) -> np.ndarray:
     """ImageData preview is rendered on a white background."""
     if psd.color_mode == ColorMode.RGB and data.shape[2] > 3:
         color = data[:, :, :3]

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Any, Literal
 
@@ -20,14 +22,14 @@ EXPECTED_CHANNELS = {
 
 
 def get_array(
-    layer: Any, channel: str, **kwargs: Any
+    layer: Any, channel: str | None, **kwargs: Any
 ) -> np.ndarray:  # TODO: Circular import
     if layer.kind == "psdimage":
         return get_image_data(layer, channel)
     return get_layer_data(layer, channel, **kwargs)
 
 
-def get_image_data(psd: Any, channel: str) -> np.ndarray:  # TODO: Circular import
+def get_image_data(psd: Any, channel: str | None) -> np.ndarray:  # TODO: Circular import
     if (channel == "mask") or (channel == "shape" and not has_transparency(psd)):
         return np.ones((psd.height, psd.width, 1), dtype=np.float32)
 
@@ -54,7 +56,7 @@ def get_image_data(psd: Any, channel: str) -> np.ndarray:  # TODO: Circular impo
     return data
 
 
-def get_layer_data(layer: Any, channel: str, real_mask: bool = True) -> np.ndarray:
+def get_layer_data(layer: Any, channel: str | None, real_mask: bool = True) -> np.ndarray:
     def _find_channel(layer, width, height, condition):
         depth, version = layer._psd.depth, layer._psd.version
         iterator = zip(layer._record.channel_info, layer._channels)
@@ -145,7 +147,7 @@ def get_transparency_index(psd: Any) -> int:
 
 
 def _parse_array(
-    data: bytes | bytearray, depth: Literal[1, 8, 16, 32], lut: bool = None
+    data: bytes | bytearray, depth: Literal[1, 8, 16, 32], lut: np.ndarray | None = None
 ) -> np.ndarray:
     if depth == 8:
         parsed = np.frombuffer(data, ">u1")

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -2,11 +2,15 @@
 PIL IO module.
 """
 
-from __future__ import absolute_import, unicode_literals
-
 import io
 import logging
+from typing import Any
 
+from PIL import Image
+from PIL.Image import Image as PILImage
+
+from psd_tools.psd import PSD
+from psd_tools.psd.patterns import Pattern
 from psd_tools.constants import ChannelID, ColorMode, Resource
 
 from .numpy_io import get_transparency_index, has_transparency
@@ -14,7 +18,7 @@ from .numpy_io import get_transparency_index, has_transparency
 logger = logging.getLogger(__name__)
 
 
-def get_color_mode(mode):
+def get_color_mode(mode: str) -> ColorMode:
     """Convert PIL mode to ColorMode."""
     name = mode.upper()
     name = name.rstrip("A")  # Trim alpha.
@@ -22,7 +26,7 @@ def get_color_mode(mode):
     return getattr(ColorMode, name)
 
 
-def get_pil_mode(color_mode, alpha=False):
+def get_pil_mode(color_mode: ColorMode, alpha: bool = False) -> str:
     """Get PIL mode from ColorMode."""
     name = {
         ColorMode.GRAYSCALE: "L",
@@ -36,7 +40,7 @@ def get_pil_mode(color_mode, alpha=False):
     return name
 
 
-def get_pil_channels(pil_mode):
+def get_pil_channels(pil_mode: str) -> int:
     """Get the number of channels for PIL modes."""
     return {
         "1": 1,
@@ -51,7 +55,8 @@ def get_pil_channels(pil_mode):
         "F": 1,
     }.get(pil_mode, 3)
 
-def get_pil_depth(pil_mode):
+
+def get_pil_depth(pil_mode: str) -> int:
     """Get the depth of image for PIL modes."""
     return {
         # Bitmap images are converted to grayscale when the layer is created from pil object
@@ -67,9 +72,11 @@ def get_pil_depth(pil_mode):
         "F": 32,
     }.get(pil_mode, 8)
 
-def convert_image_data_to_pil(psd, channel, apply_icc):
+
+def convert_image_data_to_pil(
+    psd: PSD, channel: int | None, apply_icc: bool
+) -> PILImage | None:
     """Convert ImageData to PIL Image."""
-    from PIL import Image
 
     assert channel is None or channel < psd.channels, (
         "Invalid channel specified: %s" % channel
@@ -112,7 +119,10 @@ def convert_image_data_to_pil(psd, channel, apply_icc):
     return _remove_white_background(image)
 
 
-def convert_layer_to_pil(layer, channel, apply_icc):
+# TODO: Type hint for layer.
+def convert_layer_to_pil(
+    layer: Any, channel: int | None, apply_icc: bool
+) -> PILImage:
     """Convert Layer to PIL Image."""
     alpha = None
     icc = None
@@ -130,7 +140,9 @@ def convert_layer_to_pil(layer, channel, apply_icc):
     return post_process(image, alpha, icc)
 
 
-def post_process(image, alpha, icc_profile):
+def post_process(
+    image: PILImage, alpha: PILImage, icc_profile: bytes | None = None
+) -> PILImage:
     # Fix inverted CMYK.
     if image.mode == "CMYK":
         from PIL import ImageChops
@@ -146,10 +158,8 @@ def post_process(image, alpha, icc_profile):
     return image
 
 
-def convert_pattern_to_pil(pattern):
+def convert_pattern_to_pil(pattern: Pattern) -> PILImage:
     """Convert Pattern to PIL Image."""
-    from PIL import Image
-
     mode = get_pil_mode(pattern.image_mode)
     # The order is different here.
     size = pattern.data.rectangle[3], pattern.data.rectangle[2]
@@ -171,10 +181,8 @@ def convert_pattern_to_pil(pattern):
     return post_process(image, alpha, None)  # TODO: icc support?
 
 
-def convert_thumbnail_to_pil(thumbnail, mode="RGB"):
+def convert_thumbnail_to_pil(thumbnail, mode="RGB") -> PILImage:
     """Convert thumbnail resource."""
-    from PIL import Image
-
     if thumbnail.fmt == 0:
         size = (thumbnail.width, thumbnail.height)
         stride = thumbnail.widthbytes
@@ -185,9 +193,7 @@ def convert_thumbnail_to_pil(thumbnail, mode="RGB"):
         raise ValueError("Unknown thumbnail format %d" % (thumbnail.fmt))
 
 
-def _merge_channels(layer):
-    from PIL import Image
-
+def _merge_channels(layer: Any) -> PILImage:
     mode = get_pil_mode(layer._psd.color_mode)
     channels = [
         _get_channel(layer, info.id)
@@ -200,7 +206,7 @@ def _merge_channels(layer):
     return Image.merge(mode, channels)
 
 
-def _get_channel(layer, channel):
+def _get_channel(layer: Any, channel: int) -> PILImage | None:
     if channel == ChannelID.USER_LAYER_MASK:
         width = layer.mask._data.right - layer.mask._data.left
         height = layer.mask._data.bottom - layer.mask._data.top
@@ -221,9 +227,7 @@ def _get_channel(layer, channel):
     return _create_image((width, height), channel, depth)
 
 
-def _create_image(size, data, depth):
-    from PIL import Image
-
+def _create_image(size: int, data: bytes, depth: int) -> PILImage:
     if depth == 8:
         return Image.frombytes("L", size, data, "raw")
     elif depth == 16:
@@ -256,7 +260,7 @@ def _check_channels(channels, color_mode):
     return channels
 
 
-def _apply_icc(image, icc_profile):
+def _apply_icc(image: PILImage, icc_profile: bytes) -> PILImage:
     """Apply ICC Color profile."""
     from io import BytesIO
 
@@ -278,9 +282,9 @@ def _apply_icc(image, icc_profile):
     return image
 
 
-def _remove_white_background(image):
+def _remove_white_background(image: PILImage) -> PILImage:
     """Remove white background in the preview image."""
-    from PIL import Image, ImageMath
+    from PIL import ImageMath
 
     if image.mode == "RGBA":
         bands = image.split()

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -2,8 +2,15 @@
 PSD Image module.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import IO, Any, Callable, Literal
+from typing import Any, BinaryIO, Callable, Literal
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 import numpy as np
 from PIL.Image import Image as PILImage
@@ -22,6 +29,7 @@ from psd_tools.api.layers import (
 from psd_tools.api.pil_io import get_pil_channels, get_pil_mode
 from psd_tools.constants import (
     BlendMode,
+    ChannelID,
     ColorMode,
     CompatibilityMode,
     Compression,
@@ -62,12 +70,13 @@ class PSDImage(GroupMixin):
     """
 
     def __init__(self, data: PSD):
+        from psd_tools.api.layers import Layer
+
         assert isinstance(data, PSD)
         self._record = data
-        self._layers = []
-        self._tagged_blocks = None
+        self._layers: list[Layer] = []
         self._compatibility_mode = CompatibilityMode.DEFAULT
-        self._updated_layers = False
+        self._updated_layers = False  # Flag to check if the layer tree is edited.
         self._init()
 
     @classmethod
@@ -99,7 +108,7 @@ class PSDImage(GroupMixin):
         )
 
     @classmethod
-    def frompil(cls, image: PILImage, compression=Compression.RLE) -> "PSDImage":
+    def frompil(cls, image: PILImage, compression=Compression.RLE) -> Self:
         """
         Create a new PSD document from PIL Image.
 
@@ -122,7 +131,7 @@ class PSDImage(GroupMixin):
         )
 
     @classmethod
-    def open(cls, fp: IO, **kwargs: Any) -> "PSDImage":
+    def open(cls, fp: BinaryIO | str, **kwargs: Any) -> Self:
         """
         Open a PSD document.
 
@@ -131,14 +140,14 @@ class PSDImage(GroupMixin):
             default 'macroman'. Some psd files need explicit encoding option.
         :return: A :py:class:`~psd_tools.api.psd_image.PSDImage` object.
         """
-        if hasattr(fp, "read"):
-            self = cls(PSD.read(fp, **kwargs))
-        else:
+        if isinstance(fp, str):
             with open(fp, "rb") as f:
                 self = cls(PSD.read(f, **kwargs))
+        else:
+            self = cls(PSD.read(fp, **kwargs))
         return self
 
-    def save(self, fp: IO, mode: str = "wb", **kwargs: Any) -> None:
+    def save(self, fp: BinaryIO | str, mode: str = "wb", **kwargs: Any) -> None:
         """
         Save the PSD file.
 
@@ -150,13 +159,15 @@ class PSDImage(GroupMixin):
 
         self._update_record()
 
-        if hasattr(fp, "write"):
-            self._record.write(fp, **kwargs)
-        else:
+        if isinstance(fp, str):
             with open(fp, mode) as f:
                 self._record.write(f, **kwargs)
+        else:
+            self._record.write(fp, **kwargs)
 
-    def topil(self, channel: str | None = None, apply_icc: bool = True) -> PILImage:
+    def topil(
+        self, channel: int | ChannelID | None = None, apply_icc: bool = True
+    ) -> PILImage | None:
         """
         Get PIL Image.
 
@@ -405,7 +416,7 @@ class PSDImage(GroupMixin):
         return self._record.header.channels
 
     @property
-    def depth(self) -> Literal[8, 16, 32]:
+    def depth(self) -> int:
         """
         Pixel depth bits.
 
@@ -476,16 +487,15 @@ class PSDImage(GroupMixin):
         """
         return self._compatibility_mode
 
-    @property
-    def pil_mode(self) -> str:
-        alpha = self.channels - get_pil_channels(get_pil_mode(self.color_mode))
-
-        return get_pil_mode(self.color_mode, alpha)
-
     @compatibility_mode.setter
     def compatibility_mode(self, value: CompatibilityMode) -> None:
         self._compatibility_mode = value
         self._compute_clipping_layers()
+
+    @property
+    def pil_mode(self) -> str:
+        alpha = self.channels - get_pil_channels(get_pil_mode(self.color_mode))
+        return get_pil_mode(self.color_mode, alpha > 0)
 
     def has_thumbnail(self) -> bool:
         """True if the PSDImage has a thumbnail resource."""
@@ -507,7 +517,7 @@ class PSDImage(GroupMixin):
             )
         elif Resource.THUMBNAIL_RESOURCE_PS4 in self.image_resources:
             return convert_thumbnail_to_pil(
-                self.image_resources.get_data(Resource.THUMBNAIL_RESOURCE_PS4), "BGR"
+                self.image_resources.get_data(Resource.THUMBNAIL_RESOURCE_PS4)
             )
         return None
 
@@ -613,14 +623,16 @@ class PSDImage(GroupMixin):
 
     def _init(self) -> None:
         """Initialize layer structure."""
-        group_stack = [self]
+        from psd_tools.api.layers import Layer
+
+        group_stack: list[Group | Artboard | PSDImage] = [self]
 
         for record, channels in self._record._iter_layers():
             current_group = group_stack[-1]
 
             blocks = record.tagged_blocks
             end_of_group = False
-            layer = None
+            layer: Layer | Group | Artboard | PSDImage | None = None
             divider = blocks.get_data(Tag.SECTION_DIVIDER_SETTING, None)
             divider = blocks.get_data(Tag.NESTED_SECTION_DIVIDER_SETTING, divider)
             if (
@@ -632,7 +644,12 @@ class PSDImage(GroupMixin):
                 divider.kind is not SectionDivider.OTHER
             ):
                 if divider.kind == SectionDivider.BOUNDING_SECTION_DIVIDER:
-                    layer = Group(self, None, None, current_group)
+                    layer = Group(  # type: ignore
+                        psd=self,
+                        record=None,  # type: ignore
+                        channels=None,  # type: ignore
+                        parent=current_group,
+                    )
                     layer._set_bounding_records(record, channels)
                     group_stack.append(layer)
                 elif divider.kind in (
@@ -640,7 +657,7 @@ class PSDImage(GroupMixin):
                     SectionDivider.CLOSED_FOLDER,
                 ):
                     layer = group_stack.pop()
-                    assert layer is not self
+                    assert not isinstance(layer, PSDImage)
 
                     layer._record = record
                     layer._channels = channels
@@ -688,60 +705,61 @@ class PSDImage(GroupMixin):
             assert layer is not None
 
             if not end_of_group:
+                assert not isinstance(layer, PSDImage)
                 current_group._layers.append(layer)
 
         self._compute_clipping_layers()
 
-    def _update_record(self, layer_group: GroupMixin | None = None) -> None:
+    def _update_record(self) -> None:
         """
         Compiles the tree layer structure back into records and channels list recursively
         """
 
         if not self._updated_layers:
+            # Skip if nothing is changed.
             return
 
-        if layer_group is None:
-            layer_group = self
+        layer_records, channel_image_data = _build_record_tree(self)
 
-        layer_records = LayerRecords()
-        channel_image_data = ChannelImageData()
+        # PSDImage.frompil doesn't create a LayerInfo attribute to LayerAndMaskInformation
+        if not self._record.layer_and_mask_information.layer_info:
+            self._record.layer_and_mask_information.layer_info = LayerInfo()
 
-        for layer in layer_group:
-            if layer.kind in ["group", "artboard"]:
-                layer_records.append(layer._bounding_record)
-                channel_image_data.append(layer._bounding_channels)
-
-                tmp_layer_records, tmp_channel_image_data = self._update_record(layer)
-
-                layer_records.extend(tmp_layer_records)
-                channel_image_data.extend(tmp_channel_image_data)
-
-            layer_records.append(layer._record)
-            channel_image_data.append(layer._channels)
-
-        if layer_group == self:
-            # PSDImage.frompil doesn't create a LayerInfo attribute to LayerAndMaskInformation
-            if not self._record.layer_and_mask_information.layer_info:
-                self._record.layer_and_mask_information.layer_info = LayerInfo()
-
-            if not self._record.layer_and_mask_information.global_layer_mask_info:
-                self._record.layer_and_mask_information.global_layer_mask_info = (
-                    GlobalLayerMaskInfo()
-                )
-
-            if not self._record.layer_and_mask_information.tagged_blocks:
-                self._record.layer_and_mask_information.tagged_blocks = TaggedBlocks()
-
-            self._record.layer_and_mask_information.layer_info.layer_records = (
-                layer_records
-            )
-            self._record.layer_and_mask_information.layer_info.channel_image_data = (
-                channel_image_data
-            )
-            self._record.layer_and_mask_information.layer_info.layer_count = len(
-                layer_records
+        if not self._record.layer_and_mask_information.global_layer_mask_info:
+            self._record.layer_and_mask_information.global_layer_mask_info = (
+                GlobalLayerMaskInfo()
             )
 
-            return
+        if not self._record.layer_and_mask_information.tagged_blocks:
+            self._record.layer_and_mask_information.tagged_blocks = TaggedBlocks()
 
-        return (layer_records, channel_image_data)
+        layer_info = self._record.layer_and_mask_information.layer_info
+        layer_info.layer_records = layer_records
+        layer_info.channel_image_data = channel_image_data
+        layer_info.layer_count = len(layer_records)
+
+
+def _build_record_tree(
+    layer_group: GroupMixin,
+) -> tuple[LayerRecords, ChannelImageData]:
+    """
+    Builds the layer tree structure from records and channels list recursively
+    """
+
+    layer_records = LayerRecords()
+    channel_image_data = ChannelImageData()
+
+    for layer in layer_group:
+        if isinstance(layer, (Group, Artboard)):
+            layer_records.append(layer._bounding_record)
+            channel_image_data.append(layer._bounding_channels)
+
+            tmp_layer_records, tmp_channel_image_data = _build_record_tree(layer)
+
+            layer_records.extend(tmp_layer_records)
+            channel_image_data.extend(tmp_channel_image_data)
+
+        layer_records.append(layer._record)
+        channel_image_data.append(layer._channels)
+
+    return (layer_records, channel_image_data)

--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -7,8 +7,15 @@ live shape properties and :py:class:`Stroke` to specify how outline is
 stylized.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Literal
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from psd_tools.psd.descriptor import Descriptor, DescriptorBlock2
 from psd_tools.psd.vector import (
@@ -176,7 +183,7 @@ class Stroke(object):
     def __init__(self, data: VectorStrokeContentSetting):
         self._data = data
         if self._data.classID not in (b"strokeStyle", Event.Stroke):
-            logger.warning("Unknown class ID found: {}".format(self._data.classID))
+            logger.warning("Unknown class ID found: {!r}".format(self._data.classID))
 
     @property
     def enabled(self) -> bool:
@@ -276,12 +283,12 @@ class Origination(object):
     @classmethod
     def create(
         kls, data: DescriptorBlock2
-    ) -> Literal["Invalidated", "Rectangle", "RoundedRectangle", "Line", "Ellipse"]:
+    ) -> Invalidated | Rectangle | RoundedRectangle | Line | Ellipse:
         if data.get(b"keyShapeInvalidated"):
             return Invalidated(data)
         origin_type = data.get(b"keyOriginType")
         types = {1: Rectangle, 2: RoundedRectangle, 4: Line, 5: Ellipse}
-        return types.get(origin_type, kls)(data)
+        return types.get(origin_type, kls)(data)  # type: ignore
 
     def __init__(self, data):
         self._data = data

--- a/src/psd_tools/api/smart_object.py
+++ b/src/psd_tools/api/smart_object.py
@@ -2,6 +2,8 @@
 Smart object module.
 """
 
+from __future__ import annotations
+
 import contextlib
 import io
 import logging

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -2,6 +2,8 @@
 Blend mode implementations.
 """
 
+from __future__ import annotations
+
 import functools
 import logging
 

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -14,31 +14,31 @@ logger = logging.getLogger(__name__)
 
 
 # Separable blend functions
-def normal(Cb, Cs):
+def normal(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return Cs
 
 
-def multiply(Cb, Cs):
+def multiply(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return Cb * Cs
 
 
-def screen(Cb, Cs):
+def screen(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return Cb + Cs - (Cb * Cs)
 
 
-def overlay(Cb, Cs):
+def overlay(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return hard_light(Cs, Cb)
 
 
-def darken(Cb, Cs):
+def darken(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return np.minimum(Cb, Cs)
 
 
-def lighten(Cb, Cs):
+def lighten(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return np.maximum(Cb, Cs)
 
 
-def color_dodge(Cb, Cs, s=1.0):
+def color_dodge(Cb: np.ndarray, Cs: np.ndarray, s: float = 1.0) -> np.ndarray:
     B = np.zeros_like(Cb, dtype=np.float32)
     B[Cs == 1] = 1
     B[Cb == 0] = 0
@@ -47,7 +47,7 @@ def color_dodge(Cb, Cs, s=1.0):
     return B
 
 
-def color_burn(Cb, Cs, s=1.0):
+def color_burn(Cb: np.ndarray, Cs: np.ndarray, s: float = 1.0) -> np.ndarray:
     B = np.zeros_like(Cb, dtype=np.float32)
     B[Cb == 1] = 1
     index = (Cb != 1) & (Cs != 0)
@@ -55,22 +55,22 @@ def color_burn(Cb, Cs, s=1.0):
     return B
 
 
-def linear_dodge(Cb, Cs):
+def linear_dodge(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return np.minimum(1, Cb + Cs)
 
 
-def linear_burn(Cb, Cs):
+def linear_burn(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return np.maximum(0, Cb + Cs - 1)
 
 
-def hard_light(Cb, Cs):
+def hard_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     index = Cs > 0.5
     B = multiply(Cb, 2 * Cs)
     B[index] = screen(Cb, 2 * Cs - 1)[index]
     return B
 
 
-def soft_light(Cb, Cs):
+def soft_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     index = Cs <= 0.25
     index_not = ~index
     D = np.zeros_like(Cb, dtype=np.float32)
@@ -87,7 +87,7 @@ def soft_light(Cb, Cs):
     return B
 
 
-def vivid_light(Cb, Cs):
+def vivid_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Burns or dodges the colors by increasing or decreasing the contrast,
     depending on the blend color. If the blend color (light source) is lighter
@@ -104,7 +104,7 @@ def vivid_light(Cb, Cs):
     return B
 
 
-def linear_light(Cb, Cs):
+def linear_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Burns or dodges the colors by decreasing or increasing the brightness,
     depending on the blend color. If the blend color (light source) is lighter
@@ -118,7 +118,7 @@ def linear_light(Cb, Cs):
     return B
 
 
-def pin_light(Cb, Cs):
+def pin_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Replaces the colors, depending on the blend color. If the blend color
     (light source) is lighter than 50% gray, pixels darker than the blend color
@@ -133,19 +133,19 @@ def pin_light(Cb, Cs):
     return B
 
 
-def difference(Cb, Cs):
+def difference(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return np.abs(Cb - Cs)
 
 
-def exclusion(Cb, Cs):
+def exclusion(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return Cb + Cs - 2 * Cb * Cs
 
 
-def subtract(Cb, Cs):
+def subtract(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return np.maximum(0, Cb - Cs)
 
 
-def hard_mix(Cb, Cs):
+def hard_mix(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Adds the red, green and blue channel values of the blend color to the RGB
     values of the base color. If the resulting sum for a channel is 255 or
@@ -159,7 +159,7 @@ def hard_mix(Cb, Cs):
     return B
 
 
-def divide(Cb, Cs):
+def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Looks at the color information in each channel and divides the blend color
     from the base color.
@@ -173,7 +173,7 @@ def divide(Cb, Cs):
 # blended, then CMY components should be retrieved from RGB results. K
 # component is K of Cb for hue, saturation, and color blending, and K of Cs for
 # luminosity.
-def non_separable(k="s"):
+def non_separable(k: str = "s"):
     """Wrap non-separable blending function for CMYK handling.
 
     .. note: This implementation is still inaccurate.
@@ -193,11 +193,11 @@ def non_separable(k="s"):
     return decorator
 
 
-def _cmyk2rgb(C):
+def _cmyk2rgb(C: np.ndarray) -> np.ndarray:
     return np.stack([(1.0 - C[:, :, i]) * (1.0 - C[:, :, 3]) for i in range(3)], axis=2)
 
 
-def _rgb2cmy(C, K):
+def _rgb2cmy(C: np.ndarray, K: np.ndarray) -> np.ndarray:
     K = np.repeat(K, 3, axis=2)
     color = np.zeros((C.shape[0], C.shape[1], 3))
     index = K < 1.0
@@ -206,27 +206,27 @@ def _rgb2cmy(C, K):
 
 
 @non_separable()
-def hue(Cb, Cs):
+def hue(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(_set_sat(Cs, _sat(Cb)), _lum(Cb))
 
 
 @non_separable()
-def saturation(Cb, Cs):
+def saturation(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(_set_sat(Cb, _sat(Cs)), _lum(Cb))
 
 
 @non_separable()
-def color(Cb, Cs):
+def color(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(Cs, _lum(Cb))
 
 
 @non_separable("s")
-def luminosity(Cb, Cs):
+def luminosity(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(Cb, _lum(Cs))
 
 
 @non_separable()
-def darker_color(Cb, Cs):
+def darker_color(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     index = np.repeat(_lum(Cs) < _lum(Cb), 3, axis=2)
     B = Cb.copy()
     B[index] = Cs[index]
@@ -234,30 +234,30 @@ def darker_color(Cb, Cs):
 
 
 @non_separable()
-def lighter_color(Cb, Cs):
+def lighter_color(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     index = np.repeat(_lum(Cs) > _lum(Cb), 3, axis=2)
     B = Cb.copy()
     B[index] = Cs[index]
     return B
 
 
-def dissolve(Cb, Cs):
+def dissolve(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     # TODO: Implement me!
     logger.debug("Dissolve blend is not implemented")
     return normal(Cb, Cs)
 
 
 # Helper functions from PDF reference.
-def _lum(C):
+def _lum(C: np.ndarray) -> np.ndarray:
     return 0.3 * C[:, :, 0:1] + 0.59 * C[:, :, 1:2] + 0.11 * C[:, :, 2:3]
 
 
-def _set_lum(C, L):
+def _set_lum(C: np.ndarray, L: np.ndarray) -> np.ndarray:
     d = L - _lum(C)
     return _clip_color(C + d)
 
 
-def _clip_color(C):
+def _clip_color(C: np.ndarray) -> np.ndarray:
     L = np.repeat(_lum(C), 3, axis=2)
     C_min = np.repeat(np.min(C, axis=2, keepdims=True), 3, axis=2)
     C_max = np.repeat(np.max(C, axis=2, keepdims=True), 3, axis=2)
@@ -280,7 +280,7 @@ def _sat(C):
     return np.max(C, axis=2, keepdims=True) - np.min(C, axis=2, keepdims=True)
 
 
-def _set_sat(C, s):
+def _set_sat(C: np.ndarray, s: np.ndarray) -> np.ndarray:
     s = np.repeat(s, 3, axis=2)
 
     C_max = np.repeat(np.max(C, axis=2, keepdims=True), 3, axis=2)

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -6,13 +6,16 @@ from skimage.morphology import disk
 
 import psd_tools.composite
 from psd_tools.terminology import Enum, Key
+from psd_tools.psd.descriptor import Descriptor
 
 from .vector import draw_gradient_fill, draw_pattern_fill, draw_solid_color_fill
 
 logger = logging.getLogger(__name__)
 
 
-def draw_stroke_effect(viewport, shape, desc, psd):
+def draw_stroke_effect(
+    viewport: tuple[int, int, int, int], shape: np.ndarray, desc: Descriptor, psd
+) -> tuple[np.ndarray, np.ndarray]:
     logger.debug("Stroke effect has limited support")
     height, width = viewport[3] - viewport[1], viewport[2] - viewport[0]
     if not isinstance(shape, np.ndarray):

--- a/src/psd_tools/composite/vector.py
+++ b/src/psd_tools/composite/vector.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Tuple
 

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -1,6 +1,7 @@
 """
 Image compression utils.
 """
+from __future__ import annotations
 
 from typing import Iterator
 

--- a/src/psd_tools/compression/rle.py
+++ b/src/psd_tools/compression/rle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 def decode(data: bytes, size: int) -> bytes:
     """decode(data, size) -> bytes
 

--- a/src/psd_tools/psd/image_resources.py
+++ b/src/psd_tools/psd/image_resources.py
@@ -60,7 +60,7 @@ The following resources are plain bytes::
     Resource.LIGHTROOM_WORKFLOW: 8000
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import annotations
 
 import io
 import logging
@@ -969,29 +969,6 @@ class ThumbnailResource(BaseElement):
         )
         written += write_bytes(fp, self.data)
         return written
-
-    def topil(self):
-        """
-        Get PIL Image.
-
-        :return: PIL Image object.
-        """
-        from PIL import Image
-
-        if self.fmt == 1:
-            with io.BytesIO(self.data) as f:
-                image = Image.open(f)
-                image.load()
-        else:
-            image = Image.frombytes(
-                "RGB",
-                (self.width, self.height),
-                self.data,
-                "raw",
-                self._RAW_MODE,
-                self.row,
-            )
-        return image
 
 
 @register(Resource.THUMBNAIL_RESOURCE_PS4)

--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -2,7 +2,7 @@
 Layer and mask data structure.
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import annotations
 
 import io
 import logging
@@ -431,7 +431,7 @@ class LayerRecord(BaseElement):
     left = attr.ib(default=0, type=int)
     bottom = attr.ib(default=0, type=int)
     right = attr.ib(default=0, type=int)
-    channel_info = attr.ib(factory=list)
+    channel_info: list[ChannelInfo] = attr.ib(factory=list)
     signature = attr.ib(
         default=b"8BIM", repr=False, type=bytes, validator=in_((b"8BIM",))
     )
@@ -446,7 +446,7 @@ class LayerRecord(BaseElement):
     mask_data = attr.ib(default=None)
     blending_ranges = attr.ib(factory=LayerBlendingRanges)
     name = attr.ib(default="", type=str)
-    tagged_blocks = attr.ib(factory=TaggedBlocks)
+    tagged_blocks: TaggedBlocks = attr.ib(factory=TaggedBlocks)
 
     @classmethod
     def read(cls, fp, encoding="macroman", version=1):

--- a/src/psd_tools/psd/patterns.py
+++ b/src/psd_tools/psd/patterns.py
@@ -2,7 +2,7 @@
 Patterns structure.
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import annotations
 
 import io
 import logging
@@ -84,7 +84,7 @@ class Pattern(BaseElement):
 
     version = attr.ib(default=1, type=int)
     image_mode = attr.ib(
-        default=ColorMode, converter=ColorMode, validator=in_(ColorMode)
+        default=ColorMode.RGB, converter=ColorMode, validator=in_(ColorMode)
     )
     point = attr.ib(default=None)
     name = attr.ib(default="", type=str)

--- a/src/psd_tools/psd/tagged_blocks.py
+++ b/src/psd_tools/psd/tagged_blocks.py
@@ -7,7 +7,7 @@ Tagged block data structure.
 
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import annotations
 
 import io
 import logging
@@ -714,7 +714,9 @@ class SheetColorSetting(ValueElement):
     .. py:attribute:: value
     """
 
-    value = attr.ib(default=0, converter=SheetColorType, type=SheetColorType)
+    value = attr.ib(
+        default=SheetColorType.NO_COLOR, converter=SheetColorType, type=SheetColorType
+    )
 
     @classmethod
     def read(cls, fp, **kwargs):


### PR DESCRIPTION
Changes:
- Add type annotation to high-level APIs.
- Change `apply_icc = True` by default (Resolve #445)
