### PR TITLE
Force image data update on saving

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,6 +59,7 @@ The opened PSD file can be saved::
 
     psd.save('output.psd')
 
+If the PSD File's layer structure was updated, saving it will update the ImagaData section to produce an accurate thumbnail.
 
 Working with Layers
 -------------------

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -150,7 +150,7 @@ class PSDImage(GroupMixin):
 
     def save(self, fp: BinaryIO | str | bytes | os.PathLike, mode: str = "wb", **kwargs: Any) -> None:
         """
-        Save the PSD file.
+        Save the PSD file. Updates the ImageData section if the layer structure has been updated.
 
         :param fp: filename or file-like object.
         :param encoding: charset encoding of the pascal string within the file,

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -160,6 +160,10 @@ class PSDImage(GroupMixin):
 
         self._update_record()
 
+        if self._updated_layers:
+            composited_psd = self.composite(force=True)
+            self._record.image_data.set_data([channel.tobytes() for channel in composited_psd.split()], self._record.header)
+
         if isinstance(fp, (str, bytes, os.PathLike)):
             with open(fp, mode) as f:
                 self._record.write(f, **kwargs)


### PR DESCRIPTION
Updates the ImageData section when saving the psd if the layer structure was updated.