### PR TITLE
Use ImageMath.lambda_eval to prepare for deprecation

### DIFF
--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -312,7 +312,7 @@ def _remove_white_background(image: PILImage) -> PILImage:
                     * 255.0
                     / args["float"](args["max"](args["a"], 1))
                     * args["float"](args["min"](args["a"], 1))
-                    + args["float"](x) * args["float"](1 - args["min"](args["a"], 1)),
+                    + args["float"](args["x"]) * args["float"](1 - args["min"](args["a"], 1)),
                     "L",
                 ),
                 x=x,


### PR DESCRIPTION
Changes:
- Replace `ImageMath.eval` method with `ImageMath.lambda_eval`. The current `eval` method yields the following warning.

```
DeprecationWarning: ImageMath.eval is deprecated and will be removed in Pillow 12 (2025-10-15). Use ImageMath.lambda_eval or ImageMath.unsafe_eval instead.
```