### PR TITLE
Use plain pip for docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,4 @@ build:
   jobs:
     install:
       - pip install -U pip
-      - pip install --group docs
+      - pip install . --group docs


### PR DESCRIPTION
Changes:
- Use plain `pip` install for dependency groups instead of `uv`, which prefers the `uv.lock` file not needed for other purposes