### PR TITLE
Drop python2 compatibility

### DIFF
--- a/tests/psd_tools/api/test_adjustments.py
+++ b/tests/psd_tools/api/test_adjustments.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/api/test_effects.py
+++ b/tests/psd_tools/api/test_effects.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/api/test_mask.py
+++ b/tests/psd_tools/api/test_mask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/api/test_numpy_io.py
+++ b/tests/psd_tools/api/test_numpy_io.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 

--- a/tests/psd_tools/api/test_pil_io.py
+++ b/tests/psd_tools/api/test_pil_io.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
+import pprint
 from pathlib import Path
 
 import pytest
-from IPython.lib.pretty import pprint
+from PIL import Image
 
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.constants import ColorMode, Compression
@@ -35,8 +34,6 @@ def test_new(args):
 
 
 def test_frompil_psb():
-    from PIL import Image
-
     image = Image.new("RGB", (30001, 24))
     psb = PSDImage.frompil(image)
     assert psb.version == 2
@@ -116,21 +113,18 @@ def test_thumnail(fixture):
 
 def test_repr_pretty(fixture):
     fixture.__repr__()
-    pprint(fixture)
+    pprint.pprint(fixture)
 
 
 @pytest.mark.parametrize(
     "filename",
-    [
-        os.path.join("third-party-psds", "cactus_top.psd"),
-    ],
+    [os.path.join("third-party-psds", "cactus_top.psd")],
 )
 def test_open2(filename):
     assert isinstance(PSDImage.open(full_name(filename)), PSDImage)
 
 
 def test_update_record(fixture):
-
     pixel_layer = PSDImage.open(full_name("layers/pixel-layer.psd"))[0]
     fill_layer = PSDImage.open(full_name("layers/solid-color-fill.psd"))[0]
     shape_layer = PSDImage.open(full_name("layers/shape-layer.psd"))[0]

--- a/tests/psd_tools/api/test_shape.py
+++ b/tests/psd_tools/api/test_shape.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/api/test_smart_object.py
+++ b/tests/psd_tools/api/test_smart_object.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import numpy as np

--- a/tests/psd_tools/compression/test_compression.py
+++ b/tests/psd_tools/compression/test_compression.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/psd/test_adjustments.py
+++ b/tests/psd_tools/psd/test_adjustments.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 

--- a/tests/psd_tools/psd/test_base.py
+++ b/tests/psd_tools/psd/test_base.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 from enum import Enum
 

--- a/tests/psd_tools/psd/test_color_mode_data.py
+++ b/tests/psd_tools/psd/test_color_mode_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 from psd_tools.psd.color_mode_data import ColorModeData
 from psd_tools.utils import pack

--- a/tests/psd_tools/psd/test_descriptor.py
+++ b/tests/psd_tools/psd/test_descriptor.py
@@ -1,9 +1,6 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import pytest
-from IPython.display import display
 
 from psd_tools.psd.descriptor import (
     TYPES,
@@ -39,8 +36,7 @@ def test_descriptor_rw(filename):
 def test_descriptor_display(filename):
     filepath = os.path.join(TEST_ROOT, "descriptors", filename)
     with open(filepath, "rb") as f:
-        value = Descriptor.frombytes(f.read())
-    display(value)
+        Descriptor.frombytes(f.read())
 
 
 @pytest.mark.parametrize(

--- a/tests/psd_tools/psd/test_effects_layer.py
+++ b/tests/psd_tools/psd/test_effects_layer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/psd/test_engine_data.py
+++ b/tests/psd_tools/psd/test_engine_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import pytest

--- a/tests/psd_tools/psd/test_filter_effects.py
+++ b/tests/psd_tools/psd/test_filter_effects.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 import os
 

--- a/tests/psd_tools/psd/test_header.py
+++ b/tests/psd_tools/psd/test_header.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from psd_tools.psd.header import FileHeader

--- a/tests/psd_tools/psd/test_image_data.py
+++ b/tests/psd_tools/psd/test_image_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from psd_tools.constants import Compression

--- a/tests/psd_tools/psd/test_image_resources.py
+++ b/tests/psd_tools/psd/test_image_resources.py
@@ -1,9 +1,6 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import pytest
-from IPython.display import display
 
 from psd_tools.psd import PSD
 from psd_tools.constants import Resource, ColorMode
@@ -28,7 +25,6 @@ def test_image_resources_exception():
 
 def test_image_resources_dict():
     image_resources = ImageResources.new()
-    display(image_resources)
     assert image_resources.get_data(Resource.VERSION_INFO)
     assert image_resources.get_data(Resource.OBSOLETE1) is None
     assert len([1 for key in image_resources if key == Resource.VERSION_INFO]) == 1
@@ -69,7 +65,6 @@ def test_display_info():
         psd = PSD.read(f)
     assert psd.header.color_mode == ColorMode.CMYK
     info = psd.image_resources[Resource.DISPLAY_INFO].data
-    print(display(info))
     assert len(info.alpha_channels) == 3
     expected_colors = [
         # RGB in uint16, with an extra zero because the color space can be CMYK
@@ -90,7 +85,6 @@ def test_display_info_channel_type():
 
     assert psd.header.color_mode == ColorMode.CMYK
     info = psd.image_resources[Resource.DISPLAY_INFO].data
-    print(display(info))
     assert len(info.alpha_channels) == 2
     assert info.alpha_channels[0].mode == AlphaChannelMode.SPOT
     assert info.alpha_channels[1].mode == AlphaChannelMode.INVERTED_ALPHA

--- a/tests/psd_tools/psd/test_layer_and_mask.py
+++ b/tests/psd_tools/psd/test_layer_and_mask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/psd/test_linked_layer.py
+++ b/tests/psd_tools/psd/test_linked_layer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/psd/test_patterns.py
+++ b/tests/psd_tools/psd/test_patterns.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import logging
 
 import pytest

--- a/tests/psd_tools/psd/test_psd.py
+++ b/tests/psd_tools/psd/test_psd.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import io
 import os
 

--- a/tests/psd_tools/psd/test_vector.py
+++ b/tests/psd_tools/psd/test_vector.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from psd_tools.psd.vector import Path

--- a/tests/psd_tools/test_main.py
+++ b/tests/psd_tools/test_main.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import logging
 import sys
 
@@ -15,29 +13,12 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "argv",
     [
-        [
-            "export",
-            full_name("layers/pixel-layer.psd"),
-        ],
-        [
-            "export",
-            full_name("layers/pixel-layer.psd[0]"),
-            "--verbose",
-        ],
-        [
-            "show",
-            full_name("layers/pixel-layer.psd"),
-        ],
-        [
-            "debug",
-            full_name("layers/pixel-layer.psd"),
-        ],
-        [
-            "-h",
-        ],
-        [
-            "--version",
-        ],
+        ["export", full_name("layers/pixel-layer.psd")],
+        ["export", full_name("layers/pixel-layer.psd[0]"), "--verbose"],
+        ["show", full_name("layers/pixel-layer.psd")],
+        ["debug", full_name("layers/pixel-layer.psd")],
+        ["-h"],
+        ["--version"],
     ],
 )
 def test_main(argv, tmpdir):

--- a/tests/psd_tools/test_utils.py
+++ b/tests/psd_tools/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, unicode_literals
-
 import io
 
 import pytest

--- a/tests/psd_tools/utils.py
+++ b/tests/psd_tools/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import fnmatch
 import logging
 import os


### PR DESCRIPTION
Changes:
- Drop python 2.x compatibility in the tests
- Drop IPython-dependent tests in favor of standard pprint