### PR TITLE
Add a pretty repr for subpath

### DIFF
--- a/src/psd_tools/psd/vector.py
+++ b/src/psd_tools/psd/vector.py
@@ -126,8 +126,20 @@ class Subpath(ListElement):
         """
         raise NotImplementedError
 
-    # TODO: Make subpath repr better.
-    # def __repr__(self):
+    def __repr__(self) -> str:
+        """Return a string representation of the subpath."""
+        return "%s(index=%d, operation=%d)" % (
+            self.__class__.__name__,
+            self.index,
+            self.operation,
+        )
+
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            p.text(f"({self.__class__.__name__} ...)")
+            return
+        p.text(self.__repr__())
+        super()._repr_pretty_(p, cycle)
 
 
 @attr.s(repr=False, slots=True)

--- a/tests/psd_tools/psd/test_vector.py
+++ b/tests/psd_tools/psd/test_vector.py
@@ -1,6 +1,6 @@
 import pytest
 
-from psd_tools.psd.vector import Path
+from psd_tools.psd.vector import Path, ClosedPath, OpenPath
 
 from ..utils import check_read_write
 
@@ -22,3 +22,10 @@ from ..utils import check_read_write
 )
 def test_path_rw(fixture):
     check_read_write(Path, fixture)
+
+
+def test_subpath_repr():
+    closedpath = ClosedPath()
+    assert repr(closedpath) == "ClosedPath(index=0, operation=1)"
+    openpath = OpenPath()
+    assert repr(openpath) == "OpenPath(index=0, operation=1)"


### PR DESCRIPTION
Changes:
- Add a `__repr__()` and `_repr_pretty_()` for better printing of subpath classes
- Add a test to check if the output is correct