### PR TITLE
Add fill_opacity attribute

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -668,6 +668,23 @@ class Layer(object):
             metadata = layer.tagged_blocks.get_data(Tag.METADATA_SETTING)
         """
         return self._record.tagged_blocks
+    
+    @property
+    def fill_opacity(self) -> int:
+        """
+        Fill opacity of this layer in [0, 255] range. Writable.
+
+        :return: int
+        """
+        return self.tagged_blocks.get_data(Tag.BLEND_FILL_OPACITY, 255)
+    
+    @fill_opacity.setter
+    def fill_opacity(self, value: int) -> None:
+        if value < 0 or value > 255:
+            raise ValueError("Fill opacity must be between 0 and 255.")
+        if self.fill_opacity != value and self._psd is not None:
+            self._psd._mark_updated()
+        self.tagged_blocks.set_data(Tag.BLEND_FILL_OPACITY, int(value))
 
     def __repr__(self) -> str:
         has_size = self.width > 0 and self.height > 0

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -433,6 +433,16 @@ def test_pixel_layer_frompil():
             )
 
 
+def test_layer_fill_opacity(pixel_layer):
+    assert pixel_layer.fill_opacity == 255
+
+    pixel_layer.fill_opacity = 128
+    assert pixel_layer.fill_opacity == 128
+
+    pixel_layer.fill_opacity = 0
+    assert pixel_layer.fill_opacity == 0
+
+
 def test_delete_layer(pixel_layer):
     pixel_layer.delete_layer()
 


### PR DESCRIPTION
## Summary
- Add `fill_opacity` property to the Layer class to read and write the fill opacity value
- Property returns/accepts values in [0, 255] range
- Includes getter and setter with validation and PSD update tracking

## Test plan
- Added unit tests in `test_layer_fill_opacity` covering:
  - Default fill opacity value (255)
  - Setting fill opacity to different values (128, 0)
  - Validation of the property behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)