### PR TITLE
Update CHANGES.rst for version 1.11.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.11.1 (2025-11-17)
+-------------------
+
+- [ci] Disable Python 3.14 on Windows due to aggdraw unavailability (#521)
+
 1.11.0 (2025-11-09)
 -------------------
 


### PR DESCRIPTION
## Summary

Add changelog entry for version 1.11.1 to document the changes made in #521.

## Changes

- Added version 1.11.1 section to CHANGES.rst with release date (2025-11-17)
- Documented the CI change: "Disable Python 3.14 on Windows due to aggdraw unavailability"

This completes the release documentation for version 1.11.1 before tagging and releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)