### PR TITLE
chore: Remove redundant MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/psd_tools/compression/_rle.pyx


### PR DESCRIPTION
## Summary
- Remove redundant MANIFEST.in file as pyproject.toml already handles package data inclusion

## Details

The `MANIFEST.in` file only contained:
```
include src/psd_tools/compression/_rle.pyx
```

This is redundant because [pyproject.toml](pyproject.toml#L66-L67) already configures package data:
```toml
[tool.setuptools.package-data]
psd_tools = ["*.pyx"]
```

This modern approach is more maintainable and flexible than maintaining a separate MANIFEST.in file.

## Verification

Verified that both wheel and sdist packages correctly include the required files:
- ✅ `psd_tools/compression/_rle.pyx`
- ✅ `psd_tools/compression/_rle.cpp`

Built and inspected both package types to confirm no regression in file inclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)