### PR TITLE
fix: Handle missing composite dependencies gracefully in PSDImage.save

### DIFF
--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -202,11 +202,20 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         """
         if self.is_updated():
             # Update the preview image if the layer structure has been changed.
-            composited_psd = self.composite()
-            self._record.image_data.set_data(
-                [channel.tobytes() for channel in composited_psd.split()],
-                self._record.header,
-            )
+            # TODO: Fill in a white background for the given color mode on failure.
+            # TODO: Set a `has_composite` flag in VersionInfo resource.
+            try:
+                composited_psd = self.composite()
+                self._record.image_data.set_data(
+                    [channel.tobytes() for channel in composited_psd.split()],
+                    self._record.header,
+                )
+            except ImportError as e:
+                logger.warning(
+                    "Failed to update preview image: %s. "
+                    "Install composite dependencies with: pip install 'psd-tools[composite]'",
+                    e,
+                )
 
         if isinstance(fp, (str, bytes, os.PathLike)):
             with open(fp, mode) as f:


### PR DESCRIPTION
## Summary

- Add try-catch guard around `composite()` call in `PSDImage.save()` to gracefully handle missing optional composite dependencies
- Log warning with installation instructions when composite fails
- Allow users to save PSD files even without `aggdraw`, `scipy`, and `scikit-image` installed

## Problem

Previously, when `PSDImage.save()` was called after modifying the layer structure, it would automatically try to update the preview image by calling `composite()`. However, if the optional composite dependencies were not installed, this would raise an `ImportError` and prevent the file from being saved.

## Solution

This PR wraps the `composite()` call in a try-except block to catch `ImportError`. When the composite dependencies are missing:
- A warning is logged with clear instructions on how to install the dependencies
- The save operation continues without updating the preview image
- The file is still saved successfully with the layer structure changes

## Changes

- Added try-catch guard in [psd_image.py:205-218](src/psd_tools/api/psd_image.py#L205-L218)
- Added helpful warning message with installation instructions
- Added TODO comments for future enhancements (white background fallback, `has_composite` flag in VersionInfo)

## Test plan

- [ ] Verify that `save()` works correctly when composite dependencies are installed
- [ ] Verify that `save()` doesn't crash when composite dependencies are missing
- [ ] Verify that warning message is logged when composite fails
- [ ] Verify that the file is saved successfully in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)