### PR TITLE
Refactor: Improve type annotations and standardize imports

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -589,9 +589,9 @@ class Layer(LayerProtocol):
             'shape', 'alpha', or 'mask'. Default is 'color+alpha'.
         :return: :py:class:`numpy.ndarray` or None if there is no pixel.
         """
-        from .numpy_io import get_array
+        from . import numpy_io
 
-        return get_array(self, channel, real_mask=real_mask)
+        return numpy_io.get_array(self, channel, real_mask=real_mask)
 
     def composite(
         self,

--- a/src/psd_tools/api/mask.py
+++ b/src/psd_tools/api/mask.py
@@ -5,7 +5,7 @@ Mask module.
 import logging
 from typing import Any, Optional, cast
 
-from PIL.Image import Image as PILImage
+from PIL import Image
 
 from psd_tools.api.protocols import LayerProtocol, MaskProtocol
 from psd_tools.constants import ChannelID
@@ -111,7 +111,7 @@ class Mask(MaskProtocol):
         """Return True if the mask has real flags."""
         return self.real_flags is not None and self.real_flags.parameters_applied
 
-    def topil(self, real: bool = True, **kwargs: Any) -> Optional[PILImage]:
+    def topil(self, real: bool = True, **kwargs: Any) -> Optional[Image.Image]:
         """
         Get PIL Image of the mask.
 

--- a/src/psd_tools/api/protocols.py
+++ b/src/psd_tools/api/protocols.py
@@ -9,12 +9,12 @@ to properly type hint their parameters while avoiding circular dependency issues
 from typing import Callable, Iterator, Literal, Optional, Protocol, Union
 
 import numpy as np
-from PIL.Image import Image as PILImage
+from PIL import Image
 
 from psd_tools.constants import BlendMode, ChannelID, ColorMode, CompatibilityMode
-from psd_tools.psd.layer_and_mask import ChannelDataList, LayerRecord, MaskData
 from psd_tools.psd.document import PSD
 from psd_tools.psd.image_resources import ImageResources
+from psd_tools.psd.layer_and_mask import ChannelDataList, LayerRecord, MaskData
 from psd_tools.psd.tagged_blocks import TaggedBlocks
 
 
@@ -233,7 +233,7 @@ class LayerProtocol(Protocol):
 
     def topil(
         self, channel: Optional[int] = None, apply_icc: bool = True
-    ) -> Optional[PILImage]:
+    ) -> Optional[Image.Image]:
         """
         Get PIL Image of the layer.
 
@@ -263,7 +263,7 @@ class LayerProtocol(Protocol):
         alpha: Union[float, np.ndarray] = 0.0,
         layer_filter: Optional[Callable] = None,
         apply_icc: bool = True,
-    ) -> Optional[PILImage]:
+    ) -> Optional[Image.Image]:
         """
         Composite the layer.
 
@@ -436,7 +436,7 @@ class PSDProtocol(GroupMixinProtocol, Protocol):
 
     def topil(
         self, channel: Union[int, ChannelID, None] = None, apply_icc: bool = True
-    ) -> Optional[PILImage]:
+    ) -> Optional[Image.Image]:
         """
         Get PIL Image of the document.
 
@@ -466,7 +466,7 @@ class PSDProtocol(GroupMixinProtocol, Protocol):
         layer_filter: Optional[Callable] = None,
         ignore_preview: bool = False,
         apply_icc: bool = True,
-    ) -> PILImage:
+    ) -> Image.Image:
         """
         Composite the PSD document.
 

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -75,17 +75,17 @@ from psd_tools.constants import (
     Tag,
 )
 from psd_tools.psd.document import PSD
+from psd_tools.psd.header import FileHeader
+from psd_tools.psd.image_data import ImageData
+from psd_tools.psd.image_resources import ImageResources
 from psd_tools.psd.layer_and_mask import (
     ChannelImageData,
     GlobalLayerMaskInfo,
     LayerInfo,
     LayerRecords,
 )
-from psd_tools.psd.header import FileHeader
-from psd_tools.psd.image_data import ImageData
-from psd_tools.psd.image_resources import ImageResources
-from psd_tools.psd.tagged_blocks import TaggedBlocks
 from psd_tools.psd.patterns import Patterns
+from psd_tools.psd.tagged_blocks import TaggedBlocks
 
 logger = logging.getLogger(__name__)
 
@@ -252,7 +252,9 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
             'shape', 'alpha', or 'mask'. Default is 'color+alpha'.
         :return: :py:class:`numpy.ndarray`
         """
-        return numpy_io.get_array(self, channel)
+        array = numpy_io.get_array(self, channel)
+        assert array is not None
+        return array
 
     def composite(
         self,


### PR DESCRIPTION
## Summary

- Standardize PIL imports across API modules to use consistent `from PIL import Image` pattern
- Improve type annotations for PIL Image objects (`Image.Image` instead of `PILImage`)
- Enhance type safety in numpy_io module by using `Optional[np.ndarray]` return type
- Eliminate runtime circular imports by using `kind` attribute dispatch instead of `isinstance()` checks
- Improve code clarity with better parameter naming (e.g., `psd` → `psdimage`)

## Changes

### Import Standardization
- **protocols.py**: Changed `from PIL.Image import Image as PILImage` to `from PIL import Image`
- **mask.py**: Updated PIL import pattern to match
- Updated all type hints from `PILImage` to `Image.Image`

### Type Safety Improvements in numpy_io.py
- Changed `get_array()` return type from `np.ndarray` to `Optional[np.ndarray]` for accuracy
- Replaced runtime `isinstance()` checks with `kind` attribute dispatch to avoid circular imports
- Renamed parameter `psd` to `psdimage` for clarity in `get_image_data()` and `_remove_background()`
- Added assertion in `PSDImage.numpy()` to satisfy type checker (this method always returns data)

### Code Organization
- **layers.py**: Changed to module-level import pattern (`from . import numpy_io`)
- **psd_image.py**: Minor import ordering improvements

## Benefits

1. **Consistency**: All PIL imports now follow the same pattern across the codebase
2. **Performance**: Eliminated runtime circular imports by using protocol attributes
3. **Type Safety**: More accurate type hints that better reflect actual behavior
4. **Maintainability**: Clearer code with better naming and organization

## Test Plan

- [x] Verify existing tests pass
- [x] Confirm type checking works correctly with mypy
- [x] Ensure no runtime circular import issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)