### PR TITLE
docs: Update documentation for v1.12.0 release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,13 +4,29 @@ Changelog
 1.12.0 (2025-11-17)
 -------------------
 
-- [packaging] Make composite dependencies optional via ``psd-tools[composite]`` extra
+- [packaging] Make composite dependencies optional via ``psd-tools[composite]`` extra (#525)
 - [api] Lazy-load advanced composite features (vector masks, gradients, effects) to avoid importing optional dependencies unless needed
 - [api] Basic numpy-based compositing works without ``scipy``, ``scikit-image``, or ``aggdraw``
 - [api] Composite functionality raises ``ImportError`` with installation instructions only when advanced features are used
+- [api] Handle missing composite dependencies gracefully in ``PSDImage.save()`` (#532)
 - [packaging] Move ``aggdraw``, ``scipy``, and ``scikit-image`` to optional dependencies
 - [packaging] Keep ``numpy`` as core dependency for raw pixel data access
-- [docs] Update installation instructions for optional composite support
+- [refactor] Move ``PSD`` class to dedicated ``document`` module (#530)
+- [refactor] Reorganize composite module structure and add type safety (#524)
+- [refactor] Split utils module into registry and bin_utils (#537)
+- [refactor] Create shared API utils module (#538)
+- [refactor] Improve type annotations and standardize imports (#539)
+- [api] Add comprehensive type annotations to psd_tools package (#536)
+- [tests] Add comprehensive type annotations to test suite (#534, #535)
+- [tests] Add CI testing without composite dependencies (#533)
+- [docs] Enhance package and module docstrings with comprehensive documentation (#531)
+- [docs] Update installation instructions for optional composite support (#527)
+- [docs] Convert README to Markdown (#527)
+- [ci] Fix CI status badge in README (#523)
+- [ci] Fix ReadTheDocs build by adding Self import fallback
+- [ci] Fix Python 3.10 mypy compatibility (#526)
+- [chore] Remove unused deprecated decorator (#529)
+- [chore] Remove redundant MANIFEST.in file (#528)
 
 **Breaking change**: Users who rely on advanced composite features (vector masks, gradient fills,
 pattern fills, stroke effects) must now install with ``pip install 'psd-tools[composite]'`` or

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,12 +80,14 @@ Limited support:
 * Composition of fill layer effects
 * Vector masks
 * Editing of some layer attributes such as layer name
+* Basic editing of pixel layers and groups, such as adding or removing a layer
 * Blending modes except for dissolve
 * Drawing of bezier curves
 
 Not supported:
 
-* Editing of layer structure, such as adding or removing a layer
+* Editing of various layers such as type layers, shape layers, smart objects, etc.
+* Editing of texts in type layers
 * Composition of adjustment layers
 * Composition of many layer effects
 * Font rendering

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,3 +1,75 @@
+Migrating to 1.12
+=================
+
+psd-tools 1.12 makes composite dependencies optional to support more platforms and Python versions.
+
+Breaking Change: Optional Composite Dependencies
+-------------------------------------------------
+
+The main breaking change in version 1.12 is that advanced compositing features now require
+optional dependencies that must be explicitly installed.
+
+**What changed:**
+
+- Dependencies ``aggdraw``, ``scipy``, and ``scikit-image`` are now optional
+- Basic compositing with NumPy continues to work without these dependencies
+- Advanced features (vector masks, gradients, patterns, effects) require the composite extra
+
+**Migration steps:**
+
+If you use advanced compositing features, install with the composite extra::
+
+    pip install 'psd-tools[composite]'
+
+Or install the dependencies separately::
+
+    pip install psd-tools aggdraw scipy scikit-image
+
+**What works without composite dependencies:**
+
+- Reading and writing PSD files
+- Accessing layer information (names, dimensions, etc.)
+- Extracting raw pixel data with NumPy
+- Basic pixel layer compositing
+- Using cached layer previews
+
+**What requires composite dependencies:**
+
+- Vector shape and stroke rendering
+- Gradient fills
+- Pattern fills
+- Layer effects rendering (drop shadows, strokes, etc.)
+
+**Error handling:**
+
+If you try to use advanced features without the dependencies installed, you'll see a clear error::
+
+    ImportError: Advanced compositing features require optional dependencies.
+    Install with: pip install 'psd-tools[composite]'
+
+**Why this change:**
+
+This change enables psd-tools to run on platforms where some composite dependencies
+are unavailable, particularly Python 3.14 on Windows where ``aggdraw`` is not yet available.
+
+Module Structure Changes
+------------------------
+
+Version 1.12 includes some internal refactoring that generally doesn't affect public APIs:
+
+- The ``PSD`` class moved from ``psd_tools.psd`` to ``psd_tools.psd.document`` (still importable from ``psd_tools.psd``)
+- Utils module split into ``registry`` and ``bin_utils`` (internal change)
+- Composite module reorganized for better type safety (internal change)
+
+These changes maintain backward compatibility for public imports.
+
+Type Annotations
+----------------
+
+Version 1.12 adds comprehensive type annotations throughout the codebase. If you use
+type checkers like mypy, you may discover type errors in your code that were previously
+undetected. This is a good thing - the annotations help catch bugs earlier!
+
 Migrating to 1.11
 =================
 


### PR DESCRIPTION
## Summary

This PR updates the documentation for the v1.12.0 release:

- **Changelog**: Added comprehensive list of all changes since v1.11.1 (PRs #523-#539)
- **Features**: Updated the features section in index.rst to accurately reflect current capabilities
- **Migration Guide**: Added detailed migration guide for v1.12.0 with breaking changes documentation

## Changes

### Changelog (`docs/changelog.rst`)
- Listed all 17 PRs merged since v1.11.1
- Categorized changes by type: packaging, api, refactor, tests, docs, ci, chore
- Included PR numbers for traceability
- Detailed the breaking change regarding optional composite dependencies

### Features (`docs/index.rst`)
- Moved "Basic editing of pixel layers and groups" from "Not supported" to "Limited support"
- Added more specific items to "Not supported" section (editing type layers, shape layers, etc.)
- Now matches the feature list in README.md

### Migration Guide (`docs/migration.rst`)
- Added comprehensive "Migrating to 1.12" section
- Explained the breaking change about optional composite dependencies
- Provided clear migration steps with installation commands
- Listed what works without composite dependencies vs. what requires them
- Explained error handling and rationale for the change
- Documented module structure changes and type annotation improvements

## Why these changes

These documentation updates are essential for the v1.12.0 release to:
1. Help users understand what's new and what has changed
2. Provide clear migration path for users upgrading from v1.11.x
3. Set correct expectations about feature support
4. Document the breaking change regarding optional dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)