### PR TITLE
ensure preview image mode when saving

### DIFF
--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -207,7 +207,7 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
             # TODO: Fill in a white background for the given color mode on failure.
             # TODO: Set a `has_composite` flag in VersionInfo resource.
             try:
-                composited_psd = self.composite()
+                composited_psd = self.composite().convert(self.pil_mode)
                 self._record.image_data.set_data(
                     [channel.tobytes() for channel in composited_psd.split()],
                     self._record.header,

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -256,3 +256,13 @@ def test_save_without_composite_dependencies(tmp_path: Path, caplog: Any) -> Non
     loaded = PSDImage.open(output_path)
     assert len(loaded) == 1
     assert loaded[0].name == "Test Layer"
+
+
+def test_save_rgba_pixel_layer(tmp_path: Path):
+    # create an RGBA PSD with a layer
+    psd = PSDImage.new("RGBA", (32, 48))
+    psd.create_pixel_layer(Image.linear_gradient("L").resize(psd.size), "layer1")
+    psd.save(tmp_path / "tmp.psd")
+
+    # check that the updated preview image has the expected number of channels
+    assert len(psd._record.image_data.get_data(psd._record.header)) == 4


### PR DESCRIPTION
The following code generate a corrupted PSD file (Photoshop and GIMP complain about an unexpected end-of-file):
```py
from PIL import Image
from psd_tools.api.psd_image import PSDImage

psd = PSDImage.new("RGBA", (32, 48))
psd.create_pixel_layer(Image.linear_gradient("L").resize(psd.size), "layer1")
psd.save("/tmp/rgba-layer.psd")
```

I tracked the issue down to the preview image being written as RGB even though the PSD file is RGBA. Converting the preview image to match the PSD's type seems to fix the issue (at least in that specific case) see attached files: [rgba-layer-save-bug.zip](https://github.com/user-attachments/files/23928042/rgba-layer-save-bug.zip)

I'm not 100% sure this is the correct fix (should `self.composite()` return an image with matching mode already?), let me know if it isn't an I'll open an issue instead. 