### PR TITLE
Fix least-privilege permissions in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build_wheels:
@@ -31,6 +31,8 @@ jobs:
     name: Create GitHub Release
     needs: build_wheels
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }} - ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` at the top level of `test.yml` (previously had no explicit permissions block, inheriting overly broad defaults)
- Add `permissions: contents: read` at the top level of `release.yml`, replacing the previous global `contents: write`
- Scope `permissions: contents: write` to only the `create_release` job in `release.yml`, which is the only job that actually requires write access

Resolves code scanning alerts about workflows not following the principle of least privilege.

## Test plan

- [x] Verify `test.yml` workflow runs successfully on push/PR (only needs read access for checkout)
- [ ] Verify `release.yml` `build_wheels` and `publish_pypi` jobs run with read-only access
- [ ] Verify `release.yml` `create_release` job can still create GitHub releases with its scoped `contents: write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)