### PR TITLE
Fix UTF-16 surrogate pair handling for emoji in text layers

### DIFF
--- a/src/psd_tools/psd/bin_utils.py
+++ b/src/psd_tools/psd/bin_utils.py
@@ -233,15 +233,15 @@ def write_pascal_string(
 
 def read_unicode_string(fp: BinaryIO, padding: int = 1) -> str:
     num_chars = read_fmt("I", fp)[0]
-    chars = be_array_from_bytes("H", fp.read(num_chars * 2))
+    data = fp.read(num_chars * 2)
     read_padding(fp, struct.calcsize("I") + num_chars * 2, padding)
-    return "".join(chr(num) for num in chars)
+    return data.decode("utf-16-be")
 
 
 def write_unicode_string(fp: BinaryIO, value: str, padding: int = 1) -> int:
-    arr = array.array(str("H"), [ord(x) for x in value])
-    written = write_fmt(fp, "I", len(arr))
-    written += write_bytes(fp, be_array_to_bytes(arr))
+    encoded = value.encode("utf-16-be")
+    written = write_fmt(fp, "I", len(encoded) // 2)
+    written += write_bytes(fp, encoded)
     written += write_padding(fp, written, padding)
     return written
 

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -100,8 +100,8 @@ def test_pixel_layer_writable_properties(pixel_layer: PixelLayer) -> None:
     layer.name = "foo"
     assert layer.name == "foo"
     layer._record.tobytes()
-    layer.name = "\ud83d\udc7d"
-    assert layer.name == "\ud83d\udc7d"
+    layer.name = "👽"
+    assert layer.name == "👽"
     layer._record.tobytes()
 
     layer.visible = False

--- a/tests/psd_tools/psd/test_bin_utils.py
+++ b/tests/psd_tools/psd/test_bin_utils.py
@@ -109,6 +109,8 @@ def test_pascal_string_format(input: str, expected: str, padding: int) -> None:
         ("", 1),
         ("abc", 1),
         ("\u3042\u3044\u3046\u3048\u304a", 1),
+        ("😈", 1),
+        ("Hello 😈!", 1),
         ("", 4),
         ("abc", 4),
         ("\u3042\u3044\u3046\u3048\u304a", 4),


### PR DESCRIPTION
## Summary

- Fixes `UnicodeEncodeError: surrogates not allowed` when reading text layers containing emoji (issue #545)
- `read_unicode_string()` now uses `data.decode("utf-16-be")` instead of assembling a string via `chr()` on raw 16-bit code units — the `utf-16-be` codec correctly pairs surrogates into proper Unicode code points
- `write_unicode_string()` now uses `value.encode("utf-16-be")` instead of `array.array("H", [ord(x) for x in value])` — correctly encodes emoji (code points > U+FFFF) as surrogate pairs

## Root cause

PSD files store text as UTF-16 big-endian. Emoji like 😈 (U+1F608) require a surrogate pair: two 16-bit code units (`\xD83D\xDE08`). The old code called `chr()` on each unit individually, producing lone surrogate characters (`\ud83d\ude08`) in the Python string. Python allows these internally but raises `UnicodeEncodeError: surrogates not allowed` on any UTF-8 encode (e.g. `print()`).

## Test plan

- [x] Added `"😈"` and `"Hello 😈!"` round-trip test cases to `test_unicode_string_wr`
- [x] Updated `test_pixel_layer_writable_properties` to use the proper Unicode emoji `"👽"` instead of the old lone-surrogate form `"\ud83d\udc7d"`
- [x] All 975 tests pass

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)