### PR TITLE
feat: expose Layer.sheet_color for Photoshop layer color labels

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -120,6 +120,7 @@ from psd_tools.constants import (
     Compression,
     ProtectedFlags,
     SectionDivider,
+    SheetColorType,
     Tag,
     TextType,
 )
@@ -946,6 +947,24 @@ class Layer(LayerProtocol):
         self.tagged_blocks.set_data(
             Tag.REFERENCE_POINT, [float(value[0]), float(value[1])]
         )
+
+    @property
+    def sheet_color(self) -> SheetColorType:
+        """
+        Color label of this layer in the Photoshop layers panel. Writable.
+
+        :return: :py:class:`~psd_tools.constants.SheetColorType`
+        """
+        return self.tagged_blocks.get_data(
+            Tag.SHEET_COLOR_SETTING, SheetColorType.NO_COLOR
+        )
+
+    @sheet_color.setter
+    def sheet_color(self, value: SheetColorType) -> None:
+        value = SheetColorType(value)
+        if self.sheet_color != value and self._psd is not None:
+            self._psd._mark_updated()
+        self.tagged_blocks.set_data(Tag.SHEET_COLOR_SETTING, value)
 
     def __repr__(self) -> str:
         has_size = self.width > 0 and self.height > 0

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -623,6 +623,18 @@ def test_layer_reference_point(pixel_layer: PixelLayer) -> None:
         pixel_layer.reference_point = (10.5, 20.5, 30.5)
 
 
+def test_layer_sheet_color(pixel_layer: PixelLayer) -> None:
+    from psd_tools.constants import SheetColorType
+
+    assert pixel_layer.sheet_color == SheetColorType.NO_COLOR
+
+    pixel_layer.sheet_color = SheetColorType.RED
+    assert pixel_layer.sheet_color == SheetColorType.RED
+
+    pixel_layer.sheet_color = SheetColorType.NO_COLOR
+    assert pixel_layer.sheet_color == SheetColorType.NO_COLOR
+
+
 def test_layer_move_up(
     group: Group,
     pixel_layer: PixelLayer,


### PR DESCRIPTION
Closes #546

## Summary

- Adds a `sheet_color` property (read/write) to the `Layer` base class, exposing the Photoshop Layers panel color label feature
- The low-level `lclr` tagged block (`SheetColorSetting`) and `SheetColorType` enum were already fully implemented — this PR surfaces them in the high-level API

## Usage

```python
from psd_tools import PSDImage
from psd_tools.constants import SheetColorType

psd = PSDImage.open("example.psd")
layer = psd[0]

# Read the current color label
print(layer.sheet_color)  # SheetColorType.NO_COLOR

# Set a color label
layer.sheet_color = SheetColorType.RED
psd.save("example.psd")
```

## Test plan

- [x] `test_layer_sheet_color` added covering get, set, and round-trip back to `NO_COLOR`
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [x] `uv run pytest tests/psd_tools/api/test_layers.py --no-cov` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)