### PR TITLE
fix: parse TransferFunction curve values as signed shorts

### DIFF
--- a/src/psd_tools/psd/image_resources.py
+++ b/src/psd_tools/psd/image_resources.py
@@ -1026,20 +1026,34 @@ class TransferFunctions(ListElement):
 @define(repr=False)
 class TransferFunction(BaseElement):
     """
-    Transfer function
+    Transfer function for a single plate.
+
+    Contains 13 signed short integers representing curve control points in the
+    range 0...1000 (corresponding to 0.0%...100.0%). The first and last values
+    are always present; any intermediate value may be -1 to indicate that no
+    control point exists at that position. A NULL (identity) transfer curve has
+    the form::
+
+        [0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1000]
+
+    Followed by one unsigned short ``override`` flag (non-zero means the
+    transfer function overrides the default).
+
+    See `Adobe PSD spec §Transfer Functions
+    <https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577411_pgfId-1071095>`_.
     """
 
-    curve: list = field(factory=list, converter=list)
-    override: bool = False
+    curve: list[int] = field(factory=list, converter=list)
+    override: int = 0
 
     @classmethod
     def read(cls, fp: BinaryIO, **kwargs: Any) -> "TransferFunction":
-        curve = read_fmt("13H", fp)
+        curve = read_fmt("13h", fp)
         override = read_fmt("H", fp)[0]
         return cls(curve=curve, override=override)
 
     def write(self, fp: BinaryIO, **kwargs: Any) -> int:
-        written = write_fmt(fp, "13H", *self.curve)
+        written = write_fmt(fp, "13h", *self.curve)
         written += write_fmt(fp, "H", self.override)
         return written
 

--- a/tests/psd_tools/psd/test_image_resources.py
+++ b/tests/psd_tools/psd/test_image_resources.py
@@ -6,10 +6,12 @@ import pytest
 from psd_tools.psd import PSD
 from psd_tools.constants import Resource, ColorMode
 from psd_tools.psd.image_resources import (
+    AlphaChannelMode,
     ImageResource,
     ImageResources,
     Slices,
-    AlphaChannelMode,
+    TransferFunction,
+    TransferFunctions,
 )
 
 from ..utils import TEST_ROOT, check_read_write, check_write_read
@@ -77,6 +79,85 @@ def test_display_info() -> None:
         assert c.mode == AlphaChannelMode.SPOT
         assert c.color_space == 0  # RGB color space
         assert [c.c1, c.c2, c.c3, c.c4] == expected_colors[i]
+
+
+NULL_CURVE = [0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 1000]
+
+
+@pytest.mark.parametrize(
+    "curve, override",
+    [
+        # Adobe spec NULL curve: intermediate points are -1 (no point), exercises signed values
+        (NULL_CURVE, 0),
+        # All points explicitly set (fully-defined curve, all positive)
+        ([0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950, 975, 1000], 0),
+        # Mixed -1 (no-point) with defined midpoints; also checks override is preserved
+        ([0, 250, -1, 500, -1, 750, -1, -1, -1, -1, -1, -1, 1000], 1),
+    ],
+)
+def test_transfer_function_write_read(curve: list, override: int) -> None:
+    check_write_read(TransferFunction(curve=curve, override=override))
+
+
+def test_transfer_functions_write_read() -> None:
+    null_fn = TransferFunction(curve=NULL_CURVE, override=0)  # type: ignore[arg-type]
+    # 1 function (grayscale)
+    check_write_read(TransferFunctions([null_fn]))  # type: ignore[list-item]
+    # 4 functions (duotone / CMYK / color)
+    check_write_read(TransferFunctions([null_fn] * 4))  # type: ignore[list-item]
+
+
+@pytest.mark.parametrize(
+    "psd_path, resource_key",
+    [
+        (
+            os.path.join("colormodes", "4x4_8bit_duotone.psd"),
+            Resource.DUOTONE_TRANSFER_FUNCTION,
+        ),
+        (
+            os.path.join("colormodes", "4x4_8bit_grayscale.psd"),
+            Resource.GRAYSCALE_TRANSFER_FUNCTION,
+        ),
+        (
+            os.path.join("colormodes", "4x4_16bit_grayscale.psd"),
+            Resource.GRAYSCALE_TRANSFER_FUNCTION,
+        ),
+    ],
+)
+def test_transfer_functions_rw_from_psd(psd_path: str, resource_key: Resource) -> None:
+    filepath = os.path.join(TEST_ROOT, "psd_files", psd_path)
+    with open(filepath, "rb") as f:
+        psd = PSD.read(f)
+    check_write_read(psd.image_resources[resource_key].data)
+
+
+@pytest.mark.parametrize(
+    "psd_path, resource_key, expected_count",
+    [
+        (
+            os.path.join("colormodes", "4x4_8bit_duotone.psd"),
+            Resource.DUOTONE_TRANSFER_FUNCTION,
+            4,
+        ),
+        (
+            os.path.join("colormodes", "4x4_8bit_grayscale.psd"),
+            Resource.GRAYSCALE_TRANSFER_FUNCTION,
+            1,
+        ),
+    ],
+)
+def test_transfer_functions_values(
+    psd_path: str, resource_key: Resource, expected_count: int
+) -> None:
+    """Decoded values must match the Adobe spec NULL curve with signed -1 sentinel."""
+    filepath = os.path.join(TEST_ROOT, "psd_files", psd_path)
+    with open(filepath, "rb") as f:
+        psd = PSD.read(f)
+    tf = psd.image_resources[resource_key].data
+    assert len(tf) == expected_count
+    for fn in tf:
+        assert list(fn.curve) == NULL_CURVE
+        assert fn.override == 0
 
 
 def test_display_info_channel_type() -> None:


### PR DESCRIPTION
## Summary

- The Adobe PSD spec defines the 13 `TransferFunction` curve values as **signed** short integers, where `-1` means "no control point at this position". The previous `13H` (unsigned) format incorrectly read `-1` as `65535`.
- Corrects `override` field type from `bool` to `int` (it is an unsigned short flag, not a Python bool).
- Expands the `TransferFunction` docstring with full spec details, the NULL curve example, and a link to the Adobe spec.
- Adds test coverage: round-trips for hand-crafted curves (including the NULL curve that exercises the signed fix), and validation against real duotone/grayscale PSD fixtures.

## Test plan

- [x] `test_transfer_function_write_read` — parametrized over NULL curve, fully-defined curve, and mixed curve with `override=1`
- [x] `test_transfer_functions_write_read` — container round-trip with 1 and 4 functions
- [x] `test_transfer_functions_rw_from_psd` — round-trip from real duotone and grayscale PSD fixtures
- [x] `test_transfer_functions_values` — asserts decoded curves match the spec NULL curve with signed `-1` sentinels and correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)