### PR TITLE
fix: update contributing link from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Check out the [documentation](https://psd-tools.readthedocs.io/) for features an
 
 ## Contributing
 
-See [contributing](https://github.com/psd-tools/psd-tools/blob/master/docs/contributing.rst) page.
+See [contributing](https://github.com/psd-tools/psd-tools/blob/main/docs/contributing.rst) page.
 
 > **Note**
 >


### PR DESCRIPTION
## Summary
- Updated the contributing link in README.md from the obsolete `master` branch to `main`

## Test plan
- [x] Verified no other documentation files contain stale `master` branch references

🤖 Generated with [Claude Code](https://claude.com/claude-code)