### PR TITLE
fix: don't add USER_LAYER_MASK when PSD mode already carries transparency

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -1683,14 +1683,23 @@ class PixelLayer(Layer):
         Create a PixelLayer from a PIL image for a given psd file.
 
         :param image: The :py:class:`~PIL.Image.Image` object to convert to photoshop
-        :param psdimage: The target psdimage the image will be converted for.
+        :param parent: The parent group or PSDImage this layer belongs to.
         :param name: The name of the layer. Defaults to "Layer"
         :param top: Pixelwise offset from the top of the canvas for the new layer.
         :param left: Pixelwise offset from the left of the canvas for the new layer.
         :param compression: Compression algorithm to use for the data.
 
         :return: A :py:class:`~psd_tools.api.layers.PixelLayer` object
-        :raises TypeError: If image is not a PIL Image or parent is None
+        :raises TypeError: If image is not a PIL Image
+        :raises ValueError: If parent is None
+
+        .. note::
+            If the image has an alpha channel and the parent PSD mode supports
+            layer transparency (e.g. RGBA, LA), the alpha is stored as the
+            layer transparency channel and no extra mask is created.  For PSD
+            modes that do not carry a transparency band (e.g. RGB, CMYK), the
+            alpha channel is instead stored as a pixel mask
+            (``USER_LAYER_MASK``).
         """
         if not isinstance(image, Image.Image):
             raise TypeError(f"Expected PIL Image, got {type(image).__name__}")
@@ -1719,8 +1728,11 @@ class PixelLayer(Layer):
         self = cls(parent, layer_record, channel_data_list)
         parent.append(self)
 
-        # Automatically create a mask from the alpha channel if present.
-        if "A" in original_image.getbands():
+        # Only create a mask if alpha was present in the original image but is
+        # NOT preserved in the converted image (e.g. RGB-mode PSD with RGBA
+        # input). For alpha-capable PSD modes (RGBA, LA) the alpha is already
+        # stored as the transparency channel, so no extra mask is needed.
+        if "A" in original_image.getbands() and "A" not in image.getbands():
             self.create_mask(
                 original_image, top=top, left=left, compression=compression
             )

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -496,6 +496,33 @@ def test_frompil_auto_mask_from_rgba() -> None:
     assert mask_pil.getpixel((0, 0)) == 200
 
 
+def test_frompil_rgba_psd_no_mask() -> None:
+    # Issue #607: RGBA-mode PSD should store alpha as transparency channel,
+    # not as an extra USER_LAYER_MASK.
+    psdimage = PSDImage.new(mode="RGBA", size=(4, 4))
+    img = Image.new("RGBA", (4, 4), (255, 0, 0, 128))
+    layer = psdimage.create_pixel_layer(img, name="draw")
+    assert not layer.has_mask()
+    # Alpha must be preserved in the layer's transparency channel.
+    layer_pil = layer.topil()
+    assert layer_pil is not None
+    assert layer_pil.mode == "RGBA"
+    assert layer_pil.getchannel("A").getpixel((0, 0)) == 128
+
+
+def test_frompil_la_psd_no_mask() -> None:
+    # Same check for LA-mode PSD.
+    psdimage = PSDImage.new(mode="LA", size=(4, 4))
+    img = Image.new("LA", (4, 4), (200, 128))
+    layer = psdimage.create_pixel_layer(img, name="draw")
+    assert not layer.has_mask()
+    # Alpha must be preserved in the layer's transparency channel.
+    layer_pil = layer.topil()
+    assert layer_pil is not None
+    assert layer_pil.mode == "LA"
+    assert layer_pil.getchannel("A").getpixel((0, 0)) == 128
+
+
 def test_create_mask_round_trip(tmp_path: Any) -> None:
     psdimage = PSDImage.new(mode="RGB", size=(30, 30))
     layer = psdimage.create_pixel_layer(Image.new("RGB", (30, 30)))


### PR DESCRIPTION
## Summary

- `PixelLayer.frompil()` was unconditionally creating a `USER_LAYER_MASK` from the alpha channel whenever the input image had an alpha band
- For alpha-capable PSD modes (RGBA, LA), the alpha is already stored as the `TRANSPARENCY_MASK` channel by `_build_layer_record_and_channels()` — the extra mask was redundant
- A fully-transparent RGBA layer (e.g. a blank draw layer) ended up with an all-zeros mask, making it impossible to paint on without first deleting the mask
- Fix: gate `create_mask()` on `"A" not in image.getbands()` (the post-conversion image), so a mask is only created when the alpha channel cannot be expressed as layer transparency (e.g. RGB-mode PSD receiving an RGBA image)

Fixes #607

## Test plan

- [x] `test_frompil_rgba_psd_no_mask` — RGBA PSD + RGBA image: no mask, alpha preserved in transparency channel
- [x] `test_frompil_la_psd_no_mask` — LA PSD + LA image: same
- [x] `test_frompil_auto_mask_from_rgba` — RGB PSD + RGBA image: mask still created (existing test, unchanged)
- [x] Full test suite: `uv run pytest --no-cov`

🤖 Generated with [Claude Code](https://claude.com/claude-code)