### PR TITLE
fix: compute VectorMask.bbox from full Bezier curve extent

### DIFF
--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -132,11 +132,6 @@ class VectorMask(object):
         :return: `tuple`
         """
         import math
-        from itertools import chain
-
-        all_knots = list(chain.from_iterable(self.paths))
-        if len(all_knots) == 0:
-            return (0.0, 0.0, 1.0, 1.0)
 
         def _bezier_extrema(p0: float, p1: float, p2: float, p3: float) -> list[float]:
             """Return t values in (0, 1) where the cubic Bezier has extrema."""

--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -126,17 +126,77 @@ class VectorMask(object):
         Bounding box tuple (left, top, right, bottom) in relative coordinates,
         where top-left corner is (0., 0.) and bottom-right corner is (1., 1.).
 
+        The bounding box accounts for the full extent of all cubic Bezier
+        curves, not just the anchor points.
+
         :return: `tuple`
         """
+        import math
         from itertools import chain
 
-        knots = [
-            (knot.anchor[1], knot.anchor[0]) for knot in chain.from_iterable(self.paths)
-        ]
-        if len(knots) == 0:
+        all_knots = list(chain.from_iterable(self.paths))
+        if len(all_knots) == 0:
             return (0.0, 0.0, 1.0, 1.0)
-        x, y = zip(*knots)
-        return (min(x), min(y), max(x), max(y))
+
+        def _bezier_extrema(p0: float, p1: float, p2: float, p3: float) -> list[float]:
+            """Return t values in (0, 1) where the cubic Bezier has extrema."""
+            a = -p0 + 3 * p1 - 3 * p2 + p3
+            b = 2 * (p0 - 2 * p1 + p2)
+            c = p1 - p0
+            ts = []
+            if abs(a) < 1e-12:
+                if abs(b) > 1e-12:
+                    t = -c / b
+                    if 0.0 < t < 1.0:
+                        ts.append(t)
+            else:
+                disc = b * b - 4 * a * c
+                if disc >= -1e-12:
+                    sq = math.sqrt(max(0.0, disc))
+                    for t in ((-b + sq) / (2 * a), (-b - sq) / (2 * a)):
+                        if 0.0 < t < 1.0:
+                            ts.append(t)
+            return ts
+
+        def _bezier_eval(p0: float, p1: float, p2: float, p3: float, t: float) -> float:
+            u = 1.0 - t
+            return u**3 * p0 + 3 * u**2 * t * p1 + 3 * u * t**2 * p2 + t**3 * p3
+
+        xs: list[float] = []
+        ys: list[float] = []
+
+        for path in self.paths:
+            knots = list(path)
+            if len(knots) == 0:
+                continue
+            # For a single-knot open path there are no segments, but we still
+            # need to include the anchor point in the bounding box.
+            if len(knots) == 1 and not path.is_closed():
+                xs.append(knots[0].anchor[1])
+                ys.append(knots[0].anchor[0])
+                continue
+            pairs = (
+                zip(knots, knots[1:] + knots[:1])
+                if path.is_closed()
+                else zip(knots, knots[1:])
+            )
+            for k0, k1 in pairs:
+                # anchor = (y, x); leaving/preceding = (y, x)
+                x0, y0 = k0.anchor[1], k0.anchor[0]
+                x1, y1 = k0.leaving[1], k0.leaving[0]
+                x2, y2 = k1.preceding[1], k1.preceding[0]
+                x3, y3 = k1.anchor[1], k1.anchor[0]
+
+                xs.extend([x0, x3])
+                ys.extend([y0, y3])
+                for t in _bezier_extrema(x0, x1, x2, x3):
+                    xs.append(_bezier_eval(x0, x1, x2, x3, t))
+                for t in _bezier_extrema(y0, y1, y2, y3):
+                    ys.append(_bezier_eval(y0, y1, y2, y3, t))
+
+        if not xs:
+            return (0.0, 0.0, 1.0, 1.0)
+        return (min(xs), min(ys), max(xs), max(ys))
 
     def __repr__(self) -> str:
         bbox = self.bbox

--- a/tests/psd_tools/api/test_shape.py
+++ b/tests/psd_tools/api/test_shape.py
@@ -12,7 +12,13 @@ from psd_tools.api.shape import (
     RoundedRectangle,
     VectorMask,
 )
-from psd_tools.psd.vector import ClosedKnotLinked, ClosedPath, OpenKnotLinked, OpenPath
+from psd_tools.psd.vector import (
+    ClosedKnotLinked,
+    ClosedPath,
+    OpenKnotLinked,
+    OpenPath,
+    VectorMaskSetting,
+)
 
 from ..utils import full_name
 
@@ -24,18 +30,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-class _FakeVMData:
-    """Minimal stand-in for VectorMaskSetting used in bbox unit tests."""
-
-    path: list = []
-    invert = False
-    not_link = False
-    disable = False
-
-
 def _make_vm(*paths):
     """Return a VectorMask whose _paths list is set directly."""
-    vm = VectorMask(_FakeVMData())
+    vm = VectorMask(VectorMaskSetting())
     vm._paths = list(paths)
     return vm
 

--- a/tests/psd_tools/api/test_shape.py
+++ b/tests/psd_tools/api/test_shape.py
@@ -4,11 +4,51 @@ from typing import Iterator, Type
 import pytest
 
 from psd_tools.api.psd_image import PSDImage
-from psd_tools.api.shape import Ellipse, Invalidated, Line, Rectangle, RoundedRectangle
+from psd_tools.api.shape import (
+    Ellipse,
+    Invalidated,
+    Line,
+    Rectangle,
+    RoundedRectangle,
+    VectorMask,
+)
+from psd_tools.psd.vector import ClosedKnotLinked, ClosedPath, OpenKnotLinked, OpenPath
 
 from ..utils import full_name
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for VectorMask.bbox unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeVMData:
+    """Minimal stand-in for VectorMaskSetting used in bbox unit tests."""
+
+    path: list = []
+    invert = False
+    not_link = False
+    disable = False
+
+
+def _make_vm(*paths):
+    """Return a VectorMask whose _paths list is set directly."""
+    vm = VectorMask(_FakeVMData())
+    vm._paths = list(paths)
+    return vm
+
+
+def _ck(y: float, x: float) -> ClosedKnotLinked:
+    """Closed knot with all handles at the anchor (corner knot)."""
+    return ClosedKnotLinked(preceding=(y, x), anchor=(y, x), leaving=(y, x))
+
+
+def _ok(y: float, x: float) -> OpenKnotLinked:
+    """Open knot with all handles at the anchor (corner knot)."""
+    return OpenKnotLinked(preceding=(y, x), anchor=(y, x), leaving=(y, x))
+
 
 VECTOR_MASK2 = PSDImage.open(full_name("vector-mask2.psd"))
 
@@ -92,3 +132,89 @@ def test_origination(
         assert origination.arrow_width == 0.0
         assert origination.arrow_length == 0.0
         assert origination.arrow_conc == 0
+
+
+# ---------------------------------------------------------------------------
+# VectorMask.bbox unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_empty_paths():
+    """No paths → full-canvas fallback."""
+    assert _make_vm().bbox == (0.0, 0.0, 1.0, 1.0)
+
+
+def test_bbox_single_knot_open_path():
+    """Single-knot open path has no segments; anchor point must still be included."""
+    k = _ok(0.3, 0.5)
+    vm = _make_vm(OpenPath(items=[k]))
+    assert vm.bbox == pytest.approx((0.5, 0.3, 0.5, 0.3))
+
+
+def test_bbox_interior_extremum():
+    """Bezier curve can extend beyond the convex hull of its anchor points."""
+    # k0 has a leaving handle that pulls the curve above (smaller y than) its anchor.
+    # Anchor y values: 0.3 and 0.7.  The curve dips to y ≈ 0.259 between them.
+    k0 = ClosedKnotLinked(preceding=(0.3, 0.2), anchor=(0.3, 0.2), leaving=(0.1, 0.2))
+    k1 = ClosedKnotLinked(preceding=(0.7, 0.8), anchor=(0.7, 0.8), leaving=(0.7, 0.8))
+    vm = _make_vm(ClosedPath(items=[k0, k1]))
+    left, top, right, bottom = vm.bbox
+    # The curve dips above the topmost anchor (smaller y = higher on canvas).
+    assert top < 0.3
+    assert bottom == pytest.approx(0.7)
+
+
+def test_bbox_a_zero_linear_fallback():
+    """When the cubic coefficient a==0 the derivative is quadratic → linear fallback."""
+    # Segment: P0_y=0, C1_y=C2_y=0.3, P3_y=0  →  a=0, t_ext=0.5, B(0.5)=0.225
+    k0 = ClosedKnotLinked(preceding=(0.0, 0.0), anchor=(0.0, 0.0), leaving=(0.3, 0.5))
+    k1 = ClosedKnotLinked(preceding=(0.3, 0.5), anchor=(0.0, 1.0), leaving=(0.0, 1.0))
+    vm = _make_vm(ClosedPath(items=[k0, k1]))
+    left, top, right, bottom = vm.bbox
+    assert top == pytest.approx(0.0)
+    assert bottom == pytest.approx(0.225)
+    assert left == pytest.approx(0.0)
+    assert right == pytest.approx(1.0)
+
+
+def test_bbox_repeated_root():
+    """Discriminant == 0 (tangent extremum) is handled without error."""
+    # Constructed so that disc = b²-4ac = 0 with the repeated root at t=0.5.
+    # P0_y=0.1, C1_y=0.6, C2_y=0.1, P3_y=0.6  →  a=2, b=-2, c=0.5, disc=0
+    k0 = ClosedKnotLinked(preceding=(0.1, 0.2), anchor=(0.1, 0.2), leaving=(0.6, 0.2))
+    k1 = ClosedKnotLinked(preceding=(0.1, 0.8), anchor=(0.6, 0.8), leaving=(0.6, 0.8))
+    vm = _make_vm(ClosedPath(items=[k0, k1]))
+    left, top, right, bottom = vm.bbox
+    # Interior extremum at t=0.5: B(0.5)=0.35 (within anchor range, no extension)
+    assert top == pytest.approx(0.1)
+    assert bottom == pytest.approx(0.6)
+
+
+def test_bbox_multi_subpath_union():
+    """Bounding box spans all subpaths."""
+    path1 = ClosedPath(items=[_ck(0.1, 0.1), _ck(0.2, 0.2)])
+    path2 = ClosedPath(items=[_ck(0.7, 0.6), _ck(0.8, 0.9)])
+    vm = _make_vm(path1, path2)
+    left, top, right, bottom = vm.bbox
+    assert left == pytest.approx(0.1)
+    assert top == pytest.approx(0.1)
+    assert right == pytest.approx(0.9)
+    assert bottom == pytest.approx(0.8)
+
+
+def test_bbox_single_knot_closed_path_degenerate():
+    """Single-knot closed path with coincident handles collapses to a point.
+
+    A closed path with one knot forms a self-loop cubic (k→k) whose extent is
+    determined by its leaving/preceding handles.  When all handles coincide with
+    the anchor the loop degenerates and the bbox is just the anchor point.
+    This documents current behaviour for an edge case not yet observed in real
+    PSD files.
+    """
+    k = _ck(0.4, 0.3)
+    vm = _make_vm(ClosedPath(items=[k]))
+    left, top, right, bottom = vm.bbox
+    assert left == pytest.approx(0.3)
+    assert top == pytest.approx(0.4)
+    assert right == pytest.approx(0.3)
+    assert bottom == pytest.approx(0.4)


### PR DESCRIPTION
## Summary

- **Root cause of #612**: `VectorMask.bbox` computed the bounding box from anchor points only, ignoring control points (preceding/leaving handles). Cubic Bezier curves can extend well beyond their anchor points when control points lie outside the anchor convex hull.
- **Effect**: `ShapeLayer.bbox` used the too-small vector-mask bbox as the compositing viewport, clipping the rendered shape on individual `layer.composite()`, `psd.composite(force=True)`, and `psd.composite(layer_filter=...)` calls.
- **Fix**: Replace the anchor-only min/max with proper cubic Bezier bounding box computation — solve `B'(t) = 0` per segment (quadratic formula, with linear fallback when `a ≈ 0`) and evaluate the curve at each interior extremum in `(0, 1)`.

Edge cases addressed:
- `a ≈ 0` → linear fallback (`t = -c/b`) with `|b| > ε` guard
- `disc ≈ 0` → clamp with `max(0, disc)` before `sqrt` to tolerate floating-point noise at a repeated root
- Single-knot open path → no segments; anchor contributed directly to avoid full-canvas fallback

## Test plan

- [ ] `test_bbox_empty_paths` — no paths returns `(0, 0, 1, 1)` fallback
- [ ] `test_bbox_single_knot_open_path` — single-knot open path anchor is included
- [ ] `test_bbox_interior_extremum` — bbox extends beyond anchor convex hull (core fix)
- [ ] `test_bbox_a_zero_linear_fallback` — `a == 0` quadratic derivative path
- [ ] `test_bbox_repeated_root` — `disc == 0` handled without error
- [ ] `test_bbox_multi_subpath_union` — bbox spans all subpaths
- [ ] `test_bbox_single_knot_closed_path_degenerate` — documents self-loop behaviour for unseen edge case
- [ ] Full test suite (1109 tests) passes

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)