### PR TITLE
feat: add stale issue/PR workflow and improve issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Support
+    url: https://github.com/psd-tools/psd-tools/discussions
+    about: Ask usage questions and get help from the community in Discussions.
+  - name: Documentation
+    url: https://psd-tools.readthedocs.io
+    about: Check the official documentation before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -75,4 +75,4 @@ jobs:
           # Log statistics for each run
           enable-statistics: true
 
-          debug-only: false
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,7 +32,7 @@ jobs:
 
           # ── Exemptions ────────────────────────────────────────────────────
           exempt-issue-labels: 'bug,enhancement,pinned,security'
-          exempt-pr-labels: 'pinned,security'
+          exempt-pr-labels: 'pinned,security,awaiting-review'
           exempt-draft-pr: true
 
           # ── Messages ──────────────────────────────────────────────────────

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,78 @@
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    # Run at 02:00 UTC every Monday
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Stale issues and pull requests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # ── Timing ────────────────────────────────────────────────────────
+          days-before-issue-stale: 120
+          days-before-issue-close: 21
+          days-before-pr-stale: 45
+          days-before-pr-close: 21
+
+          # ── Labels ────────────────────────────────────────────────────────
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          close-issue-label: 'auto-closed'
+          close-issue-reason: 'not_planned'
+
+          # ── Exemptions ────────────────────────────────────────────────────
+          exempt-issue-labels: 'bug,enhancement,pinned,security'
+          exempt-pr-labels: 'pinned,security'
+          exempt-draft-pr: true
+
+          # ── Messages ──────────────────────────────────────────────────────
+          stale-issue-message: |
+            This issue has been marked as stale because it has had no activity for 120 days.
+
+            If this is still relevant, please comment with updated details — ideally:
+            - psd-tools version
+            - Python version
+            - a minimal reproducible script
+            - a sample PSD/PSB file or screenshot, if applicable
+
+            Issues that remain inactive for 21 more days will be closed to keep triage manageable.
+
+          stale-pr-message: |
+            This pull request has been marked as stale due to inactivity for 45 days.
+
+            If you plan to continue it, please leave a comment or push an update. If it is waiting on maintainer review, add or request an `awaiting-review` label so it is not auto-closed.
+
+          close-issue-message: |
+            Closing due to inactivity after the stale notice.
+
+            If you can reproduce this on a current release and have updated repro details, feel free to open a new issue and link this one.
+
+          close-pr-message: |
+            Closing this pull request due to inactivity after the stale notice.
+
+            If you would like to continue this work, please open a new PR from a freshly rebased branch and reference this one. Thank you for contributing to psd-tools!
+
+          # ── Operational limits ────────────────────────────────────────────
+          # Limits per run — avoids burst notifications on first run
+          operations-per-run: 50
+
+          # Remove stale label when issue/PR receives new activity
+          remove-stale-when-updated: true
+
+          # Do not mark bot issues/PRs as stale
+          exempt-all-bots: true
+
+          # Log statistics for each run
+          enable-statistics: true
+
+          debug-only: false


### PR DESCRIPTION
## Summary

- Add `.github/workflows/stale.yml` using `actions/stale@v9` to automatically warn and close inactive issues and PRs
- Fix issue templates to auto-apply `bug`/`enhancement` labels so stale exemptions work without manual triage
- Add `ISSUE_TEMPLATE/config.yml` to disable blank issues and redirect support questions to Discussions

## Stale workflow details

| Setting | Issues | PRs |
|---|---|---|
| Days before stale warning | 120 | 45 |
| Days before close (after warning) | 21 | 21 |
| Close label | `auto-closed` | — |
| Close reason | `not_planned` | — |
| Exempt labels | `bug`, `enhancement`, `pinned`, `security` | `pinned`, `security` |
| Draft PRs exempt | — | yes |

Additional options: `remove-stale-when-updated: true`, `exempt-all-bots: true`, `enable-statistics: true`, `operations-per-run: 50` (to avoid notification burst on first run), weekly schedule.

## Test plan

- [ ] Enable `debug-only: true` temporarily and trigger via `workflow_dispatch` to preview affected issues/PRs without touching them
- [ ] Verify new bug reports filed via the template automatically get the `bug` label
- [ ] Verify new feature requests automatically get the `enhancement` label
- [ ] Verify the "New Issue" page shows the Discussions link instead of a blank issue option
- [ ] After confirming dry run looks correct, merge and monitor first live weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)