### PR TITLE
fix: enable stale workflow and remove invalid exempt-all-bots option

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -69,10 +69,7 @@ jobs:
           # Remove stale label when issue/PR receives new activity
           remove-stale-when-updated: true
 
-          # Do not mark bot issues/PRs as stale
-          exempt-all-bots: true
-
           # Log statistics for each run
           enable-statistics: true
 
-          debug-only: true
+          debug-only: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # ── Timing ────────────────────────────────────────────────────────
           days-before-issue-stale: 120


### PR DESCRIPTION
## Summary

Follow-up to #615 based on findings from the dry run.

- Remove `exempt-all-bots: true` — not a valid input for `actions/stale@v9`; produced a warning in the dry-run logs and was silently ignored
- Set `debug-only: false` to activate live stale processing

## Dry run results (from #615)

| Metric | Count |
|---|---|
| Issues fetched | 80 |
| Issues processed (hit ops limit) | 15 |
| Would be marked stale | 13 |

The full backlog will drain over ~6 weekly runs given `operations-per-run: 50`.

## Related

- Node.js 20 deprecation warning tracked separately in #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)