### PR TITLE
fix: add layer_sized option to Mask.topil() for inverted masks

### DIFF
--- a/src/psd_tools/api/mask.py
+++ b/src/psd_tools/api/mask.py
@@ -64,7 +64,8 @@ class Mask(MaskProtocol):
     def background_color(self) -> int:
         """Background color."""
         if self.has_real():
-            return self._data.real_background_color or self._data.background_color
+            real_bg = self._data.real_background_color
+            return real_bg if real_bg is not None else self._data.background_color
         return self._data.background_color
 
     @property
@@ -76,28 +77,44 @@ class Mask(MaskProtocol):
     def left(self) -> int:
         """Left coordinate."""
         if self.has_real():
-            return self._data.real_left or self._data.left
+            return (
+                self._data.real_left
+                if self._data.real_left is not None
+                else self._data.left
+            )
         return self._data.left
 
     @property
     def right(self) -> int:
         """Right coordinate."""
         if self.has_real():
-            return self._data.real_right or self._data.right
+            return (
+                self._data.real_right
+                if self._data.real_right is not None
+                else self._data.right
+            )
         return self._data.right
 
     @property
     def top(self) -> int:
         """Top coordinate."""
         if self.has_real():
-            return self._data.real_top or self._data.top
+            return (
+                self._data.real_top
+                if self._data.real_top is not None
+                else self._data.top
+            )
         return self._data.top
 
     @property
     def bottom(self) -> int:
         """Bottom coordinate."""
         if self.has_real():
-            return self._data.real_bottom or self._data.bottom
+            return (
+                self._data.real_bottom
+                if self._data.real_bottom is not None
+                else self._data.bottom
+            )
         return self._data.bottom
 
     @property
@@ -149,18 +166,39 @@ class Mask(MaskProtocol):
         """Return True if the mask has real flags."""
         return self.real_flags is not None and self.real_flags.parameters_applied
 
-    def topil(self, real: bool = True, **kwargs: Any) -> Image.Image | None:
+    def topil(
+        self, real: bool = True, layer_sized: bool = False, **kwargs: Any
+    ) -> Image.Image | None:
         """
         Get PIL Image of the mask.
 
         :param real: When True, returns pixel + vector mask combined.
+        :param layer_sized: When True, returns a layer-sized image pre-filled with
+            ``background_color``, with the mask data pasted at the correct position.
+            When False (default), returns the raw stored mask data at mask dimensions.
         :return: PIL Image object, or None if the mask is empty.
         """
         if real and self.has_real():
             channel = ChannelID.REAL_USER_LAYER_MASK
+            offset_left = (self._data.real_left or 0) - self._layer.left
+            offset_top = (self._data.real_top or 0) - self._layer.top
+            real_bg = self._data.real_background_color
+            bg = real_bg if real_bg is not None else self._data.background_color
         else:
             channel = ChannelID.USER_LAYER_MASK
-        return self._layer.topil(channel, **kwargs)
+            offset_left = self._data.left - self._layer.left
+            offset_top = self._data.top - self._layer.top
+            bg = self._data.background_color
+
+        raw = self._layer.topil(channel, **kwargs)
+        if raw is None or not layer_sized:
+            return raw
+
+        # Compose a full layer-sized mask applying background_color outside stored bbox.
+        # Out-of-bounds mask data is clipped naturally by Image.paste.
+        full = Image.new(raw.mode, self._layer.size, bg)
+        full.paste(raw, (offset_left, offset_top))
+        return full
 
     def __repr__(self) -> str:
         return "%s(offset=(%d,%d) size=%dx%d)" % (

--- a/tests/psd_tools/api/test_mask.py
+++ b/tests/psd_tools/api/test_mask.py
@@ -4,6 +4,7 @@ import pytest
 from PIL import Image
 
 from psd_tools.api.psd_image import PSDImage
+from psd_tools.psd.layer_and_mask import MaskData
 
 from ..utils import full_name
 
@@ -30,6 +31,39 @@ def test_layer_mask(layer_mask_data: PSDImage, real: bool) -> None:
     mask.real_flags
     repr(mask)
     assert mask.topil()
+
+
+def test_mask_topil_layer_sized_background_color() -> None:
+    """Regression test for issue #389: layer_sized=True must apply background_color."""
+    psdimage = PSDImage.new(mode="RGB", size=(100, 100))
+    layer = psdimage.create_pixel_layer(Image.new("RGB", (100, 100)))
+    # Create a 40x30 black mask patch
+    layer.create_mask(Image.new("L", (40, 30), 0))
+
+    # Simulate inverted mask: bbox at (10, 20)–(50, 50), background=255
+    mask_data = layer._record.mask_data
+    assert isinstance(mask_data, MaskData)
+    mask_data.top = 20
+    mask_data.left = 10
+    mask_data.bottom = 50
+    mask_data.right = 50
+    mask_data.background_color = 255
+
+    mask = layer.mask
+    assert mask is not None
+
+    # Raw topil() still returns bbox-sized image (backward compat)
+    raw = mask.topil(layer_sized=False)
+    assert raw is not None
+    assert raw.size == (40, 30)
+
+    # layer_sized=True returns full layer image with background fill
+    img = mask.topil(layer_sized=True)
+    assert img is not None
+    assert img.size == layer.size  # (100, 100)
+    assert img.getpixel((0, 0)) == 255  # outside bbox → background_color
+    assert img.getpixel((99, 99)) == 255  # outside bbox → background_color
+    assert img.getpixel((10, 20)) == 0  # top-left of pasted mask data
 
 
 def test_mask_disabled_setter() -> None:


### PR DESCRIPTION
## Summary

Fixes #389.

When a layer mask has `background_color=255` (inverted), Photoshop stores only the non-white pixels within a small bbox — everything outside implicitly takes the background color. `Mask.topil()` was returning only that raw region, making it impossible to correctly reconstruct the full mask without manual bookkeeping.

- Add `layer_sized=False` parameter to `Mask.topil()`. When `True`, returns a layer-sized image pre-filled with `background_color`, with the stored mask data pasted at the correct document-relative offset. Default `False` preserves all existing behavior.
- Fix a pre-existing falsy-zero bug in `Mask.background_color`, `.left`, `.right`, `.top`, `.bottom`: `real_* or non_real_*` would silently fall back when a real coordinate was `0`. Changed all to explicit `is not None` checks.

**Usage (after fix):**
```python
psd = PSDImage.open('canvas_01.psd')
for layer in psd:
    if layer.has_mask():
        # layer_sized=True gives a full layer-sized mask with correct background fill
        mask_img = layer.mask.topil(layer_sized=True)
        mask_img.save(layer.name + ".png")
```

## Test plan

- [x] New test `test_mask_topil_layer_sized_background_color` verifies `layer_sized=True` returns a layer-sized image filled with `background_color`, and `layer_sized=False` (default) still returns the bbox-sized raw image
- [x] All existing mask tests pass unchanged
- [x] Full test suite passes (1124 passed)
- [x] Manually verified against `canvas_01.psd` fixture from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)