### PR TITLE
docs: fix misleading ImageResource signature docstring

### DIFF
--- a/src/psd_tools/psd/image_resources.py
+++ b/src/psd_tools/psd/image_resources.py
@@ -235,7 +235,10 @@ class ImageResource(BaseElement):
 
     .. py:attribute:: signature
 
-        Binary signature, always ``b'8BIM'``.
+        Binary signature. Usually ``b'8BIM'``, but some resources use
+        alternative signatures such as ``b'MeSa'`` (e.g.,
+        :py:attr:`~psd_tools.constants.Resource.IMAGE_READY_VARIABLES`),
+        ``b'AgHg'``, ``b'PHUT'``, or ``b'DCSR'``.
 
     .. py:attribute:: key
 


### PR DESCRIPTION
## Summary

- Fixes #375
- The `ImageResource.signature` docstring said the signature is "always `b'8BIM'`", which is incorrect — the `attrs` validator already accepts `b'MeSa'`, `b'AgHg'`, `b'PHUT'`, and `b'DCSR'` as valid alternatives
- `IMAGE_READY_VARIABLES` in particular requires `b'MeSa'`, which confused the issue reporter

## Test plan

- No behaviour change; this is a docstring-only fix
- `uv run pytest --no-cov` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)