### PR TITLE
feat: enable PLC0415 and expand ruff lint scope to tests/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,10 @@ markers = [
 ]
 
 [tool.ruff]
-src = ["src"]
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+extend-select = ["PLC0415"]
 
 [tool.mypy]
 files = ["src/psd_tools", "tests"]

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -105,7 +105,7 @@ import numpy as np
 from PIL import Image, ImageChops
 
 import psd_tools.psd.engine_data as engine_data
-from psd_tools.api import pil_io
+from psd_tools.api import numpy_io, pil_io
 from psd_tools.api.effects import Effects
 from psd_tools.api.mask import Mask
 from psd_tools.api.protocols import GroupMixinProtocol, LayerProtocol, PSDProtocol
@@ -725,9 +725,7 @@ class Layer(LayerProtocol):
             :py:class:`PIL.Image.Image`. For example, 'CMYK' mode cannot include
             alpha channel in PIL. In this case, topil drops alpha channel.
         """
-        from .pil_io import convert_layer_to_pil
-
-        return convert_layer_to_pil(self, channel, apply_icc)
+        return pil_io.convert_layer_to_pil(self, channel, apply_icc)
 
     def numpy(
         self, channel: str | None = None, real_mask: bool = True
@@ -739,8 +737,6 @@ class Layer(LayerProtocol):
             'shape', 'alpha', or 'mask'. Default is 'color+alpha'.
         :return: :py:class:`numpy.ndarray` or None if there is no pixel.
         """
-        from . import numpy_io
-
         return numpy_io.get_array(self, channel, real_mask=real_mask)
 
     def composite(
@@ -767,7 +763,7 @@ class Layer(LayerProtocol):
             :py:func:`~psd_tools.api.layers.PixelLayer.is_visible`.
         :return: :py:class:`PIL.Image.Image` or `None`.
         """
-        from psd_tools.composite import composite_pil
+        from psd_tools.composite import composite_pil  # noqa: PLC0415
 
         if self._psd is not None and self._psd.is_updated():
             force = True
@@ -1438,7 +1434,7 @@ class Group(GroupMixin, Layer):
             :py:func:`~psd_tools.api.layers.PixelLayer.is_visible`.
         :return: :py:class:`PIL.Image.Image`.
         """
-        from psd_tools.composite import composite_pil
+        from psd_tools.composite import composite_pil  # noqa: PLC0415
 
         return composite_pil(
             self,
@@ -2113,7 +2109,7 @@ class TypeLayer(Layer):
         See also: :py:attr:`engine_dict`, :py:attr:`resource_dict` for raw data.
         """
         if not hasattr(self, "_typesetting"):
-            from psd_tools.api.typesetting import TypeSetting
+            from psd_tools.api.typesetting import TypeSetting  # noqa: PLC0415
 
             self._typesetting = TypeSetting(
                 self.text,

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -21,8 +21,8 @@ def get_array(
     layer: "LayerProtocol | PSDProtocol", channel: str | None, **kwargs: Any
 ) -> np.ndarray | None:
     # Import at runtime to avoid circular imports
-    from psd_tools.api.layers import Layer
-    from psd_tools.api.psd_image import PSDImage
+    from psd_tools.api.layers import Layer  # noqa: PLC0415
+    from psd_tools.api.psd_image import PSDImage  # noqa: PLC0415
 
     if isinstance(layer, PSDImage):
         return get_image_data(layer, channel)

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -6,7 +6,7 @@ import io
 import logging
 from typing import TYPE_CHECKING, cast
 
-from PIL import Image, ImageChops, ImageCms, ImageMath
+from PIL import Image, ImageChops, ImageMath
 
 from psd_tools.api.utils import get_transparency_index, has_transparency
 from psd_tools.constants import ChannelID, ColorMode, Resource
@@ -303,6 +303,12 @@ def _check_channels(
 
 def _apply_icc(image: Image.Image, icc_profile: bytes) -> Image.Image:
     """Apply ICC Color profile."""
+    try:
+        from PIL import ImageCms  # noqa: PLC0415
+    except ImportError:
+        logger.warning("ICC profile found but not supported. Install little-cms.")
+        return image
+
     try:
         with io.BytesIO(icc_profile) as f:
             in_profile = ImageCms.ImageCmsProfile(f)

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -6,7 +6,7 @@ import io
 import logging
 from typing import TYPE_CHECKING, cast
 
-from PIL import Image
+from PIL import Image, ImageChops, ImageCms, ImageMath
 
 from psd_tools.api.utils import get_transparency_index, has_transparency
 from psd_tools.constants import ChannelID, ColorMode, Resource
@@ -164,8 +164,6 @@ def post_process(
 ) -> Image.Image:
     # Fix inverted CMYK.
     if image.mode == "CMYK":
-        from PIL import ImageChops
-
         image = ImageChops.invert(image)
 
     if icc_profile:
@@ -306,12 +304,6 @@ def _check_channels(
 def _apply_icc(image: Image.Image, icc_profile: bytes) -> Image.Image:
     """Apply ICC Color profile."""
     try:
-        from PIL import ImageCms
-    except ImportError:
-        logger.warning("ICC profile found but not supported. Install little-cms.")
-        return image
-
-    try:
         with io.BytesIO(icc_profile) as f:
             in_profile = ImageCms.ImageCmsProfile(f)
         out_profile = ImageCms.createProfile("sRGB")
@@ -332,8 +324,6 @@ def _apply_icc(image: Image.Image, icc_profile: bytes) -> Image.Image:
 
 def _remove_white_background(image: Image.Image) -> Image.Image:
     """Remove white background in the preview image."""
-    from PIL import ImageMath
-
     if image.mode == "RGBA":
         bands = image.split()
         a = bands[3]

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -324,7 +324,7 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
             :py:func:`~psd_tools.api.layers.PixelLayer.is_visible`.
         :return: :py:class:`PIL.Image`.
         """
-        from psd_tools.composite import composite_pil
+        from psd_tools.composite import composite_pil  # noqa: PLC0415
 
         if (
             not (ignore_preview or force or layer_filter)
@@ -812,8 +812,6 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
 
     def _init(self) -> None:
         """Initialize layer structure."""
-        from psd_tools.api import layers
-
         group_stack: list[layers.Group | PSDImage] = [self]
 
         for record, channels in self._record._iter_layers():

--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -8,6 +8,7 @@ stylized.
 """
 
 import logging
+import math
 from typing import Any, Literal
 
 from psd_tools.psd.descriptor import Descriptor, DescriptorBlock2
@@ -131,7 +132,6 @@ class VectorMask(object):
 
         :return: `tuple`
         """
-        import math
 
         def _bezier_extrema(p0: float, p1: float, p2: float, p3: float) -> list[float]:
             """Return t values in (0, 1) where the cubic Bezier has extrema."""

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -68,8 +68,8 @@ def draw_stroke_effect(
     viewport: tuple[int, int, int, int], shape: np.ndarray, desc: Descriptor, psd
 ) -> tuple[np.ndarray, np.ndarray]:
     # Import here after checking dependencies
-    from skimage import filters
-    from skimage.morphology import disk
+    from skimage import filters  # noqa: PLC0415
+    from skimage.morphology import disk  # noqa: PLC0415
 
     logger.debug("Stroke effect has limited support")
     height, width = viewport[3] - viewport[1], viewport[2] - viewport[0]

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -225,7 +225,7 @@ def draw_pattern_fill(
 
     .. todo:: Test this.
     """
-    from skimage.transform import resize
+    from skimage.transform import resize  # noqa: PLC0415
 
     pattern_id = desc[Enum.Pattern][Key.ID].value.rstrip("\x00")
     pattern = psd._get_pattern(pattern_id)
@@ -350,7 +350,7 @@ def _make_gradient_color(color_mode, grad):
 
 
 def _make_linear_gradient_color(color_mode, grad):
-    from scipy import interpolate  # type: ignore[import-untyped]
+    from scipy import interpolate  # type: ignore[import-untyped]  # noqa: PLC0415
 
     X, Y = [], []
     for stop in grad.get(Key.Colors, []):
@@ -406,8 +406,8 @@ def _make_noise_gradient_color(grad):
             'Mxm ': [0, 100, 100, 100]
         }
     """
-    from scipy import interpolate  # type: ignore[import-untyped]
-    from scipy.ndimage import maximum_filter1d, uniform_filter1d  # type: ignore[import-untyped]
+    from scipy import interpolate  # type: ignore[import-untyped]  # noqa: PLC0415
+    from scipy.ndimage import maximum_filter1d, uniform_filter1d  # type: ignore[import-untyped]  # noqa: PLC0415
 
     logger.debug("Noise gradient is not accurate.")
     roughness = grad.get(Key.Smoothness).value / 4096.0  # Larger is sharper.

--- a/src/psd_tools/composite/vector.py
+++ b/src/psd_tools/composite/vector.py
@@ -105,7 +105,7 @@ def _draw_subpath(subpath_list, width, height, brush, pen):
 
     Note: Callers must be decorated with @needs_aggdraw before calling.
     """
-    import aggdraw  # type: ignore[import-not-found]
+    import aggdraw  # type: ignore[import-not-found]  # noqa: PLC0415
 
     mask = Image.new("L", (width, height), 0)
     draw = aggdraw.Draw(mask)

--- a/src/psd_tools/psd/document.py
+++ b/src/psd_tools/psd/document.py
@@ -10,6 +10,7 @@ from typing import Any, BinaryIO, Generator, Optional, TypeVar
 
 from attrs import define, field
 
+from psd_tools.constants import Tag
 from .base import BaseElement
 from .color_mode_data import ColorModeData
 from .header import FileHeader
@@ -110,8 +111,6 @@ class PSD(BaseElement):
                     yield record, channels
 
     def _get_layer_info(self) -> Optional[LayerInfo]:
-        from psd_tools.constants import Tag
-
         tagged_blocks = self.layer_and_mask_information.tagged_blocks
         if tagged_blocks is not None:
             for key in (Tag.LAYER_16, Tag.LAYER_32):

--- a/src/psd_tools/psd/patterns.py
+++ b/src/psd_tools/psd/patterns.py
@@ -241,10 +241,8 @@ class VirtualMemoryArray(BaseElement):
         self, size: tuple[int, int], data: bytes, depth: int, compression: int = 0
     ) -> None:
         """Set bytes."""
-        from psd_tools.constants import Compression as CompressionEnum
-
         self.data = compress(
-            data, CompressionEnum(compression), size[0], size[1], depth, version=1
+            data, Compression(compression), size[0], size[1], depth, version=1
         )
         self.depth = int(depth)
         self.pixel_depth = int(depth)

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -20,6 +20,7 @@ from psd_tools.constants import (
     CompatibilityMode,
     ProtectedFlags,
     SectionDivider,
+    SheetColorType,
     Tag,
 )
 
@@ -651,8 +652,6 @@ def test_layer_reference_point(pixel_layer: PixelLayer) -> None:
 
 
 def test_layer_sheet_color(pixel_layer: PixelLayer) -> None:
-    from psd_tools.constants import SheetColorType
-
     assert pixel_layer.sheet_color == SheetColorType.NO_COLOR
 
     pixel_layer.sheet_color = SheetColorType.RED

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -2,12 +2,14 @@ import logging
 import pprint
 from pathlib import Path
 from typing import Any, Tuple, Union
+from unittest.mock import patch
 
 import pytest
 from PIL import Image
 
 from psd_tools.api.layers import Group
 from psd_tools.api.psd_image import PSDImage
+from psd_tools.api.utils import get_transparency_index, has_transparency
 from psd_tools.constants import BlendMode, ColorMode, Compression
 
 from ..utils import full_name
@@ -226,8 +228,6 @@ def test_is_updated() -> None:
 
 def test_save_without_composite_dependencies(tmp_path: Path, caplog: Any) -> None:
     """Test that save works gracefully without composite dependencies."""
-    from unittest.mock import patch
-
     # Create a simple PSD and modify it
     psdimage = PSDImage.new(mode="RGB", size=(100, 100))
     psdimage.create_pixel_layer(
@@ -553,8 +553,6 @@ def _save_psd_with_negative_layer_count(
 
 def test_has_transparency_negative_layer_count(tmp_path: Path) -> None:
     """has_transparency() returns True when layer_count is negative."""
-    from psd_tools.api.utils import has_transparency
-
     output = _save_psd_with_negative_layer_count(tmp_path)
     loaded = PSDImage.open(output)
     assert has_transparency(loaded) is True
@@ -562,8 +560,6 @@ def test_has_transparency_negative_layer_count(tmp_path: Path) -> None:
 
 def test_has_transparency_positive_layer_count(tmp_path: Path) -> None:
     """has_transparency() returns False for a normal PSD without transparency tags."""
-    from psd_tools.api.utils import has_transparency
-
     psd = PSDImage.new("RGBA", (16, 16))
     psd.create_pixel_layer(Image.new("RGBA", (16, 16), (255, 0, 0, 255)), name="opaque")
     output = tmp_path / "positive_layer_count.psd"
@@ -578,8 +574,6 @@ def test_has_transparency_positive_layer_count(tmp_path: Path) -> None:
 def test_get_transparency_index_negative_layer_count(tmp_path: Path) -> None:
     """get_transparency_index() returns the first alpha channel index
     when layer_count is negative."""
-    from psd_tools.api.utils import get_transparency_index
-
     output = _save_psd_with_negative_layer_count(tmp_path)
     loaded = PSDImage.open(output)
     # RGB has 3 expected channels, so the transparency channel is at index 3

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import numpy as np
 import pytest
 
+from psd_tools.api.layers import GroupMixin
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.composite import composite
 from psd_tools.constants import CompatibilityMode
@@ -218,8 +219,6 @@ def test_composite_viewport() -> None:
 def test_composite_pil(
     colormode: str, depth: int, mode: str, ignore_preview: bool, apply_icc: bool
 ) -> None:
-    from PIL import Image
-
     filename = "colormodes/4x4_%gbit_%s.psd" % (depth, colormode)
     psd = PSDImage.open(full_name(filename))
     image = psd.composite(ignore_preview=ignore_preview, apply_icc=apply_icc)
@@ -239,8 +238,6 @@ def test_composite_layer_filter() -> None:
 
 
 def test_apply_mask() -> None:
-    from PIL import Image
-
     psd = PSDImage.open(full_name("masks/2.psd"))
     reference = np.asarray(Image.open(full_name("masks/2.png"))) / 255.0
     result = np.concatenate(composite(psd)[::2], axis=2)
@@ -307,8 +304,6 @@ def test_composite_pixel_layer_with_vector_stroke() -> None:
 
 def test_composite_mixed_colorspace_stroke() -> None:
     """Regression test for issue #397: ValueError on vector layer with CMYK stroke + Grayscale fill."""
-    from psd_tools.api.layers import GroupMixin
-
     psd = PSDImage.open(full_name("issues/issue397.psd"))
     psd.composite()
     for layer in psd:


### PR DESCRIPTION
## Summary

Closes #619.

- Enable ruff's `PLC0415` rule (`import` should be at top of module) via `extend-select = ["PLC0415"]` in `pyproject.toml`
- Expand ruff's lint scope to cover `tests/` alongside `src/`
- Resolve all 30 violations across 13 files:
  - **Hoisted** safe imports to module level: `math` (shape.py), `ImageChops`/`ImageCms`/`ImageMath` (pil_io.py), `Tag` (document.py), `numpy_io` (layers.py), stdlib/project imports in test files
  - **Removed** redundant local imports: `psd_image.py:_init` (layers already at module level), `layers.py:topil`/`numpy` (pil_io/numpy_io already at module level)
  - **Suppressed** with `# noqa: PLC0415` imports that must stay local: circular-dep guards (`composite_pil`, `TypeSetting`, `Layer`/`PSDImage` in numpy_io), optional-dep lazy loads (scipy/skimage in paint.py/effects.py, aggdraw in vector.py)

## Test plan

- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run pytest --no-cov` — 1129 passed, 0 failures, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)