### PR TITLE
refactor: extract color conversion math into psd_tools.color_convert

### DIFF
--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -106,6 +106,7 @@ from PIL import Image, ImageChops
 
 import psd_tools.psd.engine_data as engine_data
 from psd_tools.api import numpy_io, pil_io
+from psd_tools.color_convert import rgb_to_grayscale
 from psd_tools.api.effects import Effects
 from psd_tools.api.mask import Mask
 from psd_tools.api.protocols import GroupMixinProtocol, LayerProtocol, PSDProtocol
@@ -1715,7 +1716,7 @@ class Artboard(Group):
                 ColorMode.BITMAP,
                 ColorMode.DUOTONE,
             ):
-                lum = 0.299 * r + 0.587 * g + 0.114 * b_val
+                lum = rgb_to_grayscale(r, g, b_val)
                 return lum, 1.0
             else:
                 # NOTE: The Clr descriptor is always RGB regardless of document

--- a/src/psd_tools/color_convert.py
+++ b/src/psd_tools/color_convert.py
@@ -1,0 +1,161 @@
+"""Pure scalar color space conversion utilities.
+
+All functions operate on normalized float values in ``[0.0, 1.0]``.
+There are intentionally no numpy or internal ``psd_tools`` imports so this
+module can be imported freely from both ``psd_tools.api`` and
+``psd_tools.composite`` without introducing circular dependencies.
+
+References:
+    - ITU-R BT.601 for the luminance coefficients used in
+      :func:`rgb_to_grayscale`.
+    - Adobe Photoshop Color Model documentation for the CMYK ↔ RGB formulas.
+"""
+
+
+def rgb_to_grayscale(r: float, g: float, b: float) -> float:
+    """Convert normalized RGB to grayscale luminance (ITU-R BT.601).
+
+    Args:
+        r: Red channel in [0.0, 1.0].
+        g: Green channel in [0.0, 1.0].
+        b: Blue channel in [0.0, 1.0].
+
+    Returns:
+        Luminance value in [0.0, 1.0] using the BT.601 coefficients
+        ``0.299·R + 0.587·G + 0.114·B``.
+
+    Examples:
+        >>> rgb_to_grayscale(1.0, 1.0, 1.0)
+        1.0
+        >>> rgb_to_grayscale(0.0, 0.0, 0.0)
+        0.0
+    """
+    return 0.299 * r + 0.587 * g + 0.114 * b
+
+
+def rgb_to_cmyk(r: float, g: float, b: float) -> tuple[float, float, float, float]:
+    """Convert normalized RGB to CMYK.
+
+    Pure black ``(0, 0, 0)`` maps to ``(0, 0, 0, 1)`` to avoid a division by
+    zero in the key-channel normalization step.
+
+    Args:
+        r: Red channel in [0.0, 1.0].
+        g: Green channel in [0.0, 1.0].
+        b: Blue channel in [0.0, 1.0].
+
+    Returns:
+        4-tuple ``(C, M, Y, K)`` with each component in [0.0, 1.0].
+
+    Examples:
+        >>> rgb_to_cmyk(0.0, 0.0, 0.0)
+        (0.0, 0.0, 0.0, 1.0)
+        >>> rgb_to_cmyk(1.0, 1.0, 1.0)
+        (0.0, 0.0, 0.0, 0.0)
+    """
+    if r == 0.0 and g == 0.0 and b == 0.0:
+        return (0.0, 0.0, 0.0, 1.0)
+    c, m, y = 1.0 - r, 1.0 - g, 1.0 - b
+    k = min(c, m, y)
+    d = 1.0 - k
+    return ((c - k) / d, (m - k) / d, (y - k) / d, k)
+
+
+def cmyk_to_rgb(c: float, m: float, y: float, k: float) -> tuple[float, float, float]:
+    """Convert normalized CMYK to RGB.
+
+    Args:
+        c: Cyan channel in [0.0, 1.0].
+        m: Magenta channel in [0.0, 1.0].
+        y: Yellow channel in [0.0, 1.0].
+        k: Black (key) channel in [0.0, 1.0].
+
+    Returns:
+        3-tuple ``(R, G, B)`` with each component in [0.0, 1.0].
+
+    Examples:
+        >>> cmyk_to_rgb(0.0, 0.0, 0.0, 0.0)
+        (1.0, 1.0, 1.0)
+        >>> cmyk_to_rgb(0.0, 0.0, 0.0, 1.0)
+        (0.0, 0.0, 0.0)
+    """
+    return (
+        (1.0 - c) * (1.0 - k),
+        (1.0 - m) * (1.0 - k),
+        (1.0 - y) * (1.0 - k),
+    )
+
+
+def hsb_to_rgb(h: float, s: float, v: float) -> tuple[float, float, float]:
+    """Convert HSB (hue/saturation/brightness) to normalized RGB.
+
+    Uses the standard six-sector algorithm.  When saturation is zero the
+    color is achromatic and ``(v, v, v)`` is returned.
+
+    Args:
+        h: Hue in [0.0, 1.0); a value of exactly 1.0 wraps to 0.0.
+        s: Saturation in [0.0, 1.0].
+        v: Brightness (value) in [0.0, 1.0].
+
+    Returns:
+        3-tuple ``(R, G, B)`` with each component in [0.0, 1.0].
+
+    Examples:
+        >>> hsb_to_rgb(0.0, 0.0, 0.5)   # achromatic 50% grey
+        (0.5, 0.5, 0.5)
+    """
+    if not s:
+        return (v, v, v)
+    if h == 1.0:
+        h = 0.0
+    i = int(h * 6.0)
+    f = h * 6.0 - i
+    w = v * (1.0 - s)
+    q = v * (1.0 - s * f)
+    t = v * (1.0 - s * (1.0 - f))
+    sectors: dict[int, tuple[float, float, float]] = {
+        0: (v, t, w),
+        1: (q, v, w),
+        2: (w, v, t),
+        3: (w, q, v),
+        4: (t, w, v),
+        5: (v, w, q),
+    }
+    return sectors.get(i, (v, v, v))
+
+
+def gray_to_rgb(gray: float) -> tuple[float, float, float]:
+    """Expand a grayscale value to an achromatic RGB triple.
+
+    Args:
+        gray: Luminance in [0.0, 1.0].
+
+    Returns:
+        3-tuple ``(gray, gray, gray)``.
+
+    Examples:
+        >>> gray_to_rgb(0.5)
+        (0.5, 0.5, 0.5)
+    """
+    return (gray, gray, gray)
+
+
+def gray_to_cmyk(gray: float) -> tuple[float, float, float, float]:
+    """Convert a grayscale value to CMYK using only the K (black) channel.
+
+    White (1.0) maps to no ink ``(0, 0, 0, 0)``.
+    Black (0.0) maps to full key ``(0, 0, 0, 1)``.
+
+    Args:
+        gray: Luminance in [0.0, 1.0] where 1.0 is white.
+
+    Returns:
+        4-tuple ``(0.0, 0.0, 0.0, 1.0 - gray)``.
+
+    Examples:
+        >>> gray_to_cmyk(1.0)
+        (0.0, 0.0, 0.0, 0.0)
+        >>> gray_to_cmyk(0.0)
+        (0.0, 0.0, 0.0, 1.0)
+    """
+    return (0.0, 0.0, 0.0, 1.0 - gray)

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -6,6 +6,14 @@ import numpy as np
 
 from psd_tools.api import numpy_io
 from psd_tools.api.utils import EXPECTED_CHANNELS
+from psd_tools.color_convert import (
+    cmyk_to_rgb,
+    gray_to_cmyk,
+    gray_to_rgb,
+    hsb_to_rgb,
+    rgb_to_cmyk,
+    rgb_to_grayscale,
+)
 from psd_tools.composite._compat import require_scipy, require_skimage
 from psd_tools.constants import ColorMode, Tag
 from psd_tools.terminology import Enum, Key, Klass, Type
@@ -46,48 +54,6 @@ def _get_color(color_mode, desc) -> tuple[float, ...]:
     def _get_invert_color(color_desc, keys):
         return tuple((100.0 - float(color_desc[key])) / 100.0 for key in keys)
 
-    def hsb_to_rgb(h: float, s: float, v: float) -> tuple[float, ...]:
-        if s:
-            if h == 1.0:
-                h = 0.0
-            i = int(h * 6.0)
-            f = h * 6.0 - i
-
-            w = v * (1.0 - s)
-            q = v * (1.0 - s * f)
-            t = v * (1.0 - s * (1.0 - f))
-
-            if i == 0:
-                return (v, t, w)
-            if i == 1:
-                return (q, v, w)
-            if i == 2:
-                return (w, v, t)
-            if i == 3:
-                return (w, q, v)
-            if i == 4:
-                return (t, w, v)
-            if i == 5:
-                return (v, w, q)
-            return (v, v, v)  # fallback for unexpected i values
-        else:
-            return (v, v, v)
-
-    def rgb_to_cmyk(r, g, b) -> tuple[float, ...]:
-        if (r, g, b) == (0, 0, 0):
-            # black
-            return (0.0, 0.0, 0.0, 1.0)
-        c = 1 - r
-        m = 1 - g
-        y = 1 - b
-
-        min_cmy = min(c, m, y)
-        c = (c - min_cmy) / (1 - min_cmy)
-        m = (m - min_cmy) / (1 - min_cmy)
-        y = (y - min_cmy) / (1 - min_cmy)
-        k = min_cmy
-        return (c, m, y, k)
-
     def _get_rgb(color_mode, color_desc):
         if Key.Red in color_desc:
             rgb = _get_int_color(color_desc, (Key.Red, Key.Green, Key.Blue))
@@ -99,8 +65,7 @@ def _get_color(color_mode, desc) -> tuple[float, ...]:
         if color_mode == ColorMode.CMYK:
             return rgb_to_cmyk(*rgb)
         if color_mode == ColorMode.GRAYSCALE:
-            r, g, b = rgb
-            return (0.299 * r + 0.587 * g + 0.114 * b,)
+            return (rgb_to_grayscale(*rgb),)
         return rgb
 
     def _get_hsb(color_mode, color_desc):
@@ -117,9 +82,9 @@ def _get_color(color_mode, desc) -> tuple[float, ...]:
     def _get_gray(color_mode, x):
         (gray,) = _get_invert_color(x, (Key.Gray,))
         if color_mode == ColorMode.RGB:
-            return (gray, gray, gray)
+            return gray_to_rgb(gray)
         if color_mode == ColorMode.CMYK:
-            return (0.0, 0.0, 0.0, 1.0 - gray)
+            return gray_to_cmyk(gray)
         return (gray,)
 
     def _get_cmyk(color_mode, x):
@@ -127,13 +92,11 @@ def _get_color(color_mode, desc) -> tuple[float, ...]:
             x, (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black)
         )
         if color_mode in (ColorMode.RGB, ColorMode.GRAYSCALE):
-            r = (1.0 - c) * (1.0 - k)
-            g = (1.0 - m) * (1.0 - k)
-            b = (1.0 - y) * (1.0 - k)
+            r, g, b = cmyk_to_rgb(c, m, y, k)
         if color_mode == ColorMode.RGB:
             return (r, g, b)
         if color_mode == ColorMode.GRAYSCALE:
-            return (0.299 * r + 0.587 * g + 0.114 * b,)
+            return (rgb_to_grayscale(r, g, b),)
         return (c, m, y, k)
 
     def _get_lab(color_mode, x):

--- a/tests/psd_tools/test_color_convert.py
+++ b/tests/psd_tools/test_color_convert.py
@@ -1,0 +1,132 @@
+"""Unit tests for psd_tools.color_convert."""
+
+import pytest
+
+from psd_tools.color_convert import (
+    cmyk_to_rgb,
+    gray_to_cmyk,
+    gray_to_rgb,
+    hsb_to_rgb,
+    rgb_to_cmyk,
+    rgb_to_grayscale,
+)
+
+
+class TestRgbToGrayscale:
+    def test_white(self):
+        assert rgb_to_grayscale(1.0, 1.0, 1.0) == pytest.approx(1.0)
+
+    def test_black(self):
+        assert rgb_to_grayscale(0.0, 0.0, 0.0) == pytest.approx(0.0)
+
+    def test_pure_red(self):
+        assert rgb_to_grayscale(1.0, 0.0, 0.0) == pytest.approx(0.299)
+
+    def test_pure_green(self):
+        assert rgb_to_grayscale(0.0, 1.0, 0.0) == pytest.approx(0.587)
+
+    def test_pure_blue(self):
+        assert rgb_to_grayscale(0.0, 0.0, 1.0) == pytest.approx(0.114)
+
+    def test_coefficients_sum_to_one(self):
+        assert rgb_to_grayscale(1.0, 1.0, 1.0) == pytest.approx(0.299 + 0.587 + 0.114)
+
+
+class TestRgbToCmyk:
+    def test_black_special_case(self):
+        assert rgb_to_cmyk(0.0, 0.0, 0.0) == (0.0, 0.0, 0.0, 1.0)
+
+    def test_white(self):
+        c, m, y, k = rgb_to_cmyk(1.0, 1.0, 1.0)
+        assert (c, m, y, k) == pytest.approx((0.0, 0.0, 0.0, 0.0))
+
+    def test_pure_red(self):
+        c, m, y, k = rgb_to_cmyk(1.0, 0.0, 0.0)
+        assert (c, m, y, k) == pytest.approx((0.0, 1.0, 1.0, 0.0))
+
+    def test_pure_green(self):
+        c, m, y, k = rgb_to_cmyk(0.0, 1.0, 0.0)
+        assert (c, m, y, k) == pytest.approx((1.0, 0.0, 1.0, 0.0))
+
+    def test_pure_blue(self):
+        c, m, y, k = rgb_to_cmyk(0.0, 0.0, 1.0)
+        assert (c, m, y, k) == pytest.approx((1.0, 1.0, 0.0, 0.0))
+
+    def test_round_trip(self):
+        """cmyk_to_rgb(rgb_to_cmyk(r, g, b)) ≈ (r, g, b) for non-black colors."""
+        for r, g, b in [(1.0, 0.5, 0.25), (0.8, 0.2, 0.6), (0.5, 0.5, 0.5)]:
+            result = cmyk_to_rgb(*rgb_to_cmyk(r, g, b))
+            assert result == pytest.approx((r, g, b), abs=1e-6)
+
+
+class TestCmykToRgb:
+    def test_white(self):
+        assert cmyk_to_rgb(0.0, 0.0, 0.0, 0.0) == pytest.approx((1.0, 1.0, 1.0))
+
+    def test_black(self):
+        assert cmyk_to_rgb(0.0, 0.0, 0.0, 1.0) == pytest.approx((0.0, 0.0, 0.0))
+
+    def test_pure_cyan(self):
+        assert cmyk_to_rgb(1.0, 0.0, 0.0, 0.0) == pytest.approx((0.0, 1.0, 1.0))
+
+    def test_mid_gray(self):
+        assert cmyk_to_rgb(0.0, 0.0, 0.0, 0.5) == pytest.approx((0.5, 0.5, 0.5))
+
+
+class TestHsbToRgb:
+    def test_achromatic_zero_saturation(self):
+        assert hsb_to_rgb(0.0, 0.0, 0.5) == pytest.approx((0.5, 0.5, 0.5))
+
+    def test_achromatic_any_hue(self):
+        assert hsb_to_rgb(0.33, 0.0, 0.7) == pytest.approx((0.7, 0.7, 0.7))
+
+    def test_h_one_wraps_to_zero(self):
+        """h=1.0 should give the same result as h=0.0."""
+        assert hsb_to_rgb(1.0, 1.0, 1.0) == pytest.approx(hsb_to_rgb(0.0, 1.0, 1.0))
+
+    def test_sector_0_red(self):
+        r, g, b = hsb_to_rgb(0.0, 1.0, 1.0)
+        assert r == pytest.approx(1.0)
+        assert g == pytest.approx(0.0, abs=1e-6)
+        assert b == pytest.approx(0.0, abs=1e-6)
+
+    def test_sector_2_green(self):
+        r, g, b = hsb_to_rgb(1.0 / 3.0, 1.0, 1.0)
+        assert r == pytest.approx(0.0, abs=1e-6)
+        assert g == pytest.approx(1.0)
+        assert b == pytest.approx(0.0, abs=1e-6)
+
+    def test_sector_4_blue(self):
+        r, g, b = hsb_to_rgb(2.0 / 3.0, 1.0, 1.0)
+        assert r == pytest.approx(0.0, abs=1e-6)
+        assert g == pytest.approx(0.0, abs=1e-6)
+        assert b == pytest.approx(1.0)
+
+    @pytest.mark.parametrize("sector", range(6))
+    def test_all_six_sectors_return_tuple(self, sector):
+        h = (sector + 0.5) / 6.0
+        result = hsb_to_rgb(h, 1.0, 1.0)
+        assert len(result) == 3
+        assert all(0.0 <= v <= 1.0 for v in result)
+
+
+class TestGrayToRgb:
+    def test_mid_gray(self):
+        assert gray_to_rgb(0.5) == (0.5, 0.5, 0.5)
+
+    def test_black(self):
+        assert gray_to_rgb(0.0) == (0.0, 0.0, 0.0)
+
+    def test_white(self):
+        assert gray_to_rgb(1.0) == (1.0, 1.0, 1.0)
+
+
+class TestGrayToCmyk:
+    def test_white(self):
+        assert gray_to_cmyk(1.0) == (0.0, 0.0, 0.0, 0.0)
+
+    def test_black(self):
+        assert gray_to_cmyk(0.0) == (0.0, 0.0, 0.0, 1.0)
+
+    def test_mid_gray(self):
+        assert gray_to_cmyk(0.5) == pytest.approx((0.0, 0.0, 0.0, 0.5))


### PR DESCRIPTION
## Summary

- Extracts the duplicated ITU-R BT.601 luminance formula (`0.299·R + 0.587·G + 0.114·B`) and the `hsb_to_rgb` / `rgb_to_cmyk` closures from `composite/paint.py` into a new zero-dependency module `src/psd_tools/color_convert.py`
- Updates `api/layers.py` to use the shared `rgb_to_grayscale` helper instead of an inline formula
- Adds 34 unit tests in `tests/psd_tools/test_color_convert.py` covering all six conversion functions, including edge cases (pure black in `rgb_to_cmyk`, `h=1.0` wrap in `hsb_to_rgb`, all six HSB sectors, round-trip checks)

Motivated by reviewer feedback on PR #618 noting that the grayscale conversion logic appeared in multiple places.

## New module: `psd_tools/color_convert.py`

Six public, pure-math functions — no numpy, no internal `psd_tools` imports:

| Function | Description |
|---|---|
| `rgb_to_grayscale(r, g, b)` | ITU-R BT.601 luminance |
| `rgb_to_cmyk(r, g, b)` | RGB → CMYK (handles pure black) |
| `cmyk_to_rgb(c, m, y, k)` | CMYK → RGB |
| `hsb_to_rgb(h, s, v)` | HSB → RGB |
| `gray_to_rgb(gray)` | Expand grayscale to achromatic RGB |
| `gray_to_cmyk(gray)` | Grayscale → CMYK (pure K channel) |

`composite/blend.py` is intentionally untouched — its `_cmyk2rgb`/`_rgb2cmy`/`_lum` operate on 3D NumPy arrays with different coefficients (PDF reference blend mode values).

## Test plan

- [x] `uv run pytest tests/psd_tools/test_color_convert.py -v` — 34 unit tests pass
- [x] `uv run pytest tests/psd_tools/composite/test_composite.py -v` — all composite integration tests pass (including `test_composite_mixed_colorspace_stroke` from #618)
- [x] `uv run ruff check` — no lint issues
- [x] All pre-commit hooks pass (ruff, mypy, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)