### PR TITLE
feat: add /release Claude Code skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: release
+description: Prepare a psd-tools release: update changelog, open release PR. Use when the user wants to cut a new version.
+allowed-tools: Bash(git:*), Bash(gh:*)
+---
+
+Prepare a release for version **$ARGUMENTS**.
+
+If `$ARGUMENTS` is empty, ask the user for the target version before proceeding.
+
+Validate that `$ARGUMENTS` is a valid PEP 440 version string (e.g. `1.2.3`, `1.2.3a1`, `1.2.3rc1`, `1.2.3.post1`). If it is not, stop and ask the user to provide a valid version.
+
+## Step 1 — Review commits since the last release
+
+Here are the commits since the last tag:
+
+```
+!`git log $(git describe --tags --abbrev=0)..HEAD --oneline`
+```
+
+Last tag: !`git describe --tags --abbrev=0`
+
+Today's date: !`date +%Y-%m-%d`
+
+## Step 2 — Draft changelog entry
+
+Read `docs/changelog.rst` to understand the current format, then draft a new entry for version `$ARGUMENTS` using this RST format:
+
+```
+$ARGUMENTS (YYYY-MM-DD)
+-------------------
+
+- [category] Description (#PR)
+```
+
+Use these categories (pick the most specific one per bullet):
+
+- `api` — public API additions or changes
+- `psd` — low-level PSD parsing/writing
+- `fix` — bug fixes
+- `refactor` — internal restructuring, no behaviour change
+- `docs` — documentation only
+- `ci` — CI/CD, GitHub Actions
+- `chore` — dependency bumps, tooling, housekeeping
+- `security` — security fixes
+
+Group related changes. Omit purely internal churn that users won't care about. Reference PR numbers where available.
+
+Show the draft to the user and ask for approval or edits before continuing.
+
+## Step 3 — Update docs/changelog.rst
+
+Prepend the approved changelog entry directly after the `Changelog\n=========` header (line 3 of the file), leaving a blank line between the header and the new entry.
+
+## Step 4 — Create release branch and commit
+
+```bash
+git checkout -b release/v$ARGUMENTS
+git add docs/changelog.rst
+git commit -m "docs: release v$ARGUMENTS"
+git push -u origin release/v$ARGUMENTS
+```
+
+## Step 5 — Open a pull request
+
+```bash
+gh pr create \
+  --title "Release v$ARGUMENTS" \
+  --body "$(cat <<'EOF'
+## Release v$ARGUMENTS
+
+### Changelog
+
+<!-- paste the changelog entry here -->
+
+### Release checklist
+
+- [ ] Changelog entry reviewed and accurate
+- [ ] Version follows PEP 440
+
+After this PR is merged, the `auto-tag` workflow will tag the merge commit as `v$ARGUMENTS` and the `release` workflow will build wheels and publish to PyPI automatically.
+EOF
+)"
+```
+
+Fill in the changelog entry in the PR body from Step 2.
+
+## Step 6 — Done
+
+Print the PR URL. Remind the user:
+
+> After the PR is approved and merged, the `auto-tag` GitHub Actions workflow tags the merge commit automatically. That tag push triggers the `release` workflow to build wheels for all platforms and publish to PyPI. No manual tagging or publishing is needed.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -4,11 +4,26 @@ description: Prepare a psd-tools release: update changelog, open release PR. Use
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(date:*)
 ---
 
-Prepare a release for version **$ARGUMENTS**.
+## Step 0 — Determine target version
 
-If `$ARGUMENTS` is empty, ask the user for the target version before proceeding.
+**Provided version**: $ARGUMENTS
 
-Validate that `$ARGUMENTS` is a valid PEP 440 version string (e.g. `1.2.3`, `1.2.3a1`, `1.2.3rc1`, `1.2.3.post1`). If it is not, stop and ask the user to provide a valid version.
+### If a version was provided (above is non-empty)
+
+Validate it as a PEP 440 string (e.g. `1.2.3`, `1.2.3a1`, `1.2.3rc1`, `1.2.3.post1`).
+Stop and ask the user to correct it if invalid. Use it as VERSION for all subsequent steps.
+
+### If no version was provided (above is empty)
+
+Analyze the commits listed in Step 1 to recommend the correct next version.
+Apply these semver rules against the last tag shown in Step 1:
+
+- **Major bump** (`X+1.0.0`) — any commit that breaks a public API or documented behaviour
+- **Minor bump** (`X.Y+1.0`) — any new public feature or API addition, no breaking changes
+- **Patch bump** (`X.Y.Z+1`) — bug fixes, security patches, chores, docs, or refactoring only
+
+Show your reasoning and proposed version to the user, then ask them to confirm or override it.
+Treat the confirmed version as VERSION for all subsequent steps.
 
 ## Step 1 — Review commits since the last release
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -38,7 +38,7 @@ Fetch tags and list commits since the last release:
 
 Here are the commits since the last tag:
 
-!`if git tag --list | grep -q .; then git log "$(git describe --tags --abbrev=0)..HEAD" --oneline; else git log "$(git rev-list --max-parents=0 HEAD)..HEAD" --oneline; fi`
+!`LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"; if [ -n "$LAST_TAG" ]; then git log "$LAST_TAG..HEAD" --oneline; else git log "$(git rev-list --max-parents=0 HEAD)..HEAD" --oneline; fi`
 
 Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -11,29 +11,34 @@ allowed-tools: Bash(git:*), Bash(gh:*), Bash(date:*)
 ### If a version was provided (above is non-empty)
 
 Validate it as a PEP 440 string (e.g. `1.2.3`, `1.2.3a1`, `1.2.3rc1`, `1.2.3.post1`).
-Stop and ask the user to correct it if invalid. Use it as VERSION for all subsequent steps.
+Note: PEP 440 versions must **not** start with `v` — that prefix belongs on the git tag, not
+the version string.
+Stop and ask the user to correct it if invalid. Store it as **VERSION** for all subsequent steps.
 
 ### If no version was provided (above is empty)
 
 Analyze the commits listed in Step 1 to recommend the correct next version.
-Apply these semver rules against the last tag shown in Step 1:
+The last tag shown in Step 1 uses a `v` prefix (e.g. `v1.14.3`); strip it when computing
+the next version so the result is a bare PEP 440 string (e.g. `1.14.4`, not `v1.14.4`).
+
+Apply these semver rules:
 
 - **Major bump** (`X+1.0.0`) — any commit that breaks a public API or documented behaviour
 - **Minor bump** (`X.Y+1.0`) — any new public feature or API addition, no breaking changes
 - **Patch bump** (`X.Y.Z+1`) — bug fixes, security patches, chores, docs, or refactoring only
 
 Show your reasoning and proposed version to the user, then ask them to confirm or override it.
-Treat the confirmed version as VERSION for all subsequent steps.
+Store the confirmed version as **VERSION** for all subsequent steps.
 
 ## Step 1 — Review commits since the last release
 
 Fetch tags and list commits since the last release:
 
-!`git fetch --tags -q 2>/dev/null && echo ""`
+!`git fetch --tags -q || echo "Warning: failed to fetch tags — check network/auth and consider retrying."`
 
 Here are the commits since the last tag:
 
-!`git log "$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)"..HEAD --oneline`
+!`if git tag --list | grep -q .; then git log "$(git describe --tags --abbrev=0)..HEAD" --oneline; else git log "$(git rev-list --max-parents=0 HEAD)..HEAD" --oneline; fi`
 
 Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
 
@@ -41,17 +46,18 @@ Today's date: !`date +%Y-%m-%d`
 
 ## Step 2 — Draft changelog entry
 
-Read `docs/changelog.rst` to understand the current format, then draft a new entry for version `$ARGUMENTS` using this RST format:
+Read `docs/changelog.rst` to understand the current format, then draft a new entry for **VERSION**
+using this RST format:
 
 ```
-$ARGUMENTS (YYYY-MM-DD)
------------------------
+VERSION (YYYY-MM-DD)
+--------------------
 
 - [category] Description (#PR)
 ```
 
 **Important**: The `-` underline must be at least as long as the title line (RST requirement).
-Count the exact characters in `$ARGUMENTS (YYYY-MM-DD)` and use that many dashes.
+Count the exact characters in `VERSION (YYYY-MM-DD)` and use that many dashes.
 
 Use these categories (pick the most specific one per bullet):
 
@@ -70,30 +76,40 @@ Show the draft to the user and ask for approval or edits before continuing.
 
 ## Step 3 — Update docs/changelog.rst
 
-Prepend the approved changelog entry directly after the `Changelog\n=========` header (line 3 of the file), leaving a blank line between the header and the new entry.
+Prepend the approved changelog entry directly after the `Changelog` header block and the
+following blank line, leaving a blank line between the header and the new entry.
 
 ## Step 4 — Create release branch and commit
 
 ```bash
-git checkout -b release/v$ARGUMENTS
+git checkout -b release/vVERSION
 git add docs/changelog.rst
-git commit -m "docs: release v$ARGUMENTS"
-git push -u origin release/v$ARGUMENTS
+git commit -m "docs: release vVERSION"
+git push -u origin release/vVERSION
 ```
+
+Replace `VERSION` with the actual version string (e.g. `1.14.4`).
 
 ## Step 5 — Open a pull request
 
-Run `gh pr create` with `--title "Release v$ARGUMENTS"` and a `--body` containing:
+Run `gh pr create` with `--title "Release vVERSION"` and a `--body` containing:
 
-- A `## Release v$ARGUMENTS` heading
+- A `## Release vVERSION` heading
 - A `### Changelog` section with the approved entry from Step 2 pasted in
 - A `### Release checklist` section with these items:
   - `[ ] Changelog entry reviewed and accurate`
   - `[ ] Version follows PEP 440`
-- A closing note: "After this PR is merged, the `auto-tag` workflow will tag the merge commit as `v$ARGUMENTS` and the `release` workflow will build wheels and publish to PyPI automatically."
+- A closing note: "After this PR is merged, the `auto-tag` workflow will tag the merge commit
+  as `vVERSION` and the `release` workflow will build wheels and publish to PyPI automatically."
+
+Replace `VERSION` with the actual version string throughout.
 
 ## Step 6 — Done
 
 Print the PR URL. Remind the user:
 
-> After the PR is approved and merged, the `auto-tag` GitHub Actions workflow tags the merge commit automatically. That tag push triggers the `release` workflow to build wheels for all platforms and publish to PyPI. No manual tagging or publishing is needed.
+> After the PR is approved and merged, the `auto-tag` GitHub Actions workflow tags the merge
+> commit as `vVERSION` automatically. That tag push triggers the `release` workflow to build
+> wheels for all platforms and publish to PyPI. No manual tagging or publishing is needed.
+
+Replace `VERSION` with the actual version string.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: Prepare a psd-tools release: update changelog, open release PR. Use when the user wants to cut a new version.
-allowed-tools: Bash(git:*), Bash(gh:*)
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(date:*)
 ---
 
 Prepare a release for version **$ARGUMENTS**.
@@ -12,13 +12,15 @@ Validate that `$ARGUMENTS` is a valid PEP 440 version string (e.g. `1.2.3`, `1.2
 
 ## Step 1 — Review commits since the last release
 
+Fetch tags and list commits since the last release:
+
+!`git fetch --tags -q 2>/dev/null && echo ""`
+
 Here are the commits since the last tag:
 
-```
-!`git log $(git describe --tags --abbrev=0)..HEAD --oneline`
-```
+!`git log "$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)"..HEAD --oneline`
 
-Last tag: !`git describe --tags --abbrev=0`
+Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
 
 Today's date: !`date +%Y-%m-%d`
 
@@ -28,10 +30,13 @@ Read `docs/changelog.rst` to understand the current format, then draft a new ent
 
 ```
 $ARGUMENTS (YYYY-MM-DD)
--------------------
+-----------------------
 
 - [category] Description (#PR)
 ```
+
+**Important**: The `-` underline must be at least as long as the title line (RST requirement).
+Count the exact characters in `$ARGUMENTS (YYYY-MM-DD)` and use that many dashes.
 
 Use these categories (pick the most specific one per bullet):
 
@@ -63,27 +68,14 @@ git push -u origin release/v$ARGUMENTS
 
 ## Step 5 — Open a pull request
 
-```bash
-gh pr create \
-  --title "Release v$ARGUMENTS" \
-  --body "$(cat <<'EOF'
-## Release v$ARGUMENTS
+Run `gh pr create` with `--title "Release v$ARGUMENTS"` and a `--body` containing:
 
-### Changelog
-
-<!-- paste the changelog entry here -->
-
-### Release checklist
-
-- [ ] Changelog entry reviewed and accurate
-- [ ] Version follows PEP 440
-
-After this PR is merged, the `auto-tag` workflow will tag the merge commit as `v$ARGUMENTS` and the `release` workflow will build wheels and publish to PyPI automatically.
-EOF
-)"
-```
-
-Fill in the changelog entry in the PR body from Step 2.
+- A `## Release v$ARGUMENTS` heading
+- A `### Changelog` section with the approved entry from Step 2 pasted in
+- A `### Release checklist` section with these items:
+  - `[ ] Changelog entry reviewed and accurate`
+  - `[ ] Version follows PEP 440`
+- A closing note: "After this PR is merged, the `auto-tag` workflow will tag the merge commit as `v$ARGUMENTS` and the `release` workflow will build wheels and publish to PyPI automatically."
 
 ## Step 6 — Done
 

--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,8 @@ Temporary Items
 
 # Agents
 CLAUDE.local.md
-.claude
+.claude/*
+!.claude/skills/
 
 # Project-specific
 tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm==1.0.0
-        # Exclude GitHub issue/PR templates and Claude Code skills — they use YAML front matter
+        # Exclude GitHub issue templates and Claude Code skills — they use YAML front matter
         # delimited by `---` which mdformat incorrectly treats as a thematic break.
         files: ^(?!\.venv/|build/|dist/|\.github/ISSUE_TEMPLATE/|\.claude/skills/).*\.md$
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,9 +59,9 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm==1.0.0
-        # Exclude GitHub issue/PR templates — they use YAML front matter
+        # Exclude GitHub issue/PR templates and Claude Code skills — they use YAML front matter
         # delimited by `---` which mdformat incorrectly treats as a thematic break.
-        files: ^(?!\.venv/|build/|dist/|\.github/ISSUE_TEMPLATE/).*\.md$
+        files: ^(?!\.venv/|build/|dist/|\.github/ISSUE_TEMPLATE/|\.claude/skills/).*\.md$
 
   # ---------------------------------------------------------------------------
   # RST: sphinx-lint (linter — no mature RST formatter exists)


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/release/SKILL.md` — a project-level Claude Code skill that automates the release workflow when invoked as `/release [X.Y.Z]`
- Updates `.gitignore` to use `.claude/*` (instead of `.claude`) so `.claude/skills/` can be tracked in git
- Extends the `mdformat` pre-commit exclusion pattern to cover `.claude/skills/`, since skill YAML frontmatter is misidentified as thematic breaks

## What the skill does

### `/release 1.14.4` (version provided)

1. Validates the version against PEP 440
2. Fetches tags and injects the git log since the last tag into context
3. Drafts a changelog entry in the RST format used by `docs/changelog.rst`, with correct category prefixes (`api`, `fix`, `chore`, etc.) and a correctly-sized underline
4. Shows the draft and waits for approval
5. Prepends the entry to `docs/changelog.rst`
6. Creates a `release/v1.14.4` branch, commits, pushes, and opens a PR
7. Reminds the contributor that after merge the `auto-tag` + `release` workflows handle tagging and PyPI publishing automatically

### `/release` (no version provided)

Same as above, but adds an automatic version suggestion step before drafting the changelog:

- Analyzes commits since the last tag and recommends the correct semver increment (major / minor / patch) with its reasoning
- Asks the user to confirm or override the suggested version before proceeding

## Test plan

- [ ] Run `/release 1.14.4` — verify Claude validates the version, shows the git log, drafts an RST changelog entry, and opens a PR on `release/v1.14.4`
- [ ] Run `/release` — verify Claude suggests a version with reasoning based on the commit history and waits for confirmation
- [ ] Confirm branch names match the pattern expected by `auto-tag.yml` (`release/v*.*.*`)
- [ ] Close/delete test PRs without merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)