### PR TITLE
fix: avoid command_substitution in /release skill inline commands

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -36,13 +36,11 @@ Fetch tags and list commits since the last release:
 
 !`git fetch --tags -q || echo "Warning: failed to fetch tags — check network/auth and consider retrying."`
 
-Here are the commits since the last tag:
-
-!`LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"; if [ -n "$LAST_TAG" ]; then git log "$LAST_TAG..HEAD" --oneline; else git log "$(git rev-list --max-parents=0 HEAD)..HEAD" --oneline; fi`
-
 Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
 
 Today's date: !`date +%Y-%m-%d`
+
+Using the last tag shown above, run `git log <LAST_TAG>..HEAD --oneline` to list commits since that tag. If there is no last tag, run `git log --oneline` to list all commits.
 
 ## Step 2 — Draft changelog entry
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -32,7 +32,7 @@ Store the confirmed version as **VERSION** for all subsequent steps.
 
 ## Step 1 — Review commits since the last release
 
-Fetch tags and list commits since the last release:
+Fetch tags:
 
 !`git fetch --tags -q || echo "Warning: failed to fetch tags — check network/auth and consider retrying."`
 
@@ -40,7 +40,12 @@ Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
 
 Today's date: !`date +%Y-%m-%d`
 
-If the "Last tag" output above is `(none)`, do not use `(none)` as a tag name; run `git log --oneline` to list all commits. Otherwise, use the actual tag shown above and run `git log <LAST_TAG>..HEAD --oneline` to list commits since that tag.
+Now list the commits since the last release by running one of these commands:
+
+- If "Last tag" above is `(none)`: run `git log --oneline`
+- Otherwise: run `git log <LAST_TAG>..HEAD --oneline` (substituting the actual tag)
+
+You must run this command and review the output before proceeding to Step 0 or Step 2.
 
 ## Step 2 — Draft changelog entry
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -40,7 +40,7 @@ Last tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "(none)"`
 
 Today's date: !`date +%Y-%m-%d`
 
-Using the last tag shown above, run `git log <LAST_TAG>..HEAD --oneline` to list commits since that tag. If there is no last tag, run `git log --oneline` to list all commits.
+If the "Last tag" output above is `(none)`, do not use `(none)` as a tag name; run `git log --oneline` to list all commits. Otherwise, use the actual tag shown above and run `git log <LAST_TAG>..HEAD --oneline` to list commits since that tag.
 
 ## Step 2 — Draft changelog entry
 


### PR DESCRIPTION
## Summary

- The `/release` skill's inline `!` commands were failing with permission errors because the checker rejects shell variable assignments and `$()` command substitutions
- Removes the complex multi-statement shell script (`LAST_TAG="$(...)"; if [ -n ... ]; then ... fi`) that was used to list commits since the last tag
- Replaces it with a plain-text instruction for Claude to call `git log <LAST_TAG>..HEAD --oneline` as a Bash tool call after reading the last tag from the preceding inline command

## Root cause

The skill's permission checker parses inline `!` commands as a shell AST and rejects:
1. Variable assignments → `"Unhandled node type: string"`
2. `$()` command substitutions → `"Contains command_substitution"`

Simple commands with `||` (already used on other lines in the skill) are fine.

## Test plan

- [x] Run `/release` and confirm Step 1 loads without a permission error
- [x] Verify Claude correctly runs `git log <last_tag>..HEAD --oneline` after reading the last tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)