### PR TITLE
Use `IO[bytes]` instead of `BinaryIO`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,10 +124,10 @@ All binary structures inherit from `BaseElement` and implement:
 
 ```python
 @classmethod
-def read(cls, fp: BinaryIO, **kwargs) -> Self:
+def read(cls, fp: IO[bytes], **kwargs) -> Self:
     """Read from file pointer"""
 
-def write(self, fp: BinaryIO, **kwargs) -> int:
+def write(self, fp: IO[bytes], **kwargs) -> int:
     """Write to file pointer, return bytes written"""
 ```
 

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Sequence
-from typing import Any, BinaryIO, Callable, Iterable, Literal
+from typing import IO, Any, Callable, Iterable, Literal
 
 from typing_extensions import Self
 
@@ -209,7 +209,7 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         return psdimage
 
     @classmethod
-    def open(cls, fp: BinaryIO | str | bytes | os.PathLike, **kwargs: Any) -> Self:
+    def open(cls, fp: IO[bytes] | str | bytes | os.PathLike, **kwargs: Any) -> Self:
         """
         Open a PSD document.
 
@@ -227,7 +227,7 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
 
     def save(
         self,
-        fp: BinaryIO | str | bytes | os.PathLike,
+        fp: IO[bytes] | str | bytes | os.PathLike,
         mode: str = "wb",
         **kwargs: Any,
     ) -> None:

--- a/src/psd_tools/api/smart_object.py
+++ b/src/psd_tools/api/smart_object.py
@@ -6,7 +6,7 @@ import contextlib
 import io
 import logging
 import os
-from typing import BinaryIO, Iterator
+from typing import IO, Iterator
 
 from psd_tools.api.protocols import LayerProtocol
 from psd_tools.constants import Tag
@@ -67,7 +67,7 @@ class SmartObject:
         return self._data.filename.strip("\x00")
 
     @contextlib.contextmanager
-    def open(self, external_dir: str | None = None) -> Iterator[BinaryIO]:
+    def open(self, external_dir: str | None = None) -> Iterator[IO[bytes]]:
         """
         Open the smart object as binary IO.
 

--- a/src/psd_tools/psd/adjustments.py
+++ b/src/psd_tools/psd/adjustments.py
@@ -3,7 +3,7 @@ Adjustment layer structure.
 """
 
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field, astuple
 
@@ -66,10 +66,10 @@ class BrightnessContrast(BaseElement):
     lab_only: int = 0
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(*read_fmt("3HBx", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "3HBx", *astuple(self))
 
 
@@ -91,14 +91,14 @@ class ColorBalance(BaseElement):
     luminosity: bool = False
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         shadows = read_fmt("3h", fp)
         midtones = read_fmt("3h", fp)
         highlights = read_fmt("3h", fp)
         luminosity = read_fmt("B", fp)[0]
         return cls(shadows, midtones, highlights, luminosity)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "3h", *self.shadows)
         written += write_fmt(fp, "3h", *self.midtones)
         written += write_fmt(fp, "3h", *self.highlights)
@@ -118,11 +118,11 @@ class ColorLookup(DescriptorBlock2):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version, data_version = read_fmt("HI", fp)
         return cls(version=version, data_version=data_version, **cls._read_body(fp))  # type: ignore[call-arg, attr-defined]
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "HI", self.version, self.data_version)
         written += self._write_body(fp)
         written += write_padding(fp, written, padding)
@@ -146,13 +146,13 @@ class ChannelMixer(BaseElement):
     unknown: bytes = field(default=b"", repr=False)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version, monochrome = read_fmt("2H", fp)
         data = list(read_fmt("5h", fp))
         unknown = fp.read()
         return cls(version=version, monochrome=monochrome, data=data, unknown=unknown)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "2H", self.version, self.monochrome)
         written += write_fmt(fp, "5h", *self.data)
         written += write_bytes(fp, self.unknown)
@@ -179,7 +179,7 @@ class Curves(BaseElement):
     extra: object = None
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         # NOTE: This is highly experimental and unstable.
         is_map, version, count_map = read_fmt("BHI", fp)
         assert version in (1, 4), "Invalid version %d" % (version)
@@ -211,7 +211,7 @@ class Curves(BaseElement):
 
         return cls(is_map, version, count_map, data, extra)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "BHI", self.is_map, self.version, self.count_map)
         if self.is_map:
             written += sum(write_fmt(fp, "256B", *item) for item in self.data)
@@ -238,7 +238,7 @@ class CurvesExtraMarker(ListElement):
     version: int = field(default=4, validator=in_((3, 4)))
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         signature, version, count = read_fmt("4sHI", fp)
         assert signature == b"Crv ", "Invalid signature %r" % (signature)
         items = []
@@ -246,7 +246,7 @@ class CurvesExtraMarker(ListElement):
             items.append(CurvesExtraItem.read(fp, **kwargs))
         return cls(version=version, items=items)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "4sHI", b"Crv ", self.version, len(self))
         written += sum(item.write(fp) for item in self)
         return written
@@ -265,7 +265,7 @@ class CurvesExtraItem(BaseElement):
     points: list[Any] = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, is_map: bool = False, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], is_map: bool = False, **kwargs: Any) -> T:
         if is_map:
             channel_id = read_fmt("H", fp)[0]
             points = list(read_fmt("256B", fp))
@@ -274,7 +274,7 @@ class CurvesExtraItem(BaseElement):
             points = [read_fmt("2H", fp) for c in range(point_count)]
         return cls(channel_id, points)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "H", self.channel_id)
         if len(self.points) > 0 and isinstance(self.points[0], int):
             written += write_fmt(fp, "256B", *self.points)
@@ -347,7 +347,7 @@ class GradientMap(BaseElement):
     maximum_color: list = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version, is_reversed, is_dithered = read_fmt("H2B", fp)
         assert version in (1, 3), "Invalid version %s" % (version)
         method = read_fmt("4s", fp)[0] if version == 3 else b"Gcls"
@@ -384,7 +384,7 @@ class GradientMap(BaseElement):
             maximum_color,
         )  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "H2B", self.version, self.is_reversed, self.is_dithered)
         if self.version == 3:
             written += write_fmt(fp, "4s", self.method)
@@ -430,12 +430,12 @@ class ColorStop(BaseElement):
     color: tuple = (0,)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         location, midpoint, mode = read_fmt("2IH", fp)
         color = read_fmt("4H2x", fp)
         return cls(location, midpoint, mode, color)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(
             fp, "2I5H2x", self.location, self.midpoint, self.mode, *self.color
         )
@@ -456,10 +456,10 @@ class TransparencyStop(BaseElement):
     opacity: int = 0
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(*read_fmt("2IH", fp))  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "2IH", *astuple(self))
 
 
@@ -481,10 +481,10 @@ class Exposure(BaseElement):
     gamma: float = 0.0
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(*read_fmt("H3f", fp))
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "H3f", *astuple(self))
         written += write_padding(fp, written, padding)
         return written
@@ -511,7 +511,7 @@ class HueSaturation(BaseElement):
     items: list = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version, enable = read_fmt("HBx", fp)
         assert version == 2, "Invalid version %d" % (version)
         colorization = read_fmt("3h", fp)
@@ -529,7 +529,7 @@ class HueSaturation(BaseElement):
             items=items,
         )  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "HBx", self.version, self.enable)
         written += write_fmt(fp, "3h", *self.colorization)
         written += write_fmt(fp, "3h", *self.master)
@@ -560,7 +560,7 @@ class Levels(ListElement):
     extra_version: int | None = None
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version = read_fmt("H", fp)[0]
         if version != 2:
             raise ValueError("Invalid version %d" % (version))
@@ -589,7 +589,7 @@ class Levels(ListElement):
 
         return cls(version=version, extra_version=extra_version, items=items)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "H", self.version)
         for index in range(29):
             written += self[index].write(fp)
@@ -638,10 +638,10 @@ class LevelRecord(BaseElement):
     gamma: int = 0
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(*read_fmt("5H", fp))  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "5H", *astuple(self))
 
 
@@ -667,7 +667,7 @@ class PhotoFilter(BaseElement):
     luminosity: int | None = None
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version = read_fmt("H", fp)[0]
         assert version in (2, 3), "Invalid version %d" % (version)
         if version == 3:
@@ -688,7 +688,7 @@ class PhotoFilter(BaseElement):
             luminosity=luminosity,
         )  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "H", self.version)
         if self.version == 3:
             written += write_fmt(fp, "3I", *self.xyz)  # type: ignore[misc]
@@ -715,12 +715,12 @@ class SelectiveColor(BaseElement):
     data: list = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version, method = read_fmt("2H", fp)
         data = [read_fmt("4h", fp) for i in range(10)]
         return cls(version=version, method=method, data=data)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "2H", self.version, self.method)
         for plate in self.data:
             written += write_fmt(fp, "4h", *plate)

--- a/src/psd_tools/psd/base.py
+++ b/src/psd_tools/psd/base.py
@@ -16,7 +16,7 @@ import io
 import logging
 from collections import OrderedDict
 from enum import Enum
-from typing import Any, BinaryIO, Callable, Generator, TypeVar
+from typing import IO, Any, Callable, Generator, TypeVar
 
 from attrs import define, field, fields, has, validate
 
@@ -61,10 +61,10 @@ class BaseElement:
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         raise NotImplementedError()
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         raise NotImplementedError()
 
     @classmethod
@@ -142,10 +142,10 @@ class EmptyElement(BaseElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, *args: Any, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], *args: Any, **kwargs: Any) -> T:
         return cls()
 
-    def write(self, fp: BinaryIO, *args: Any, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], *args: Any, **kwargs: Any) -> int:
         return 0
 
 
@@ -273,10 +273,10 @@ class NumericElement(ValueElement):
         return float(self.value)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(read_fmt("d", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "d", self.value)
 
 
@@ -327,10 +327,10 @@ class IntegerElement(NumericElement):
         return self.value.__index__()
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(read_fmt("I", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "I", self.value)
 
 
@@ -343,14 +343,14 @@ class ShortIntegerElement(IntegerElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         try:
             return cls(read_fmt("H2x", fp)[0])  # type: ignore[call-arg]
         except IOError as e:
             logger.error(e)
         return cls(read_fmt("H", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "H2x", self.value)
 
 
@@ -363,14 +363,14 @@ class ByteElement(IntegerElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         try:
             return cls(read_fmt("B3x", fp)[0])  # type: ignore[call-arg]
         except IOError as e:
             logger.error(e)
         return cls(read_fmt("B", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "B3x", self.value)
 
 
@@ -385,14 +385,14 @@ class BooleanElement(IntegerElement):
     value: bool = field(default=False, converter=bool)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         try:
             return cls(read_fmt("?3x", fp)[0])  # type: ignore[call-arg]
         except IOError as e:
             logger.error(e)
         return cls(read_fmt("?", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "?3x", self.value)
 
 
@@ -409,10 +409,10 @@ class StringElement(ValueElement):
     value: str = ""
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, padding: int = 1, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], padding: int = 1, **kwargs: Any) -> T:
         return cls(read_unicode_string(fp, padding=padding))  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, padding: int = 1, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 1, **kwargs: Any) -> int:
         return write_unicode_string(fp, self.value, padding=padding)
 
 
@@ -486,7 +486,7 @@ class ListElement(BaseElement):
                 p.pretty(value)
             p.breakable("")
 
-    def write(self, fp: BinaryIO, *args: Any, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], *args: Any, **kwargs: Any) -> int:
         written = 0
         for item in self:
             if hasattr(item, "write"):
@@ -590,10 +590,10 @@ class DictElement(BaseElement):
         return key
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, *args: Any, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], *args: Any, **kwargs: Any) -> T:
         raise NotImplementedError
 
-    def write(self, fp: BinaryIO, *args: Any, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], *args: Any, **kwargs: Any) -> int:
         written = 0
         for key in self:
             value = self[key]

--- a/src/psd_tools/psd/bin_utils.py
+++ b/src/psd_tools/psd/bin_utils.py
@@ -13,7 +13,7 @@ import array
 import logging
 import struct
 import sys
-from typing import Any, BinaryIO, Callable
+from typing import IO, Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ def unpack(fmt: str, data: bytes) -> tuple[Any, ...]:
     return struct.unpack(fmt, data)
 
 
-def read_fmt(fmt: str, fp: BinaryIO) -> tuple[Any, ...]:
+def read_fmt(fmt: str, fp: IO[bytes]) -> tuple[Any, ...]:
     """
     Reads data from ``fp`` according to ``fmt``.
     """
@@ -44,7 +44,7 @@ def read_fmt(fmt: str, fp: BinaryIO) -> tuple[Any, ...]:
     return struct.unpack(fmt, data)
 
 
-def write_fmt(fp: BinaryIO, fmt: str, *args: Any) -> int:
+def write_fmt(fp: IO[bytes], fmt: str, *args: Any) -> int:
     """
     Writes data to ``fp`` according to ``fmt``.
     """
@@ -59,7 +59,7 @@ def write_fmt(fp: BinaryIO, fmt: str, *args: Any) -> int:
     return written
 
 
-def write_bytes(fp: BinaryIO, data: bytes) -> int:
+def write_bytes(fp: IO[bytes], data: bytes) -> int:
     """
     Write bytes to the file object and returns bytes written.
 
@@ -75,7 +75,7 @@ def write_bytes(fp: BinaryIO, data: bytes) -> int:
     return written
 
 
-def read_length_block(fp: BinaryIO, fmt: str = "I", padding: int = 1) -> bytes:
+def read_length_block(fp: IO[bytes], fmt: str = "I", padding: int = 1) -> bytes:
     """
     Read a block of data with a length marker at the beginning.
 
@@ -95,7 +95,7 @@ def read_length_block(fp: BinaryIO, fmt: str = "I", padding: int = 1) -> bytes:
 
 
 def write_length_block(
-    fp: BinaryIO,
+    fp: IO[bytes],
     writer: Callable[..., int],
     fmt: str = "I",
     padding: int = 1,
@@ -122,7 +122,7 @@ def write_length_block(
     return written
 
 
-def reserve_position(fp: BinaryIO, fmt: str = "I") -> int:
+def reserve_position(fp: IO[bytes], fmt: str = "I") -> int:
     """
     Reserves the current position for write.
 
@@ -137,7 +137,7 @@ def reserve_position(fp: BinaryIO, fmt: str = "I") -> int:
     return position
 
 
-def write_position(fp: BinaryIO, position: int, value: int, fmt: str = "I") -> int:
+def write_position(fp: IO[bytes], position: int, value: int, fmt: str = "I") -> int:
     """
     Writes a value to the specified position.
 
@@ -154,7 +154,7 @@ def write_position(fp: BinaryIO, position: int, value: int, fmt: str = "I") -> i
     return written
 
 
-def read_padding(fp: BinaryIO, size: int, divisor: int = 2) -> bytes:
+def read_padding(fp: IO[bytes], size: int, divisor: int = 2) -> bytes:
     """
     Read padding bytes for the given byte size.
 
@@ -168,7 +168,7 @@ def read_padding(fp: BinaryIO, size: int, divisor: int = 2) -> bytes:
     return b""
 
 
-def write_padding(fp: BinaryIO, size: int, divisor: int = 2) -> int:
+def write_padding(fp: IO[bytes], size: int, divisor: int = 2) -> int:
     """
     Writes padding bytes given the currently written size.
 
@@ -182,7 +182,7 @@ def write_padding(fp: BinaryIO, size: int, divisor: int = 2) -> int:
     return 0
 
 
-def is_readable(fp: BinaryIO, size: int = 1) -> bool:
+def is_readable(fp: IO[bytes], size: int = 1) -> bool:
     """
     Check if the file-like object is readable.
 
@@ -202,7 +202,7 @@ def pad(number: int, divisor: int) -> int:
 
 
 def read_pascal_string(
-    fp: BinaryIO, encoding: str = "macroman", padding: int = 2
+    fp: IO[bytes], encoding: str = "macroman", padding: int = 2
 ) -> str:
     """
     Reads pascal string (length + bytes).
@@ -222,7 +222,7 @@ def read_pascal_string(
 
 
 def write_pascal_string(
-    fp: BinaryIO, value: str, encoding: str = "macroman", padding: int = 2
+    fp: IO[bytes], value: str, encoding: str = "macroman", padding: int = 2
 ) -> int:
     data = value.encode(encoding)
     written = write_fmt(fp, "B", len(data))
@@ -231,14 +231,14 @@ def write_pascal_string(
     return written
 
 
-def read_unicode_string(fp: BinaryIO, padding: int = 1) -> str:
+def read_unicode_string(fp: IO[bytes], padding: int = 1) -> str:
     num_chars = read_fmt("I", fp)[0]
     data = fp.read(num_chars * 2)
     read_padding(fp, struct.calcsize("I") + num_chars * 2, padding)
     return data.decode("utf-16-be")
 
 
-def write_unicode_string(fp: BinaryIO, value: str, padding: int = 1) -> int:
+def write_unicode_string(fp: IO[bytes], value: str, padding: int = 1) -> int:
     encoded = value.encode("utf-16-be")
     written = write_fmt(fp, "I", len(encoded) // 2)
     written += write_bytes(fp, encoded)
@@ -246,7 +246,7 @@ def write_unicode_string(fp: BinaryIO, value: str, padding: int = 1) -> int:
     return written
 
 
-def read_be_array(fmt: str, count: int, fp: BinaryIO) -> array.array:
+def read_be_array(fmt: str, count: int, fp: IO[bytes]) -> array.array:
     """
     Reads an array from a file with big-endian data.
     """
@@ -255,7 +255,7 @@ def read_be_array(fmt: str, count: int, fp: BinaryIO) -> array.array:
     return fix_byteorder(arr)
 
 
-def write_be_array(fp: BinaryIO, arr: array.array) -> int:
+def write_be_array(fp: IO[bytes], arr: array.array) -> int:
     """
     Writes an array to a file with big-endian data.
     """

--- a/src/psd_tools/psd/color.py
+++ b/src/psd_tools/psd/color.py
@@ -3,7 +3,7 @@ Color structure and conversion methods.
 """
 
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field
 
@@ -34,7 +34,7 @@ class Color(BaseElement):
     values: list = field(factory=lambda: [0, 0, 0, 0])
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         id = read_fmt("H", fp)[0]
         try:
             id = ColorSpaceID(id)
@@ -46,7 +46,7 @@ class Color(BaseElement):
             values = read_fmt("4H", fp)
         return cls(id, list(values))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         id = getattr(self.id, "value", self.id)
         written = write_fmt(fp, "H", id)
         if self.id == ColorSpaceID.LAB:

--- a/src/psd_tools/psd/color_mode_data.py
+++ b/src/psd_tools/psd/color_mode_data.py
@@ -4,7 +4,7 @@ Color mode data structure.
 
 import array
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define
 
@@ -30,14 +30,14 @@ class ColorModeData(ValueElement):
     value: bytes = b""
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         value = read_length_block(fp)
         logger.debug("reading color mode data, len=%d" % (len(value)))
         # TODO: Parse color table.
         return cls(value)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
-        def writer(f: BinaryIO) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
+        def writer(f: IO[bytes]) -> int:
             return write_bytes(f, self.value)
 
         logger.debug("writing color mode data, len=%d" % (len(self.value)))

--- a/src/psd_tools/psd/descriptor.py
+++ b/src/psd_tools/psd/descriptor.py
@@ -17,7 +17,7 @@ Pretty printing is the best approach to check the descriptor content::
 """
 
 import logging
-from typing import Any, BinaryIO, Iterator, TypeVar
+from typing import IO, Any, Iterator, TypeVar
 
 from attrs import define, field
 
@@ -60,7 +60,7 @@ _TERMS = set(
 )
 
 
-def read_length_and_key(fp: BinaryIO) -> bytes:
+def read_length_and_key(fp: IO[bytes]) -> bytes:
     """
     Helper to read descriptor key.
     """
@@ -72,7 +72,7 @@ def read_length_and_key(fp: BinaryIO) -> bytes:
     return key
 
 
-def write_length_and_key(fp: BinaryIO, value: bytes) -> int:
+def write_length_and_key(fp: IO[bytes], value: bytes) -> int:
     """
     Helper to write descriptor key.
     """
@@ -86,7 +86,7 @@ class _DescriptorMixin(DictElement):
     classID: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def _read_body(cls, fp: BinaryIO) -> dict[str, Any]:
+    def _read_body(cls, fp: IO[bytes]) -> dict[str, Any]:
         name = read_unicode_string(fp, padding=1)
         classID = read_length_and_key(fp)
         items = []
@@ -100,7 +100,7 @@ class _DescriptorMixin(DictElement):
 
         return dict(name=name, classID=classID, items=items)
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         written = write_unicode_string(fp, self.name, padding=1)
         written += write_length_and_key(fp, self.classID)
         written += write_fmt(fp, "I", len(self))
@@ -173,10 +173,10 @@ class Descriptor(_DescriptorMixin):
     classID: bytes = Klass.Null.value
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(**cls._read_body(fp))  # type: ignore[attr-defined]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return self._write_body(fp)
 
 
@@ -205,11 +205,11 @@ class ObjectArray(_DescriptorMixin):
     classID: bytes = Klass.Null.value
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         items_count = read_fmt("I", fp)[0]
         return cls(items_count=items_count, **cls._read_body(fp))  # type: ignore[attr-defined,call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.items_count)
         written += self._write_body(fp)
         return written
@@ -228,7 +228,7 @@ class List(ListElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         items = []
         count = read_fmt("I", fp)[0]
         for _ in range(count):
@@ -238,7 +238,7 @@ class List(ListElement):
             items.append(value)
         return cls(items)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", len(self))
         for item in self:
             written += write_bytes(fp, item.ostype.value)
@@ -270,13 +270,13 @@ class Property(BaseElement):
     keyID: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         name = read_unicode_string(fp)
         classID = read_length_and_key(fp)
         keyID = read_length_and_key(fp)
         return cls(name, classID, keyID)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_unicode_string(fp, self.name)
         written += write_length_and_key(fp, self.classID)
         written += write_length_and_key(fp, self.keyID)
@@ -302,7 +302,7 @@ class UnitFloat(NumericElement):
     unit: Unit = Unit._None
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         unit, value = read_fmt("4sd", fp)
         try:
             unit = Unit(unit)
@@ -311,7 +311,7 @@ class UnitFloat(NumericElement):
             unit = Enum(unit)
         return cls(unit=unit, value=value)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "4sd", self.unit.value, self.value)
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:
@@ -342,7 +342,7 @@ class UnitFloats(BaseElement):
     values: list = field(factory=list)
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         unit, count = read_fmt("4sI", fp)
         try:
             unit = Unit(unit)
@@ -352,7 +352,7 @@ class UnitFloats(BaseElement):
         values = list(read_fmt("%dd" % count, fp))
         return cls(unit=unit, values=values)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(
             fp,
             "4sI%dd" % len(self.values),
@@ -383,10 +383,10 @@ class Double(NumericElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(*read_fmt("d", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "d", self.value)
 
 
@@ -408,12 +408,12 @@ class Class(BaseElement):
     classID: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         name = read_unicode_string(fp)
         classID = read_length_and_key(fp)
         return cls(name, classID)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_unicode_string(fp, self.name)
         written += write_length_and_key(fp, self.classID)
         return written
@@ -461,14 +461,14 @@ class EnumeratedReference(BaseElement):
     enum: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         name = read_unicode_string(fp)
         classID = read_length_and_key(fp)
         typeID = read_length_and_key(fp)
         enum = read_length_and_key(fp)
         return cls(name, classID, typeID, enum)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_unicode_string(fp, self.name)
         written += write_length_and_key(fp, self.classID)
         written += write_length_and_key(fp, self.typeID)
@@ -500,13 +500,13 @@ class Offset(BaseElement):
     value: int = 0
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         name = read_unicode_string(fp)
         classID = read_length_and_key(fp)
         offset = read_fmt("I", fp)[0]
         return cls(name, classID, offset)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_unicode_string(fp, self.name)
         written += write_length_and_key(fp, self.classID)
         written += write_fmt(fp, "I", self.value)
@@ -524,10 +524,10 @@ class Bool(BooleanElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(read_fmt("?", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "?", self.value)
 
 
@@ -542,10 +542,10 @@ class LargeInteger(IntegerElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(read_fmt("q", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "q", self.value)
 
 
@@ -560,10 +560,10 @@ class Integer(IntegerElement):
     """
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(read_fmt("i", fp)[0])  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "i", self.value)
 
 
@@ -586,12 +586,12 @@ class Enumerated(BaseElement):
     enum: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         typeID = read_length_and_key(fp)
         enum = read_length_and_key(fp)
         return cls(typeID, enum)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_length_and_key(fp, self.typeID)
         written += write_length_and_key(fp, self.enum)
         return written
@@ -630,11 +630,11 @@ class RawData(BaseElement):
     value: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(read_length_block(fp))  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
-        def writer(f: BinaryIO) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
+        def writer(f: IO[bytes]) -> int:
             if hasattr(self.value, "write"):
                 return self.value.write(f)
             return write_bytes(f, self.value)
@@ -755,13 +755,13 @@ class Name(BaseElement):
     value: str = ""
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         name = read_unicode_string(fp)
         classID = read_length_and_key(fp)
         value = read_unicode_string(fp)
         return cls(name, classID, value)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_unicode_string(fp, self.name)
         written += write_length_and_key(fp, self.classID)
         written += write_unicode_string(fp, self.value)
@@ -780,11 +780,11 @@ class DescriptorBlock(Descriptor):
     version: int = field(default=16, validator=in_((16,)))
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version = read_fmt("I", fp)[0]
         return cls(version=version, **cls._read_body(fp))  # type: ignore[attr-defined,call-arg]
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.version)
         written += self._write_body(fp)
         written += write_padding(fp, written, padding)
@@ -806,11 +806,11 @@ class DescriptorBlock2(Descriptor):
     data_version: int = field(default=16, validator=in_((16,)))
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         version, data_version = read_fmt("2I", fp)
         return cls(version=version, data_version=data_version, **cls._read_body(fp))  # type: ignore[attr-defined,call-arg]
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "2I", self.version, self.data_version)
         written += self._write_body(fp)
         written += write_padding(fp, written, padding)

--- a/src/psd_tools/psd/document.py
+++ b/src/psd_tools/psd/document.py
@@ -6,7 +6,7 @@ binary structure of a PSD/PSB file.
 """
 
 import logging
-from typing import Any, BinaryIO, Generator, Optional, TypeVar
+from typing import IO, Any, Generator, Optional, TypeVar
 
 from attrs import define, field
 
@@ -75,7 +75,7 @@ class PSD(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T], fp: BinaryIO, encoding: str = "macroman", **kwargs: Any
+        cls: type[T], fp: IO[bytes], encoding: str = "macroman", **kwargs: Any
     ) -> T:
         header = FileHeader.read(fp)
         logger.debug("read %s" % header)
@@ -87,7 +87,7 @@ class PSD(BaseElement):
             ImageData.read(fp),
         )
 
-    def write(self, fp: BinaryIO, encoding: str = "macroman", **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], encoding: str = "macroman", **kwargs: Any) -> int:
         logger.debug("writing %s" % self.header)
         written = self.header.write(fp)
         written += self.color_mode_data.write(fp)

--- a/src/psd_tools/psd/effects_layer.py
+++ b/src/psd_tools/psd/effects_layer.py
@@ -6,7 +6,7 @@ are stored in tagged blocks.
 """
 
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field, astuple
 
@@ -47,11 +47,11 @@ class CommonStateInfo(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_CommonStateInfo], fp: BinaryIO, **kwargs: Any
+        cls: type[T_CommonStateInfo], fp: IO[bytes], **kwargs: Any
     ) -> T_CommonStateInfo:
         return cls(*read_fmt("IB2x", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "IB2x", *astuple(self))
 
 
@@ -88,7 +88,7 @@ class ShadowInfo(BaseElement):
     native_color: Color = field(factory=Color)
 
     @classmethod
-    def read(cls: type[T_ShadowInfo], fp: BinaryIO, **kwargs: Any) -> T_ShadowInfo:
+    def read(cls: type[T_ShadowInfo], fp: IO[bytes], **kwargs: Any) -> T_ShadowInfo:
         # TODO: Check 4-byte = 2-byte int + 2-byte fraction?
         version, blur, intensity, angle, distance = read_fmt("IIIiI", fp)
         color = Color.read(fp)
@@ -111,7 +111,7 @@ class ShadowInfo(BaseElement):
             native_color=native_color,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp,
             "IIIiI",
@@ -147,7 +147,7 @@ class _GlowInfo:
 
     @classmethod
     def _read_body(
-        cls, fp: BinaryIO
+        cls, fp: IO[bytes]
     ) -> tuple[int, int, int, Color, BlendMode, int, int]:
         # TODO: Check 4-byte = 2-byte int + 2-byte fraction?
         version, blur, intensity = read_fmt("III", fp)
@@ -158,7 +158,7 @@ class _GlowInfo:
         enabled, opacity = read_fmt("2B", fp)
         return version, blur, intensity, color, blend_mode, enabled, opacity
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         written = write_fmt(fp, "III", self.version, self.blur, self.intensity)
         written += self.color.write(fp)
         written += write_fmt(
@@ -195,7 +195,7 @@ class OuterGlowInfo(BaseElement, _GlowInfo):
 
     @classmethod
     def read(
-        cls: type[T_OuterGlowInfo], fp: BinaryIO, **kwargs: Any
+        cls: type[T_OuterGlowInfo], fp: IO[bytes], **kwargs: Any
     ) -> T_OuterGlowInfo:
         version, blur, intensity, color, blend_mode, enabled, opacity = cls._read_body(
             fp
@@ -214,7 +214,7 @@ class OuterGlowInfo(BaseElement, _GlowInfo):
             native_color=native_color,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = self._write_body(fp)
         if self.native_color and hasattr(self.native_color, "write"):
             written += self.native_color.write(fp)  # type: ignore[attr-defined]
@@ -251,7 +251,7 @@ class InnerGlowInfo(BaseElement, _GlowInfo):
 
     @classmethod
     def read(
-        cls: type[T_InnerGlowInfo], fp: BinaryIO, **kwargs: Any
+        cls: type[T_InnerGlowInfo], fp: IO[bytes], **kwargs: Any
     ) -> T_InnerGlowInfo:
         version, blur, intensity, color, blend_mode, enabled, opacity = cls._read_body(
             fp
@@ -272,7 +272,7 @@ class InnerGlowInfo(BaseElement, _GlowInfo):
             native_color=native_color,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = self._write_body(fp)
         if self.version >= 2:
             written += write_fmt(fp, "B", self.invert)
@@ -325,7 +325,7 @@ class BevelInfo(BaseElement):
     real_shadow_color: object = None
 
     @classmethod
-    def read(cls: type[T_BevelInfo], fp: BinaryIO, **kwargs: Any) -> T_BevelInfo:
+    def read(cls: type[T_BevelInfo], fp: IO[bytes], **kwargs: Any) -> T_BevelInfo:
         # TODO: Check 4-byte = 2-byte int + 2-byte fraction?
         version, angle, depth, blur = read_fmt("Ii2I", fp)
         signature, highlight_blend_mode = read_fmt("4s4s", fp)
@@ -359,7 +359,7 @@ class BevelInfo(BaseElement):
             real_shadow_color=real_shadow_color,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "Ii2I", self.version, self.angle, self.depth, self.blur)
         written += write_fmt(
             fp,
@@ -411,7 +411,7 @@ class SolidFillInfo(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_SolidFillInfo], fp: BinaryIO, **kwargs: Any
+        cls: type[T_SolidFillInfo], fp: IO[bytes], **kwargs: Any
     ) -> T_SolidFillInfo:
         version = read_fmt("I", fp)[0]
         signature, blend_mode = read_fmt("4s4s", fp)
@@ -428,7 +428,7 @@ class SolidFillInfo(BaseElement):
             native_color=native_color,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I4s4s", self.version, b"8BIM", self.blend_mode.value)
         written += self.color.write(fp)
         written += write_fmt(fp, "2B", self.opacity, self.enabled)
@@ -458,7 +458,7 @@ class EffectsLayer(DictElement):
     }
 
     @classmethod
-    def read(cls: type[T_EffectsLayer], fp: BinaryIO, **kwargs: Any) -> T_EffectsLayer:
+    def read(cls: type[T_EffectsLayer], fp: IO[bytes], **kwargs: Any) -> T_EffectsLayer:
         version, count = read_fmt("2H", fp)
         items = []
         for _ in range(count):
@@ -470,7 +470,7 @@ class EffectsLayer(DictElement):
             items.append((ostype, kls.frombytes(read_length_block(fp))))  # type: ignore[attr-defined]
         return cls(version=version, items=items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "2H", self.version, len(self))
         for key in self:
             written += write_fmt(fp, "4s4s", b"8BIM", key.value)

--- a/src/psd_tools/psd/filter_effects.py
+++ b/src/psd_tools/psd/filter_effects.py
@@ -4,7 +4,7 @@ Filter effects structure.
 
 import io
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field
 
@@ -40,7 +40,7 @@ class FilterEffects(ListElement):
 
     @classmethod
     def read(
-        cls: type[T_FilterEffects], fp: BinaryIO, **kwargs: Any
+        cls: type[T_FilterEffects], fp: IO[bytes], **kwargs: Any
     ) -> T_FilterEffects:
         version = read_fmt("I", fp)[0]
         assert version in (1, 2, 3), "Invalid version %d" % (version)
@@ -50,7 +50,7 @@ class FilterEffects(ListElement):
                 items.append(FilterEffect.read(f))
         return cls(version=version, items=items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.version)
         for item in self:
             written += write_length_block(fp, item.write, fmt="Q", padding=4)
@@ -85,7 +85,7 @@ class FilterEffect(BaseElement):
     extra: object | None = None
 
     @classmethod
-    def read(cls: type[T_FilterEffect], fp: BinaryIO, **kwargs: Any) -> T_FilterEffect:
+    def read(cls: type[T_FilterEffect], fp: IO[bytes], **kwargs: Any) -> T_FilterEffect:
         uuid = read_pascal_string(fp, encoding="ascii", padding=1)
         version = read_fmt("I", fp)[0]
         assert version <= 1, "Invalid version %d" % (version)
@@ -104,7 +104,7 @@ class FilterEffect(BaseElement):
         )
 
     @classmethod
-    def _read_body(cls, fp: BinaryIO) -> tuple[tuple, int, int, list]:
+    def _read_body(cls, fp: IO[bytes]) -> tuple[tuple, int, int, list]:
         rectangle = read_fmt("4i", fp)
         depth, max_channels = read_fmt("2I", fp)
         channels = []
@@ -112,11 +112,11 @@ class FilterEffect(BaseElement):
             channels.append(FilterEffectChannel.read(fp))
         return rectangle, depth, max_channels, channels
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_pascal_string(fp, self.uuid or "", encoding="ascii", padding=1)
         written += write_fmt(fp, "I", self.version)
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             return self._write_body(f)
 
         written += write_length_block(fp, writer, fmt="Q")
@@ -125,7 +125,7 @@ class FilterEffect(BaseElement):
             written += self.extra.write(fp)  # type: ignore[attr-defined]
         return written
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         assert self.rectangle is not None
         assert self.depth is not None
         assert self.max_channels is not None
@@ -153,7 +153,7 @@ class FilterEffectChannel(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_FilterEffectChannel], fp: BinaryIO, **kwargs: Any
+        cls: type[T_FilterEffectChannel], fp: IO[bytes], **kwargs: Any
     ) -> T_FilterEffectChannel:
         is_written = read_fmt("I", fp)[0]
         if is_written == 0:
@@ -166,12 +166,12 @@ class FilterEffectChannel(BaseElement):
             data = f.read()
         return cls(is_written, compression, data)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.is_written)
         if self.is_written == 0:
             return written
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             if self.compression is None:
                 return 0
             length = write_fmt(f, "H", self.compression)
@@ -200,7 +200,7 @@ class FilterEffectExtra(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_FilterEffectExtra], fp: BinaryIO, **kwargs: Any
+        cls: type[T_FilterEffectExtra], fp: IO[bytes], **kwargs: Any
     ) -> T_FilterEffectExtra:
         is_written = read_fmt("B", fp)[0]
         if not is_written:
@@ -220,10 +220,10 @@ class FilterEffectExtra(BaseElement):
             data=data,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "B", self.is_written)
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             length = write_fmt(f, "H", self.compression)
             length += write_bytes(f, self.data)
             return length

--- a/src/psd_tools/psd/header.py
+++ b/src/psd_tools/psd/header.py
@@ -3,7 +3,7 @@ File header structure.
 """
 
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field, astuple
 
@@ -79,8 +79,8 @@ class FileHeader(BaseElement):
             raise ValueError("This is not a PSD or PSB file")
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         return cls(*read_fmt(cls._FORMAT, fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, self._FORMAT, *astuple(self))

--- a/src/psd_tools/psd/image_data.py
+++ b/src/psd_tools/psd/image_data.py
@@ -8,7 +8,7 @@ this is the only place pixels are saved.
 
 import io
 import logging
-from typing import Any, BinaryIO, Sequence, TypeVar
+from typing import IO, Any, Sequence, TypeVar
 
 from attrs import define, field
 
@@ -44,14 +44,14 @@ class ImageData(BaseElement):
     data: bytes = b""
 
     @classmethod
-    def read(cls: type[T], fp: BinaryIO, **kwargs: Any) -> T:
+    def read(cls: type[T], fp: IO[bytes], **kwargs: Any) -> T:
         start_pos = fp.tell()
         compression = Compression(read_fmt("H", fp)[0])
         data = fp.read()  # TODO: Parse data here. Need header.
         logger.debug("  read image data, len=%d" % (fp.tell() - start_pos))
         return cls(compression, data)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         start_pos = fp.tell()
         written = write_fmt(fp, "H", self.compression.value)
         written += write_bytes(fp, self.data)

--- a/src/psd_tools/psd/image_resources.py
+++ b/src/psd_tools/psd/image_resources.py
@@ -62,7 +62,7 @@ The following resources are plain bytes::
 
 import io
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field, astuple
 
@@ -174,7 +174,7 @@ class ImageResources(DictElement):
     @classmethod
     def read(
         cls: type[T_ImageResources],
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         **kwargs: Any,
     ) -> T_ImageResources:
@@ -185,7 +185,7 @@ class ImageResources(DictElement):
 
     @classmethod
     def _read_body(
-        cls: type[T_ImageResources], fp: BinaryIO, *args: Any, **kwargs: Any
+        cls: type[T_ImageResources], fp: IO[bytes], *args: Any, **kwargs: Any
     ) -> T_ImageResources:
         items = []
         while is_readable(fp, 4):
@@ -193,8 +193,8 @@ class ImageResources(DictElement):
             items.append((item.key, item))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, encoding: str = "macroman", **kwargs: Any) -> int:
-        def writer(f: BinaryIO) -> int:
+    def write(self, fp: IO[bytes], encoding: str = "macroman", **kwargs: Any) -> int:
+        def writer(f: IO[bytes]) -> int:
             written = sum(self[key].write(f, encoding) for key in self)
             logger.debug("writing image resources, len=%d" % (written))
             return written
@@ -263,7 +263,7 @@ class ImageResource(BaseElement):
     @classmethod
     def read(
         cls: type[T_ImageResource],
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         **kwargs: Any,
     ) -> T_ImageResource:
@@ -293,13 +293,13 @@ class ImageResource(BaseElement):
             data = raw_data
         return cls(signature, key, name, data)
 
-    def write(self, fp: BinaryIO, encoding: str = "macroman", **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], encoding: str = "macroman", **kwargs: Any) -> int:
         written = write_fmt(
             fp, "4sH", self.signature, getattr(self.key, "value", self.key)
         )
         written += write_pascal_string(fp, self.name, encoding, 2)
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             if hasattr(self.data, "write"):
                 return self.data.write(f, padding=1)
             return write_bytes(f, self.data)
@@ -315,13 +315,13 @@ class AlphaIdentifiers(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "AlphaIdentifiers":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "AlphaIdentifiers":
         items = []
         while is_readable(fp, 4):
             items.append(read_fmt("I", fp)[0])
         return cls(items)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(write_fmt(fp, "I", item) for item in self)
 
 
@@ -332,13 +332,13 @@ class AlphaNamesPascal(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "AlphaNamesPascal":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "AlphaNamesPascal":
         items = []
         while is_readable(fp):
             items.append(read_pascal_string(fp, "macroman", padding=1))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(write_pascal_string(fp, item, padding=1) for item in self)
 
 
@@ -349,13 +349,13 @@ class AlphaNamesUnicode(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "AlphaNamesUnicode":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "AlphaNamesUnicode":
         items = []
         while is_readable(fp):
             items.append(read_unicode_string(fp))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(write_unicode_string(fp, item) for item in self)
 
 
@@ -370,7 +370,7 @@ class DisplayInfo(BaseElement):
     alpha_channels: list = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "DisplayInfo":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "DisplayInfo":
         # ref: https://github.com/MolecularMatters/psd_sdk/blob/311b5c2e3fe04c8cc6a563665e66b19b3fcf8116/src/Psd/PsdParseImageResourcesSection.cpp#L83
         version = read_fmt("I", fp)[0]
         items = []
@@ -378,7 +378,7 @@ class DisplayInfo(BaseElement):
             items.append(AlphaChannel.read(fp))
         return cls(version=version, alpha_channels=items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.version)
         written += sum(item.write(fp) for item in self.alpha_channels)
         return written
@@ -395,12 +395,12 @@ class AlphaChannel(BaseElement):
     mode: AlphaChannelMode = AlphaChannelMode.ALPHA  # type: ignore[assignment]
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "AlphaChannel":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "AlphaChannel":
         vals = read_fmt("6H", fp)
         mode = AlphaChannelMode(read_fmt("B", fp)[0])
         return cls(*vals, mode)  # type: ignore[call-arg]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp, "6H", self.color_space, self.c1, self.c2, self.c3, self.c4, self.opacity
         )
@@ -418,10 +418,10 @@ class Byte(ByteElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "Byte":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "Byte":
         return cls(*read_fmt("B", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "B", self.value)
 
 
@@ -440,7 +440,7 @@ class GridGuidesInfo(BaseElement):
     data: list = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "GridGuidesInfo":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "GridGuidesInfo":
         version, horizontal, vertical, count = read_fmt("4I", fp)
         items = []
         for _ in range(count):
@@ -452,7 +452,7 @@ class GridGuidesInfo(BaseElement):
             data=items,  # type: ignore[arg-type]
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp, "4I", self.version, self.horizontal, self.vertical, len(self.data)
         )
@@ -469,13 +469,13 @@ class HalftoneScreens(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "HalftoneScreens":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "HalftoneScreens":
         items = []
         while is_readable(fp, 18):
             items.append(HalftoneScreen.read(fp))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(item.write(fp) for item in self)
 
 
@@ -500,14 +500,14 @@ class HalftoneScreen(BaseElement):
     use_printer: bool = False
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "HalftoneScreen":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "HalftoneScreen":
         freq = float(read_fmt("I", fp)[0]) / 0x10000
         unit = read_fmt("H", fp)[0]
         angle = float(read_fmt("i", fp)[0]) / 0x10000
         shape, use_accurate, use_printer = read_fmt("H4x2?", fp)
         return cls(freq, unit, angle, shape, use_accurate, use_printer)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", int(self.freq * 0x10000))
         written += write_fmt(fp, "H", self.unit)
         written += write_fmt(fp, "i", int(self.angle * 0x10000))
@@ -526,10 +526,10 @@ class Integer(IntegerElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "Integer":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "Integer":
         return cls(*read_fmt("i", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "i", self.value)
 
 
@@ -540,13 +540,13 @@ class LayerGroupEnabledIDs(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "LayerGroupEnabledIDs":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "LayerGroupEnabledIDs":
         items = []
         while is_readable(fp, 1):
             items.append(read_fmt("B", fp)[0])
         return cls(items)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(write_fmt(fp, "B", item) for item in self)
 
 
@@ -557,13 +557,13 @@ class LayerGroupInfo(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "LayerGroupInfo":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "LayerGroupInfo":
         items = []
         while is_readable(fp, 2):
             items.append(read_fmt("H", fp)[0])
         return cls(items)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(write_fmt(fp, "H", item) for item in self)
 
 
@@ -574,11 +574,11 @@ class LayerSelectionIDs(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "LayerSelectionIDs":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "LayerSelectionIDs":
         count = read_fmt("H", fp)[0]
         return cls(read_fmt("I", fp)[0] for _ in range(count))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "H", len(self))
         written += sum(write_fmt(fp, "I", item) for item in self)
         return written
@@ -593,10 +593,10 @@ class ShortInteger(ShortIntegerElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "ShortInteger":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "ShortInteger":
         return cls(*read_fmt("H", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "H", self.value)
 
 
@@ -608,10 +608,10 @@ class PascalString(ValueElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PascalString":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PascalString":
         return cls(read_pascal_string(fp, "macroman"))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_pascal_string(fp, self.value, "macroman", padding=1)  # type: ignore[arg-type]
 
 
@@ -627,11 +627,11 @@ class PixelAspectRatio(NumericElement):
     version: int = 1
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PixelAspectRatio":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PixelAspectRatio":
         version, value = read_fmt("Id", fp)
         return cls(version=version, value=value)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "Id", self.version, self.value)
 
 
@@ -663,7 +663,7 @@ class PrintFlags(BaseElement):
     print_flags: bool | None = None  # Not existing for old versions.
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PrintFlags":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PrintFlags":
         values = read_fmt("8?", fp)
         print_flags_value = read_fmt("?", fp)[0] if is_readable(fp) else None
         return cls(
@@ -678,7 +678,7 @@ class PrintFlags(BaseElement):
             print_flags=print_flags_value,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         values = astuple(self)
         if self.print_flags is None:
             values = values[:-1]
@@ -703,10 +703,10 @@ class PrintFlagsInfo(BaseElement):
     bleed_width_scale: int = 0
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PrintFlagsInfo":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PrintFlagsInfo":
         return cls(*read_fmt("HBxIH", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "HBxIH", *astuple(self))
 
 
@@ -732,10 +732,10 @@ class PrintScale(BaseElement):
     scale: float = 0.0
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PrintScale":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PrintScale":
         return cls(*read_fmt("H3f", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "H3f", self.style.value, self.x, self.y, self.scale)
 
 
@@ -761,10 +761,10 @@ class ResoulutionInfo(BaseElement):
     height_unit: int = 0
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "ResoulutionInfo":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "ResoulutionInfo":
         return cls(*read_fmt("I2HI2H", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "I2HI2H", *astuple(self))
 
 
@@ -782,14 +782,14 @@ class Slices(BaseElement):
     data: object = None
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "Slices":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "Slices":
         version = read_fmt("I", fp)[0]
         assert version in (6, 7, 8), "Invalid version %d" % (version)
         if version == 6:
             return cls(version=version, data=SlicesV6.read(fp))
         return cls(version=version, data=DescriptorBlock.read(fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.version)
         if hasattr(self.data, "write"):
             written += self.data.write(fp, padding=1)
@@ -811,14 +811,14 @@ class SlicesV6(BaseElement):
     items: list = field(factory=list, converter=list)
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "SlicesV6":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "SlicesV6":
         bbox = read_fmt("4I", fp)
         name = read_unicode_string(fp)
         count = read_fmt("I", fp)[0]
         items = [SliceV6.read(fp) for _ in range(count)]
         return cls(bbox=bbox, name=name, items=items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "4I", *self.bbox)
         written += write_unicode_string(fp, self.name)
         written += write_fmt(fp, "I", len(self.items))
@@ -875,7 +875,7 @@ class SliceV6(BaseElement):
     data: object = None
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "SliceV6":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "SliceV6":
         slice_id, group_id, origin = read_fmt("3I", fp)
         associated_id = read_fmt("I", fp)[0] if origin == 1 else None
         name = read_unicode_string(fp)
@@ -928,7 +928,7 @@ class SliceV6(BaseElement):
             data=data,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "3I", self.slice_id, self.group_id, self.origin)
         if self.origin == 1 and self.associated_id is not None:
             written += write_fmt(fp, "I", self.associated_id)
@@ -980,12 +980,12 @@ class ThumbnailResource(BaseElement):
     data: bytes = b""
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "ThumbnailResource":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "ThumbnailResource":
         fmt, width, height, row, total_size, size, bits, planes = read_fmt("6I2H", fp)
         data = fp.read(size)
         return cls(fmt, width, height, row, total_size, bits, planes, data)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp,
             "6I2H",
@@ -1016,13 +1016,13 @@ class TransferFunctions(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "TransferFunctions":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "TransferFunctions":
         items = []
         while is_readable(fp, 28):
             items.append(TransferFunction.read(fp))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return sum(item.write(fp) for item in self)
 
 
@@ -1050,12 +1050,12 @@ class TransferFunction(BaseElement):
     override: int = 0
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "TransferFunction":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "TransferFunction":
         curve = read_fmt("13h", fp)
         override = read_fmt("H", fp)[0]
         return cls(curve=curve, override=override)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "13h", *self.curve)
         written += write_fmt(fp, "H", self.override)
         return written
@@ -1068,14 +1068,14 @@ class URLList(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "URLList":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "URLList":
         count = read_fmt("I", fp)[0]
         items = []
         for _ in range(count):
             items.append(URLItem.read(fp))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", len(self))
         written += sum(item.write(fp) for item in self)
         return written
@@ -1096,12 +1096,12 @@ class URLItem(BaseElement):
     name: str = ""
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "URLItem":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "URLItem":
         number, id = read_fmt("2I", fp)
         name = read_unicode_string(fp)
         return cls(number, id, name)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "2I", self.number, self.id)
         written += write_unicode_string(fp, self.name)
         return written
@@ -1127,14 +1127,14 @@ class VersionInfo(BaseElement):
     file_version: int = 1
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "VersionInfo":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "VersionInfo":
         version, has_composite = read_fmt("I?", fp)
         writer = read_unicode_string(fp)
         reader = read_unicode_string(fp)
         file_version = read_fmt("I", fp)[0]
         return cls(version, has_composite, writer, reader, file_version)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I?", self.version, self.has_composite)
         written += write_unicode_string(fp, self.writer)
         written += write_unicode_string(fp, self.reader)

--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -60,7 +60,7 @@ API which provides easier access to this data.
 
 import io
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field, astuple
 
@@ -133,7 +133,7 @@ class LayerAndMaskInformation(BaseElement):
     @classmethod
     def read(
         cls: type[T_LayerAndMaskInformation],
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         **kwargs: Any,
@@ -159,7 +159,7 @@ class LayerAndMaskInformation(BaseElement):
     @classmethod
     def _read_body(
         cls: type[T_LayerAndMaskInformation],
-        fp: BinaryIO,
+        fp: IO[bytes],
         end_pos: int,
         encoding: str,
         version: int,
@@ -181,13 +181,13 @@ class LayerAndMaskInformation(BaseElement):
 
     def write(
         self,
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         padding: int = 4,
         **kwargs: Any,
     ) -> int:
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             written = self._write_body(f, encoding, version, padding)
             logger.debug("writing layer and mask info, len=%d" % (written))
             return written
@@ -196,7 +196,7 @@ class LayerAndMaskInformation(BaseElement):
         return write_length_block(fp, writer, fmt=fmt)
 
     def _write_body(
-        self, fp: BinaryIO, encoding: str, version: int, padding: int
+        self, fp: IO[bytes], encoding: str, version: int, padding: int
     ) -> int:
         written = 0
         if self.layer_info:
@@ -235,7 +235,7 @@ class LayerInfo(BaseElement):
     @classmethod
     def read(
         cls: type[T_LayerInfo],
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         **kwargs: Any,
@@ -253,7 +253,7 @@ class LayerInfo(BaseElement):
 
     @classmethod
     def _read_body(
-        cls: type[T_LayerInfo], fp: BinaryIO, encoding: str, version: int
+        cls: type[T_LayerInfo], fp: IO[bytes], encoding: str, version: int
     ) -> T_LayerInfo:
         start_pos = fp.tell()
         layer_count = read_fmt("h", fp)[0]
@@ -268,13 +268,13 @@ class LayerInfo(BaseElement):
 
     def write(
         self,
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         padding: int = 4,
         **kwargs: Any,
     ) -> int:
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             written = self._write_body(f, encoding, version, padding)
             logger.debug("writing layer info, len=%d" % (written))
             return written
@@ -285,7 +285,7 @@ class LayerInfo(BaseElement):
         return write_length_block(fp, writer, fmt=fmt)
 
     def _write_body(
-        self, fp: BinaryIO, encoding: str, version: int, padding: int
+        self, fp: IO[bytes], encoding: str, version: int, padding: int
     ) -> int:
         start_pos = fp.tell()
         written = write_fmt(fp, "h", self.layer_count)
@@ -317,7 +317,7 @@ class LayerInfoBlock(LayerInfo):
     @classmethod
     def read(
         cls: type[T_LayerInfo],
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         **kwargs: Any,
@@ -326,7 +326,7 @@ class LayerInfoBlock(LayerInfo):
 
     def write(
         self,
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         padding: int = 4,
@@ -359,12 +359,12 @@ class ChannelInfo(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_ChannelInfo], fp: BinaryIO, version: int = 1, **kwargs: Any
+        cls: type[T_ChannelInfo], fp: IO[bytes], version: int = 1, **kwargs: Any
     ) -> T_ChannelInfo:
         values = read_fmt(("hI", "hQ")[version - 1], fp)
         return cls(id=values[0], length=values[1])
 
-    def write(self, fp: BinaryIO, version: int = 1, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], version: int = 1, **kwargs: Any) -> int:
         return write_fmt(fp, ("hI", "hQ")[version - 1], *astuple(self))
 
 
@@ -390,7 +390,7 @@ class LayerFlags(BaseElement):
     undocumented_3: bool = field(default=False, repr=False)
 
     @classmethod
-    def read(cls: type[T_LayerFlags], fp: BinaryIO, **kwargs: Any) -> T_LayerFlags:
+    def read(cls: type[T_LayerFlags], fp: IO[bytes], **kwargs: Any) -> T_LayerFlags:
         flags = read_fmt("B", fp)[0]
         return cls(
             bool(flags & 1),
@@ -403,7 +403,7 @@ class LayerFlags(BaseElement):
             bool(flags & 128),
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         flags = (
             (self.transparency_protected * 1)
             | ((not self.visible) * 2)
@@ -447,7 +447,7 @@ class LayerBlendingRanges(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_LayerBlendingRanges], fp: BinaryIO, **kwargs: Any
+        cls: type[T_LayerBlendingRanges], fp: IO[bytes], **kwargs: Any
     ) -> T_LayerBlendingRanges:
         data = read_length_block(fp)
         if len(data) == 0:
@@ -458,9 +458,9 @@ class LayerBlendingRanges(BaseElement):
 
     @classmethod
     def _read_body(
-        cls: type[T_LayerBlendingRanges], fp: BinaryIO
+        cls: type[T_LayerBlendingRanges], fp: IO[bytes]
     ) -> T_LayerBlendingRanges:
-        def read_channel_range(f: BinaryIO) -> list[tuple[int, int]]:
+        def read_channel_range(f: IO[bytes]) -> list[tuple[int, int]]:
             values = read_fmt("4H", f)
             return [values[0:2], values[2:4]]  # type: ignore[return-value]
 
@@ -470,10 +470,10 @@ class LayerBlendingRanges(BaseElement):
             channel_ranges.append(read_channel_range(fp))
         return cls(composite_ranges, channel_ranges)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_length_block(fp, lambda f: self._write_body(f))
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         written = 0
         if self.composite_ranges is not None:
             for x in self.composite_ranges:
@@ -493,7 +493,7 @@ class LayerRecords(ListElement):
     @classmethod
     def read(  # type: ignore[override]
         cls: type[T_LayerRecords],
-        fp: BinaryIO,
+        fp: IO[bytes],
         layer_count: int,
         encoding: str = "macroman",
         version: int = 1,
@@ -590,7 +590,7 @@ class LayerRecord(BaseElement):
     @classmethod
     def read(
         cls: type[T_LayerRecord],
-        fp: BinaryIO,
+        fp: IO[bytes],
         encoding: str = "macroman",
         version: int = 1,
         **kwargs: Any,
@@ -632,7 +632,7 @@ class LayerRecord(BaseElement):
 
     @classmethod
     def _read_extra(
-        cls, fp: BinaryIO, encoding: str, version: int
+        cls, fp: IO[bytes], encoding: str, version: int
     ) -> tuple["MaskData | None", LayerBlendingRanges, str, TaggedBlocks]:
         mask_data = MaskData.read(fp)
         blending_ranges = LayerBlendingRanges.read(fp)
@@ -641,7 +641,7 @@ class LayerRecord(BaseElement):
         return mask_data, blending_ranges, name, tagged_blocks
 
     def write(
-        self, fp: BinaryIO, encoding: str = "macroman", version: int = 1, **kwargs: Any
+        self, fp: IO[bytes], encoding: str = "macroman", version: int = 1, **kwargs: Any
     ) -> int:
         start_pos = fp.tell()
         written = write_fmt(
@@ -664,7 +664,7 @@ class LayerRecord(BaseElement):
         )
         written += self.flags.write(fp)
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             written = self._write_extra(f, encoding, version)
             logger.debug("  wrote layer record, len=%d" % (fp.tell() - start_pos))
             return written
@@ -672,7 +672,7 @@ class LayerRecord(BaseElement):
         written += write_length_block(fp, writer, fmt="xI")
         return written
 
-    def _write_extra(self, fp: BinaryIO, encoding: str, version: int) -> int:
+    def _write_extra(self, fp: IO[bytes], encoding: str, version: int) -> int:
         written = 0
         if self.mask_data and hasattr(self.mask_data, "write"):
             written += self.mask_data.write(fp)  # type: ignore[attr-defined]
@@ -745,7 +745,7 @@ class MaskFlags(BaseElement):
     undocumented_3: bool = field(default=False, repr=False)
 
     @classmethod
-    def read(cls: type[T_MaskFlags], fp: BinaryIO, **kwargs: Any) -> T_MaskFlags:
+    def read(cls: type[T_MaskFlags], fp: IO[bytes], **kwargs: Any) -> T_MaskFlags:
         flags = read_fmt("B", fp)[0]
         return cls(
             bool(flags & 1),
@@ -758,7 +758,7 @@ class MaskFlags(BaseElement):
             bool(flags & 128),
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         flags = (
             (self.pos_relative_to_layer * 1)
             | (self.mask_disabled * 2)
@@ -847,7 +847,7 @@ class MaskData(BaseElement):
     real_right: int | None = None
 
     @classmethod
-    def read(cls: type[T_MaskData], fp: BinaryIO, **kwargs: Any) -> T_MaskData:  # type: ignore[return]
+    def read(cls: type[T_MaskData], fp: IO[bytes], **kwargs: Any) -> T_MaskData:  # type: ignore[return]
         data = read_length_block(fp)
         if len(data) == 0:
             return None  # type: ignore[return-value]
@@ -856,7 +856,7 @@ class MaskData(BaseElement):
             return cls._read_body(f, len(data))
 
     @classmethod
-    def _read_body(cls: type[T_MaskData], fp: BinaryIO, length: int) -> T_MaskData:
+    def _read_body(cls: type[T_MaskData], fp: IO[bytes], length: int) -> T_MaskData:
         top, left, bottom, right, background_color = read_fmt("4iB", fp)
         flags = MaskFlags.read(fp)
 
@@ -894,10 +894,10 @@ class MaskData(BaseElement):
             real_right=real_right,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_length_block(fp, lambda f: self._write_body(f))
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         written = write_fmt(
             fp,
             "4iB",
@@ -970,7 +970,7 @@ class MaskParameters(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_MaskParameters], fp: BinaryIO, **kwargs: Any
+        cls: type[T_MaskParameters], fp: IO[bytes], **kwargs: Any
     ) -> T_MaskParameters:
         parameters = read_fmt("B", fp)[0]
         user_mask_density = None
@@ -999,7 +999,7 @@ class MaskParameters(BaseElement):
             vector_mask_feather,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = 0
         written += write_fmt(
             fp,
@@ -1036,7 +1036,7 @@ class ChannelImageData(ListElement):
     @classmethod
     def read(
         cls: type[T_ChannelImageData],
-        fp: BinaryIO,
+        fp: IO[bytes],
         layer_records: "LayerRecords | None" = None,
         **kwargs: Any,
     ) -> T_ChannelImageData:
@@ -1048,7 +1048,7 @@ class ChannelImageData(ListElement):
         logger.debug("  read channel image data, len=%d" % (fp.tell() - start_pos))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         start_pos = fp.tell()
         written = sum(item.write(fp) for item in self)
         logger.debug("  wrote channel image data, len=%d" % (fp.tell() - start_pos))
@@ -1070,7 +1070,7 @@ class ChannelDataList(ListElement):
     @classmethod
     def read(  # type: ignore[override]
         cls: type[T_ChannelDataList],
-        fp: BinaryIO,
+        fp: IO[bytes],
         channel_info: list["ChannelInfo"],
         **kwargs: Any,
     ) -> T_ChannelDataList:
@@ -1126,7 +1126,7 @@ class ChannelData(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_ChannelData], fp: BinaryIO, length: int = 0, **kwargs: Any
+        cls: type[T_ChannelData], fp: IO[bytes], length: int = 0, **kwargs: Any
     ) -> T_ChannelData:
         compression = Compression(read_fmt("H", fp)[0])
         # length is c.length - 2 (the 2-byte compression header is excluded).
@@ -1140,7 +1140,7 @@ class ChannelData(BaseElement):
         data = fp.read(length)
         return cls(compression=compression, data=data)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "H", self.compression.value)
         written += write_bytes(fp, self.data)
         # written += write_padding(fp, written, 2)  # Seems no padding here.
@@ -1211,7 +1211,7 @@ class GlobalLayerMaskInfo(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_GlobalLayerMaskInfo], fp: BinaryIO, **kwargs: Any
+        cls: type[T_GlobalLayerMaskInfo], fp: IO[bytes], **kwargs: Any
     ) -> T_GlobalLayerMaskInfo:
         pos = fp.tell()
         data = read_length_block(fp)  # fmt?
@@ -1231,16 +1231,16 @@ class GlobalLayerMaskInfo(BaseElement):
 
     @classmethod
     def _read_body(
-        cls: type[T_GlobalLayerMaskInfo], fp: BinaryIO
+        cls: type[T_GlobalLayerMaskInfo], fp: IO[bytes]
     ) -> T_GlobalLayerMaskInfo:
         overlay_color = list(read_fmt("5H", fp))
         opacity, kind = read_fmt("HB", fp)
         return cls(overlay_color, opacity, kind)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_length_block(fp, lambda f: self._write_body(f))
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         written = 0
         if self.overlay_color is not None:
             written = write_fmt(fp, "5H", *self.overlay_color)

--- a/src/psd_tools/psd/linked_layer.py
+++ b/src/psd_tools/psd/linked_layer.py
@@ -4,7 +4,7 @@ Linked layer structure.
 
 import io
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field
 
@@ -38,7 +38,7 @@ class LinkedLayers(ListElement):
     """
 
     @classmethod
-    def read(cls: type[T_LinkedLayers], fp: BinaryIO, **kwargs: Any) -> T_LinkedLayers:
+    def read(cls: type[T_LinkedLayers], fp: IO[bytes], **kwargs: Any) -> T_LinkedLayers:
         items = []
         while is_readable(fp, 8):
             data = read_length_block(fp, fmt="Q", padding=4)
@@ -46,7 +46,7 @@ class LinkedLayers(ListElement):
                 items.append(LinkedLayer.read(f))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = 0
         for item in self:
             written += write_length_block(fp, item.write, fmt="Q", padding=4)
@@ -92,7 +92,7 @@ class LinkedLayer(BaseElement):
     lock_state: int | None = None
 
     @classmethod
-    def read(cls: type[T_LinkedLayer], fp: BinaryIO, **kwargs: Any) -> T_LinkedLayer:
+    def read(cls: type[T_LinkedLayer], fp: IO[bytes], **kwargs: Any) -> T_LinkedLayer:
         kind = LinkedLayerType(read_fmt("4s", fp)[0])
         version = read_fmt("I", fp)[0]
         assert 1 <= version and version <= 8, "Invalid version %d" % (version)
@@ -152,7 +152,7 @@ class LinkedLayer(BaseElement):
             lock_state,
         )
 
-    def write(self, fp: BinaryIO, padding: int = 1, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 1, **kwargs: Any) -> int:
         written = write_fmt(fp, "4sI", self.kind.value, self.version)
         written += write_pascal_string(fp, self.uuid, "macroman", padding=1)
         written += write_unicode_string(fp, self.filename)

--- a/src/psd_tools/psd/patterns.py
+++ b/src/psd_tools/psd/patterns.py
@@ -4,7 +4,7 @@ Patterns structure.
 
 import io
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from typing_extensions import Self
 
@@ -40,7 +40,7 @@ class Patterns(ListElement):
     """
 
     @classmethod
-    def read(cls: type[T_Patterns], fp: BinaryIO, **kwargs: Any) -> T_Patterns:
+    def read(cls: type[T_Patterns], fp: IO[bytes], **kwargs: Any) -> T_Patterns:
         items = []
         while is_readable(fp, 4):
             data = read_length_block(fp, padding=4)
@@ -48,7 +48,7 @@ class Patterns(ListElement):
                 items.append(Pattern.read(f))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = 0
         for item in self:
             written += write_length_block(fp, item.write, padding=4)
@@ -97,7 +97,7 @@ class Pattern(BaseElement):
     data: "VirtualMemoryArrayList" = field(default=None)
 
     @classmethod
-    def read(cls: type[T_Pattern], fp: BinaryIO, **kwargs: Any) -> T_Pattern:
+    def read(cls: type[T_Pattern], fp: IO[bytes], **kwargs: Any) -> T_Pattern:
         version = read_fmt("I", fp)[0]
         assert version == 1, "Invalid version %d" % (version)
         image_mode = ColorMode(read_fmt("I", fp)[0])
@@ -112,7 +112,7 @@ class Pattern(BaseElement):
         data = VirtualMemoryArrayList.read(fp)
         return cls(version, image_mode, point, name, pattern_id, color_table, data)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "2I", self.version, self.image_mode.value)
         written += write_fmt(fp, "2h", *self.point)
         written += write_unicode_string(fp, self.name)
@@ -145,7 +145,7 @@ class VirtualMemoryArrayList(BaseElement):
     channels: list["VirtualMemoryArray"] = field(factory=list)
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> Self:
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> Self:
         version = read_fmt("I", fp)[0]
         assert version == 3, "Invalid version %d" % (version)
 
@@ -159,11 +159,11 @@ class VirtualMemoryArrayList(BaseElement):
 
         return cls(version, rectangle, channels)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.version)
         return written + write_length_block(fp, lambda f: self._write_body(f))
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         written = write_fmt(fp, "4I", *self.rectangle)
         written += write_fmt(fp, "I", len(self.channels) - 2)
         for channel in self.channels:
@@ -194,7 +194,7 @@ class VirtualMemoryArray(BaseElement):
     data: bytes = b""
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> Self:
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> Self:
         is_written = read_fmt("I", fp)[0]
         if is_written == 0:
             return cls(is_written=is_written)
@@ -207,7 +207,7 @@ class VirtualMemoryArray(BaseElement):
         data = fp.read(length - 23)
         return cls(is_written, depth, rectangle, pixel_depth, compression, data)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.is_written)
         if self.is_written == 0:
             return written
@@ -217,7 +217,7 @@ class VirtualMemoryArray(BaseElement):
 
         return written + write_length_block(fp, lambda f: self._write_body(f))
 
-    def _write_body(self, fp: BinaryIO) -> int:
+    def _write_body(self, fp: IO[bytes]) -> int:
         assert self.depth is not None
         assert self.rectangle is not None
         written = write_fmt(fp, "I", self.depth)

--- a/src/psd_tools/psd/tagged_blocks.py
+++ b/src/psd_tools/psd/tagged_blocks.py
@@ -9,7 +9,7 @@ Tagged block data structure.
 
 import io
 import logging
-from typing import Any, BinaryIO, TypeVar
+from typing import IO, Any, TypeVar
 
 from attrs import define, field
 
@@ -174,7 +174,7 @@ class TaggedBlocks(DictElement):
     @classmethod
     def read(
         cls: type[T_TaggedBlocks],
-        fp: BinaryIO,
+        fp: IO[bytes],
         version: int = 1,
         padding: int = 1,
         end_pos: int | None = None,
@@ -264,7 +264,7 @@ class TaggedBlock(BaseElement):
     @classmethod
     def read(
         cls: type[T_TaggedBlock],
-        fp: BinaryIO,
+        fp: IO[bytes],
         version: int = 1,
         padding: int = 1,
         **kwargs: Any,
@@ -300,12 +300,12 @@ class TaggedBlock(BaseElement):
         return cls(signature, key, data)
 
     def write(
-        self, fp: BinaryIO, version: int = 1, padding: int = 1, **kwargs: Any
+        self, fp: IO[bytes], version: int = 1, padding: int = 1, **kwargs: Any
     ) -> int:
         key = self.key if isinstance(self.key, bytes) else self.key.value
         written = write_fmt(fp, "4s4s", self.signature, key)
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             if hasattr(self.data, "write"):
                 # It seems padding size applies at the block level here.
                 inner_padding = 1 if padding == 4 else 4
@@ -335,7 +335,7 @@ class Annotations(ListElement):
     minor_version: int = 1
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "Annotations":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "Annotations":
         major_version, minor_version, count = read_fmt("2HI", fp)
         items = []
         for _ in range(count):
@@ -349,7 +349,7 @@ class Annotations(ListElement):
             items=items,  # type: ignore[arg-type]
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp, "2HI", self.major_version, self.minor_version, len(self)
         )
@@ -384,7 +384,7 @@ class Annotation(BaseElement):
     data: bytes = b""
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "Annotation":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "Annotation":
         kind, is_open, flags, optional_blocks = read_fmt("4s2BH", fp)
         icon_location = read_fmt("4i", fp)
         popup_location = read_fmt("4i", fp)
@@ -409,7 +409,7 @@ class Annotation(BaseElement):
             data,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp, "4s2BH", self.kind, self.is_open, self.flags, self.optional_blocks
         )
@@ -437,10 +437,10 @@ class Bytes(ValueElement):
     value: bytes = b"\x00\x00\x00\x00"
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "Bytes":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "Bytes":
         return cls(fp.read(4))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_bytes(fp, self.value)
 
 
@@ -454,13 +454,13 @@ class ChannelBlendingRestrictionsSetting(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "ChannelBlendingRestrictionsSetting":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "ChannelBlendingRestrictionsSetting":
         items = []
         while is_readable(fp, 4):
             items.append(read_fmt("I", fp)[0])
         return cls(items)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "%dI" % len(self), *self._items)
 
 
@@ -478,12 +478,12 @@ class FilterMask(BaseElement):
     opacity: int = 0
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "FilterMask":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "FilterMask":
         color = Color.read(fp)
         opacity = read_fmt("H", fp)[0]
         return cls(color, opacity)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = self.color.write(fp)
         written += write_fmt(fp, "H", self.opacity)
         return written
@@ -496,14 +496,14 @@ class MetadataSettings(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "MetadataSettings":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "MetadataSettings":
         count = read_fmt("I", fp)[0]
         items = []
         for _ in range(count):
             items.append(MetadataSetting.read(fp))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", len(self))
         written += sum(item.write(fp) for item in self)
         return written
@@ -525,7 +525,7 @@ class MetadataSetting(BaseElement):
     data: bytes = b""
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "MetadataSetting":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "MetadataSetting":
         signature = read_fmt("4s", fp)[0]
         assert signature in cls._KNOWN_SIGNATURES, "Invalid signature %r" % signature
         key, copy_on_sheet = read_fmt("4s?3x", fp)
@@ -541,10 +541,10 @@ class MetadataSetting(BaseElement):
             data = data
         return cls(signature, key, copy_on_sheet, data)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "4s4s?3x", self.signature, self.key, self.copy_on_sheet)
 
-        def writer(f: BinaryIO) -> int:
+        def writer(f: IO[bytes]) -> int:
             if hasattr(self.data, "write"):
                 return self.data.write(f, padding=4)
             elif isinstance(self.data, int):
@@ -563,13 +563,13 @@ class PixelSourceData2(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PixelSourceData2":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PixelSourceData2":
         items = []
         while is_readable(fp, 8):
             items.append(read_length_block(fp, fmt="Q"))
         return cls(items)  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = 0
         for item in self:
             written += write_length_block(
@@ -602,7 +602,7 @@ class PlacedLayerData(BaseElement):
     warp: object = None
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "PlacedLayerData":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "PlacedLayerData":
         kind, version = read_fmt("4sI", fp)
         uuid_str = read_pascal_string(fp, "macroman", padding=1)
         page, total_pages, anti_alias, layer_type = read_fmt("4I", fp)
@@ -620,7 +620,7 @@ class PlacedLayerData(BaseElement):
             warp,
         )
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "4sI", self.kind, self.version)
         uuid_str = (
             self.uuid.decode("macroman") if isinstance(self.uuid, bytes) else self.uuid
@@ -678,10 +678,10 @@ class ReferencePoint(ListElement):
     """
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "ReferencePoint":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "ReferencePoint":
         return cls(list(read_fmt("2d", fp)))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "2d", *self._items)
 
 
@@ -707,7 +707,7 @@ class SectionDividerSetting(BaseElement):
     sub_type: int | None = None
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "SectionDividerSetting":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "SectionDividerSetting":
         kind = SectionDivider(read_fmt("I", fp)[0])
         signature, blend_mode = None, None
         if is_readable(fp, 8):
@@ -719,7 +719,7 @@ class SectionDividerSetting(BaseElement):
             sub_type = read_fmt("I", fp)[0]
         return cls(kind, signature=signature, blend_mode=blend_mode, sub_type=sub_type)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "I", self.kind.value)
         if self.blend_mode:
             if self.signature is None:
@@ -753,10 +753,10 @@ class SheetColorSetting(ValueElement):
     )
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "SheetColorSetting":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "SheetColorSetting":
         return cls(SheetColorType(*read_fmt("H6x", fp)))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "H6x", self.value.value)
 
 
@@ -777,12 +777,12 @@ class SmartObjectLayerData(BaseElement):
     data: DescriptorBlock = field(factory=DescriptorBlock)
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "SmartObjectLayerData":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "SmartObjectLayerData":
         kind, version = read_fmt("4sI", fp)
         data = DescriptorBlock.read(fp)
         return cls(kind, version, data)
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "4sI", self.kind, self.version)
         written += self.data.write(fp, padding=1)
         written += write_padding(fp, written, padding)
@@ -822,7 +822,7 @@ class TypeToolObjectSetting(BaseElement):
     bottom: int = 0
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "TypeToolObjectSetting":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "TypeToolObjectSetting":
         version = read_fmt("H", fp)[0]
         transform = read_fmt("6d", fp)
         text_version = read_fmt("H", fp)[0]
@@ -851,7 +851,7 @@ class TypeToolObjectSetting(BaseElement):
             bottom,
         )
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "H6d", self.version, *self.transform)
         written += write_fmt(fp, "H", self.text_version)
         written += self.text_data.write(fp, padding=1)
@@ -878,12 +878,12 @@ class UserMask(BaseElement):
     flag: int = 128
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> "UserMask":
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> "UserMask":
         color = Color.read(fp)
         opacity, flag = read_fmt("HBx", fp)
         return cls(color, opacity, flag)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = self.color.write(fp)
         written += write_fmt(fp, "HBx", self.opacity, self.flag)
         return written

--- a/src/psd_tools/psd/vector.py
+++ b/src/psd_tools/psd/vector.py
@@ -3,7 +3,7 @@ Vector mask, path, and stroke structure.
 """
 
 import logging
-from typing import Any, BinaryIO, Sequence, TypeVar
+from typing import IO, Any, Sequence, TypeVar
 
 from typing_extensions import Self
 
@@ -52,7 +52,7 @@ class Path(ListElement):
     """
 
     @classmethod
-    def read(cls: type[T_Path], fp: BinaryIO, **kwargs: Any) -> T_Path:
+    def read(cls: type[T_Path], fp: IO[bytes], **kwargs: Any) -> T_Path:
         items = []
         while is_readable(fp, 26):
             selector = PathResourceID(read_fmt("H", fp)[0])
@@ -61,7 +61,7 @@ class Path(ListElement):
             items.append(kls.read(fp))
         return cls(items)
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = 0
         for item in self:
             written += write_fmt(fp, "H", item.selector.value)
@@ -99,7 +99,7 @@ class Subpath(ListElement):
     _unknown3: bytes = field(default=b"\x00" * 10, repr=False)
 
     @classmethod
-    def read(cls: type[T_Subpath], fp: BinaryIO, **kwargs: Any) -> T_Subpath:
+    def read(cls: type[T_Subpath], fp: IO[bytes], **kwargs: Any) -> T_Subpath:
         items = []
         length, operation, _unknown1, _unknown2, index, _unknown3 = read_fmt(
             "HhH2I10s", fp
@@ -118,7 +118,7 @@ class Subpath(ListElement):
             unknown3=_unknown3,
         )
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(
             fp,
             "HhH2I10s",
@@ -182,13 +182,13 @@ class Knot(BaseElement):
     leaving: tuple = (0.0,)
 
     @classmethod
-    def read(cls: type[T_Knot], fp: BinaryIO, **kwargs: Any) -> T_Knot:
+    def read(cls: type[T_Knot], fp: IO[bytes], **kwargs: Any) -> T_Knot:
         preceding = decode_fixed_point(read_fmt("2i", fp))
         anchor = decode_fixed_point(read_fmt("2i", fp))
         leaving = decode_fixed_point(read_fmt("2i", fp))
         return cls(preceding, anchor, leaving)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         values = self.preceding + self.anchor + self.leaving
         return write_fmt(fp, "6i", *encode_fixed_point(values))
 
@@ -233,11 +233,11 @@ class PathFillRule(BaseElement):
     """
 
     @classmethod
-    def read(cls: type[T_PathFillRule], fp: BinaryIO, **kwargs: Any) -> T_PathFillRule:
+    def read(cls: type[T_PathFillRule], fp: IO[bytes], **kwargs: Any) -> T_PathFillRule:
         read_fmt("24x", fp)
         return cls()
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "24x")
 
 
@@ -276,11 +276,11 @@ class ClipboardRecord(BaseElement):
 
     @classmethod
     def read(
-        cls: type[T_ClipboardRecord], fp: BinaryIO, **kwargs: Any
+        cls: type[T_ClipboardRecord], fp: IO[bytes], **kwargs: Any
     ) -> T_ClipboardRecord:
         return cls(*decode_fixed_point(read_fmt("5i4x", fp)))  # type: ignore[arg-type]
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "5i4x", *encode_fixed_point(astuple(self)))
 
 
@@ -299,10 +299,10 @@ class InitialFillRule(ValueElement):
     value: int = field(default=0, converter=int)
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> Self:
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> Self:
         return cls(*read_fmt("H22x", fp))
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         return write_fmt(fp, "H22x", *astuple(self))
 
 
@@ -322,13 +322,13 @@ class VectorMaskSetting(BaseElement):
     path: Path | None = None
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> Self:
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> Self:
         version, flags = read_fmt("2I", fp)
         assert version == 3, "Unknown vector mask version %d" % version
         path = Path.read(fp)
         return cls(version=version, flags=flags, path=path)
 
-    def write(self, fp: BinaryIO, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], **kwargs: Any) -> int:
         written = write_fmt(fp, "2I", self.version, self.flags)
         if self.path:
             written += self.path.write(fp)
@@ -364,11 +364,11 @@ class VectorStrokeContentSetting(Descriptor):
     version: int = 1
 
     @classmethod
-    def read(cls, fp: BinaryIO, **kwargs: Any) -> Self:
+    def read(cls, fp: IO[bytes], **kwargs: Any) -> Self:
         key, version = read_fmt("4sI", fp)
         return cls(key=key, version=version, **cls._read_body(fp))
 
-    def write(self, fp: BinaryIO, padding: int = 4, **kwargs: Any) -> int:
+    def write(self, fp: IO[bytes], padding: int = 4, **kwargs: Any) -> int:
         written = write_fmt(fp, "4sI", self.key, self.version)
         written += self._write_body(fp)
         written += write_padding(fp, written, padding)


### PR DESCRIPTION
`IO[bytes]` is less restrictive.