### PR TITLE
chore: migrate pre-commit hooks to uv local for ruff and add T10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,8 @@ repos:
         entry: uv run mypy
         language: system
         types: [python]
-        files: ^(src|tests)/
-        args: [src/psd_tools, tests]
+        files: ^(src|tests|tools|docs)/
+        args: [src/psd_tools, tests, tools, docs/conf.py]
         pass_filenames: false
 
   # ---------------------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
         entry: uv run ruff check --fix
         language: system
         types: [python]
-        files: ^(src|tests)/
       - id: ruff-format
         name: ruff (format)
         entry: uv run ruff format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,30 +16,22 @@ repos:
       - id: check-merge-conflict
       - id: check-added-large-files
         args: [--maxkb=500]
-      - id: debug-statements
 
-  # ---------------------------------------------------------------------------
-  # Python: ruff linting + formatting (mirrors CI scope: src/ and tests/)
-  # ---------------------------------------------------------------------------
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
-    hooks:
-      - id: ruff-check
-        args: [--fix]
-        files: ^(src|tests)/
-      - id: ruff-format
-        files: ^(src|tests)/
-
-  # ---------------------------------------------------------------------------
-  # Python: mypy type checking (mirrors CI: `uv run mypy src/psd_tools`)
-  #
-  # Uses repo:local + language:system so mypy runs in the project's own venv
-  # and has access to all installed stubs/dependencies (attrs, numpy, Pillow,
-  # etc.). pass_filenames:false ensures the full package is checked for
-  # accurate cross-module type inference, not just the changed files.
-  # ---------------------------------------------------------------------------
+  # Python tools run via uv so they use the versions pinned in uv.lock.
   - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff (lint)
+        entry: uv run ruff check --fix
+        language: system
+        types: [python]
+        files: ^(src|tests)/
+      - id: ruff-format
+        name: ruff (format)
+        entry: uv run ruff format
+        language: system
+        types: [python]
+        files: ^(src|tests)/
       - id: mypy
         name: mypy
         entry: uv run mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
         entry: uv run ruff format
         language: system
         types: [python]
-        files: ^(src|tests)/
       - id: mypy
         name: mypy
         entry: uv run mypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ htmlhelp_basename = "srcdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ src = ["src", "tests"]
 extend-select = ["PLC0415", "T10"]
 
 [tool.mypy]
-files = ["src/psd_tools", "tests"]
+files = ["src/psd_tools", "tests", "tools", "docs/conf.py"]
 
 [tool.cibuildwheel]
 archs = "auto64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ markers = [
 src = ["src", "tests"]
 
 [tool.ruff.lint]
-extend-select = ["PLC0415"]
+extend-select = ["PLC0415", "T10"]
 
 [tool.mypy]
 files = ["src/psd_tools", "tests"]


### PR DESCRIPTION
## Summary

- Replace the external \`ruff-pre-commit\` repo hook with \`repo: local\` + \`uv run ruff\`, so ruff and mypy both use versions pinned in \`uv.lock\`
- Consolidate the two separate \`repo: local\` blocks (ruff + mypy) into one
- Replace the \`debug-statements\` pre-commit hook with ruff's \`T10\` (\`flake8-debugger\`) rule
- Remove \`files:\` scope restrictions from \`ruff-check\` and \`ruff-format\` so all hooks cover the full repo
- Expand mypy scope to \`tools/\` and \`docs/conf.py\`; fix the one type error found (\`latex_elements\` annotation in \`docs/conf.py\`)
- \`setup.py\` is intentionally excluded from mypy — Cython has no stubs

## Test plan

- [x] \`pre-commit run --all-files\` passes
- [x] \`uv run mypy src/psd_tools tests tools docs/conf.py\` passes (99 source files, no issues)
- [x] \`uv run ruff check\` catches \`import pdb\` / \`breakpoint()\` calls (T10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)