### PR TITLE
fix(build): disable Limited API for Windows Cython extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,12 @@ try:
     is_free_threaded = int(_py_gil_disabled or 0) != 0
 except (TypeError, ValueError):
     is_free_threaded = False
-use_limited_api = sys.version_info >= (3, 13) and not is_free_threaded
+# On Windows, the stable-ABI extension links against python3.dll which is absent
+# in many embedded Python environments (e.g. Substance Painter). Windows wheels
+# are already built per-version, so there is no benefit to the Limited API there.
+use_limited_api = (
+    sys.version_info >= (3, 13) and not is_free_threaded and sys.platform != "win32"
+)
 
 extensions = [
     Extension(


### PR DESCRIPTION
## Summary

- On Python 3.13+, `setup.py` was enabling `Py_LIMITED_API` on all platforms including Windows, causing `_rle` to be built as `_rle.pyd` (stable-ABI naming) linking against `python3.dll`.
- `python3.dll` is absent in many embedded Python runtimes (e.g. Substance Painter), so the import failed silently and fell back to the pure-Python RLE codec.
- Fix: add `sys.platform != "win32"` to the `use_limited_api` guard. Windows already ships separate per-version wheels with no abi3 tag, so the Limited API provides no benefit there. After this change, Windows builds produce `_rle.cp313-win_amd64.pyd` (linking `python313.dll`) which is present in all embedded environments.

No other files need updating — `configure_abi_tag.sh` and the `cibuildwheel` abi3audit overrides already exclude Windows.

Fixes #660

## Test plan

- [ ] Verify that a Windows cp313 wheel built from this branch contains `_rle.cp313-win_amd64.pyd` (not `_rle.pyd`)
- [ ] Verify that Linux/macOS cp313+ wheels still contain `_rle.abi3.so` (behaviour unchanged)
- [ ] Confirm the extension imports successfully in an embedded Python 3.13 environment on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)