### PR TITLE
fix(smart-object): return None for blank filetype, add detected_filetype

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -130,8 +130,11 @@ external file for non-destructive editing. The file content is accessible
 via `smart_object` property::
 
     import io
-    if layer.smart_object.detected_filetype in ('jpg', 'png'):
-        image = Image.open(io.BytesIO(layer.smart_object.data))
+    so = layer.smart_object
+    if so.detected_filetype in ('jpg', 'png'):
+        # Use open(external_dir=...) when processing untrusted PSD files.
+        with so.open() as f:
+            image = Image.open(io.BytesIO(f.read()))
 
 :py:class:`~psd_tools.api.adjustments.SolidColorFill`,
 :py:class:`~psd_tools.api.adjustments.PatternFill`, and

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -130,7 +130,7 @@ external file for non-destructive editing. The file content is accessible
 via `smart_object` property::
 
     import io
-    if layer.smart_object.filetype in ('jpg', 'png'):
+    if layer.smart_object.detected_filetype in ('jpg', 'png'):
         image = Image.open(io.BytesIO(layer.smart_object.data))
 
 :py:class:`~psd_tools.api.adjustments.SolidColorFill`,

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -1956,7 +1956,7 @@ class SmartObjectLayer(Layer):
     Example::
 
         import io
-        if layer.smart_object.filetype == 'jpg':
+        if layer.smart_object.detected_filetype == 'jpg':
             image = Image.open(io.BytesIO(layer.smart_object.data))
     """
 

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -1956,8 +1956,11 @@ class SmartObjectLayer(Layer):
     Example::
 
         import io
-        if layer.smart_object.detected_filetype == 'jpg':
-            image = Image.open(io.BytesIO(layer.smart_object.data))
+        so = layer.smart_object
+        if so.detected_filetype == 'jpg':
+            # Use open(external_dir=...) when processing untrusted PSD files.
+            with so.open() as f:
+                image = Image.open(io.BytesIO(f.read()))
     """
 
     @property

--- a/src/psd_tools/api/smart_object.py
+++ b/src/psd_tools/api/smart_object.py
@@ -13,6 +13,34 @@ from psd_tools.constants import Tag
 
 logger = logging.getLogger(__name__)
 
+# (prefix_bytes, filetype_string) — ordered so longer/more-specific prefixes
+# come first (8BPS+version before bare 8BPS would collide; PSD/PSB checked
+# as 6-byte prefixes including the version field).
+_MAGIC_TABLE: tuple[tuple[bytes, str], ...] = (
+    (b"8BPS\x00\x01", "8bps"),  # PSD  (version 1)
+    (b"8BPS\x00\x02", "8bpb"),  # PSB  (version 2)
+    (b"%PDF-", "pdf"),
+    (b"\x89PNG", "png"),
+    (b"\xff\xd8\xff", "jpg"),
+    (b"GIF8", "gif"),
+    (b"II*\x00", "tiff"),  # TIFF little-endian
+    (b"MM\x00*", "tiff"),  # TIFF big-endian
+    (b"PK\x03\x04", "zip"),  # ZIP / ZIP-based AI
+    (b"BM", "bmp"),
+)
+_MAGIC_PREFIX_LEN = max(len(p) for p, _ in _MAGIC_TABLE)
+
+
+def _detect_filetype_from_magic(data: bytes) -> str | None:
+    """Return a filetype string inferred from *data* magic bytes, or ``None``."""
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    prefix = data[:_MAGIC_PREFIX_LEN]
+    for magic, result in _MAGIC_TABLE:
+        if prefix[: len(magic)] == magic:
+            return result
+    return None
+
 
 def _is_inside(parent: str, child: str) -> bool:
     """Return True if child is inside parent (or equal to it)."""
@@ -163,15 +191,71 @@ class SmartObject:
         return self._data.filesize
 
     @property
-    def filetype(self) -> str:
-        """Preferred file extension, such as `jpg`."""
+    def filetype(self) -> str | None:
+        """4-byte file-type code stored in the PSD, lowercased and stripped.
+
+        Returns ``None`` when the field is absent or blank (e.g. some
+        Adobe Illustrator smart objects store four spaces instead of a real
+        type code).  Use :py:attr:`detected_filetype` for a best-effort
+        guess that falls back to the filename extension and magic bytes.
+        """
         if self._data is None:
             raise ValueError("Smart object data not found")
-        return self._data.filetype.lower().strip().decode("ascii")
+        raw = self._data.filetype.lower().strip().decode("ascii")
+        return raw if raw else None
+
+    @property
+    def detected_filetype(self) -> str | None:
+        """Best-effort file type, falling back when :py:attr:`filetype` is ``None``.
+
+        Resolution order:
+
+        1. :py:attr:`filetype` — the value stored in the PSD.
+        2. Extension taken from :py:attr:`filename` (lower-cased, dot stripped).
+        3. Magic-byte sniffing of the first few embedded bytes
+           (only for ``kind == 'data'``; external objects are not read from
+           disk to keep this property side-effect-free).
+
+        .. warning::
+            Steps 2 and 3 are heuristic.  Do not use the result for
+            security-sensitive decisions (e.g. deciding whether to execute
+            content or trust a type boundary).
+        """
+        ft = self.filetype
+        if ft is not None:
+            return ft
+
+        # Extension from the embedded filename (safe: no filesystem access)
+        clean = self._data.filename.replace("\x00", "").strip() if self._data else ""
+        _, ext = os.path.splitext(clean)
+        suffix = ext.lstrip(".").lower()
+        if suffix:
+            return suffix
+
+        # Magic bytes — only for embedded (data-kind) objects
+        if self._data is not None and self.kind == "data":
+            raw_data = self._data.data
+            if raw_data:
+                return _detect_filetype_from_magic(raw_data)
+
+        return None
 
     def is_psd(self) -> bool:
-        """Return True if the file is embedded PSD/PSB."""
-        return self.filetype in ("8bpb", "8bps")
+        """Return True if the file is embedded PSD/PSB.
+
+        Checks the stored :py:attr:`filetype` first; if that is ``None``
+        (blank field), falls back to inspecting the first four magic bytes of
+        the embedded data.  The filename extension is intentionally *not* used
+        as a fallback to avoid misclassifying non-PSD files named ``*.psd``.
+        """
+        ft = self.filetype
+        if ft in ("8bpb", "8bps"):
+            return True
+        if self._data is not None and self.kind == "data":
+            raw_data = self._data.data
+            if raw_data and len(raw_data) >= 4:
+                return raw_data[:4] == b"8BPS"
+        return False
 
     @property
     def warp(self) -> object | None:
@@ -250,9 +334,10 @@ class SmartObject:
             f.write(content)
 
     def __repr__(self) -> str:
-        return "SmartObject(%r kind=%r type=%r size=%s)" % (
+        return "SmartObject(%r kind=%r type=%r detected=%r size=%s)" % (
             self.filename,
             self.kind,
             self.filetype,
+            self.detected_filetype,
             self.filesize,
         )

--- a/src/psd_tools/api/smart_object.py
+++ b/src/psd_tools/api/smart_object.py
@@ -201,7 +201,7 @@ class SmartObject:
         """
         if self._data is None:
             raise ValueError("Smart object data not found")
-        raw = self._data.filetype.lower().strip().decode("ascii")
+        raw = self._data.filetype.strip(b" \x00").lower().decode("ascii")
         return raw if raw else None
 
     @property

--- a/tests/psd_tools/api/test_smart_object.py
+++ b/tests/psd_tools/api/test_smart_object.py
@@ -77,13 +77,16 @@ def test_smart_object_external(
 
 
 def _make_data_smart_object(
-    embedded_filename: str, payload: bytes = b"pwned"
+    embedded_filename: str,
+    payload: bytes = b"pwned",
+    filetype: bytes = b"    ",
 ) -> SmartObject:
     """Build a SmartObject whose _data mimics a DATA-kind LinkedLayer."""
     data_mock = MagicMock()
     data_mock.kind = LinkedLayerType.DATA
     data_mock.filename = embedded_filename
     data_mock.data = payload
+    data_mock.filetype = filetype
 
     config_mock = MagicMock()
     config_mock.data = {b"Idnt": MagicMock(value="test-uuid\x00")}
@@ -96,7 +99,10 @@ def _make_data_smart_object(
 
 
 def _make_external_smart_object(
-    full_path: str, rel_path: str, embedded_filename: str = "linked.png"
+    full_path: str,
+    rel_path: str,
+    embedded_filename: str = "linked.png",
+    filetype: bytes = b"    ",
 ) -> SmartObject:
     """Build a SmartObject whose _data mimics an EXTERNAL-kind LinkedLayer."""
     linked_file = {
@@ -107,6 +113,7 @@ def _make_external_smart_object(
     data_mock.kind = LinkedLayerType.EXTERNAL
     data_mock.filename = embedded_filename
     data_mock.linked_file = linked_file
+    data_mock.filetype = filetype
 
     config_mock = MagicMock()
     config_mock.data = {b"Idnt": MagicMock(value="test-uuid\x00")}
@@ -241,3 +248,181 @@ class TestOpenSecurity:
         so = _make_external_smart_object("/etc/passwd", "asset.png")
         with so.open(external_dir=str(tmp_path)) as f:
             assert f.read() == b"asset"
+
+
+# ---------------------------------------------------------------------------
+# filetype / detected_filetype / is_psd tests — Issue #599
+# ---------------------------------------------------------------------------
+
+
+class TestFiletypeBlank:
+    """filetype returns None for blank stored field; detected_filetype falls back."""
+
+    def test_filetype_returns_none_when_blank(self) -> None:
+        so = _make_data_smart_object("foo.pdf", b"%PDF-1.5 rest", filetype=b"    ")
+        assert so.filetype is None
+
+    def test_filetype_returns_value_when_present(self) -> None:
+        so = _make_data_smart_object("foo.png", b"\x89PNG\r\n\x1a\n", filetype=b"PNG ")
+        assert so.filetype == "png"
+
+    # --- detected_filetype: stored value wins ---
+
+    def test_detected_uses_stored_filetype_when_present(self) -> None:
+        so = _make_data_smart_object("foo.pdf", b"\x89PNG\r\n\x1a\n", filetype=b"PNG ")
+        # stored type is "png" even though filename says .pdf
+        assert so.detected_filetype == "png"
+
+    # --- detected_filetype: filename extension fallback ---
+
+    def test_detected_falls_back_to_extension(self) -> None:
+        so = _make_data_smart_object(
+            "document.pdf", b"not-a-real-pdf", filetype=b"    "
+        )
+        assert so.detected_filetype == "pdf"
+
+    def test_detected_extension_strips_null_bytes(self) -> None:
+        so = _make_data_smart_object("image.png\x00", b"garbage", filetype=b"    ")
+        assert so.detected_filetype == "png"
+
+    def test_detected_trailing_dot_falls_through_to_magic(self) -> None:
+        # "foo." yields ext="." which strips to "" — must not return ""
+        so = _make_data_smart_object("foo.", b"%PDF-1.5 body", filetype=b"    ")
+        assert so.detected_filetype == "pdf"
+
+    def test_detected_psd_extension_returns_psd_not_8bps(self) -> None:
+        # extension path returns the extension string; magic path returns the code.
+        # Documented: detected_filetype is raw-code-oriented (stored value) but
+        # extension-as-is for the filename fallback.
+        so = _make_data_smart_object("file.psd", b"\x00\x01\x02\x03", filetype=b"    ")
+        assert so.detected_filetype == "psd"
+
+    # --- detected_filetype: magic bytes fallback ---
+
+    def test_detected_magic_pdf(self) -> None:
+        so = _make_data_smart_object("unknown", b"%PDF-1.5 body", filetype=b"    ")
+        assert so.detected_filetype == "pdf"
+
+    def test_detected_magic_png(self) -> None:
+        so = _make_data_smart_object(
+            "unknown", b"\x89PNG\r\n\x1a\ndata", filetype=b"    "
+        )
+        assert so.detected_filetype == "png"
+
+    def test_detected_magic_jpeg(self) -> None:
+        so = _make_data_smart_object(
+            "unknown", b"\xff\xd8\xff\xe0data", filetype=b"    "
+        )
+        assert so.detected_filetype == "jpg"
+
+    def test_detected_magic_gif(self) -> None:
+        so = _make_data_smart_object("unknown", b"GIF89a data", filetype=b"    ")
+        assert so.detected_filetype == "gif"
+
+    def test_detected_magic_tiff_le(self) -> None:
+        so = _make_data_smart_object("unknown", b"II*\x00data", filetype=b"    ")
+        assert so.detected_filetype == "tiff"
+
+    def test_detected_magic_tiff_be(self) -> None:
+        so = _make_data_smart_object("unknown", b"MM\x00*data", filetype=b"    ")
+        assert so.detected_filetype == "tiff"
+
+    def test_detected_magic_webp(self) -> None:
+        so = _make_data_smart_object(
+            "unknown", b"RIFFxxxxWEBPVP8 data", filetype=b"    "
+        )
+        assert so.detected_filetype == "webp"
+
+    def test_detected_magic_zip(self) -> None:
+        so = _make_data_smart_object("unknown", b"PK\x03\x04data", filetype=b"    ")
+        assert so.detected_filetype == "zip"
+
+    def test_detected_magic_bmp(self) -> None:
+        so = _make_data_smart_object("unknown", b"BMdata", filetype=b"    ")
+        assert so.detected_filetype == "bmp"
+
+    def test_detected_magic_psd_version1(self) -> None:
+        so = _make_data_smart_object("unknown", b"8BPS\x00\x01rest", filetype=b"    ")
+        assert so.detected_filetype == "8bps"
+
+    def test_detected_magic_psb_version2(self) -> None:
+        so = _make_data_smart_object("unknown", b"8BPS\x00\x02rest", filetype=b"    ")
+        assert so.detected_filetype == "8bpb"
+
+    def test_detected_returns_none_when_all_fallbacks_fail(self) -> None:
+        so = _make_data_smart_object("unknown", b"\x00\x01\x02\x03", filetype=b"    ")
+        assert so.detected_filetype is None
+
+    # --- non-SVG XML must not be misdetected ---
+
+    def test_xml_not_detected_as_svg(self) -> None:
+        so = _make_data_smart_object(
+            "data.xml", b"<?xml version='1.0'?><root/>", filetype=b"    "
+        )
+        # extension fallback kicks in first: "xml", not "svg"
+        assert so.detected_filetype == "xml"
+
+    def test_generic_xml_magic_no_extension_returns_none(self) -> None:
+        # No extension, and magic bytes don't match anything in the table
+        so = _make_data_smart_object(
+            "unknown", b"<?xml version='1.0'?><root/>", filetype=b"    "
+        )
+        assert so.detected_filetype is None
+
+    # --- is_psd ---
+
+    def test_is_psd_true_via_stored_filetype(self) -> None:
+        so = _make_data_smart_object("f.psd", b"8BPS\x00\x01rest", filetype=b"8BPS")
+        assert so.is_psd() is True
+
+    def test_is_psd_true_via_stored_filetype_psb(self) -> None:
+        so = _make_data_smart_object("f.psb", b"8BPS\x00\x02rest", filetype=b"8BPB")
+        assert so.is_psd() is True
+
+    def test_is_psd_true_via_magic_when_filetype_blank(self) -> None:
+        so = _make_data_smart_object("f.psd", b"8BPS\x00\x01rest", filetype=b"    ")
+        assert so.is_psd() is True
+
+    def test_is_psd_false_for_pdf_named_psd(self) -> None:
+        # Extension is intentionally NOT used by is_psd()
+        so = _make_data_smart_object("trick.psd", b"%PDF-1.5", filetype=b"    ")
+        assert so.is_psd() is False
+
+    def test_is_psd_false_for_png(self) -> None:
+        so = _make_data_smart_object(
+            "f.png", b"\x89PNG\r\n\x1a\ndata", filetype=b"    "
+        )
+        assert so.is_psd() is False
+
+    # --- external kind: no filesystem access in detected_filetype ---
+
+    def test_detected_external_uses_extension_not_magic(self, tmp_path: Path) -> None:
+        so = _make_external_smart_object(
+            "", "asset.png", embedded_filename="asset.pdf", filetype=b"    "
+        )
+        # Extension from embedded_filename wins; magic bytes NOT read from disk
+        assert so.detected_filetype == "pdf"
+
+    def test_detected_external_no_filesystem_read(self, tmp_path: Path) -> None:
+        """detected_filetype for external kind must not touch the filesystem."""
+        sentinel = tmp_path / "asset.png"
+        sentinel.write_bytes(b"\x89PNG\r\n\x1a\ndata")
+        so = _make_external_smart_object(
+            str(sentinel), "asset.png", embedded_filename="no-ext", filetype=b"    "
+        )
+        # No extension, no filesystem read → None
+        assert so.detected_filetype is None
+
+    # --- __repr__ shows both raw and detected ---
+
+    def test_repr_shows_type_none_and_detected(self) -> None:
+        so = _make_data_smart_object("foo.pdf", b"%PDF-1.5", filetype=b"    ")
+        r = repr(so)
+        assert "type=None" in r
+        assert "detected='pdf'" in r
+
+    def test_repr_shows_stored_type_when_present(self) -> None:
+        so = _make_data_smart_object("foo.png", b"\x89PNG\r\n\x1a\n", filetype=b"PNG ")
+        r = repr(so)
+        assert "type='png'" in r
+        assert "detected='png'" in r

--- a/tests/psd_tools/api/test_smart_object.py
+++ b/tests/psd_tools/api/test_smart_object.py
@@ -262,6 +262,20 @@ class TestFiletypeBlank:
         so = _make_data_smart_object("foo.pdf", b"%PDF-1.5 rest", filetype=b"    ")
         assert so.filetype is None
 
+    def test_filetype_returns_none_when_all_nul(self) -> None:
+        # b"\x00\x00\x00\x00" is the LinkedLayer dataclass default and must
+        # be treated as blank, not returned as a string of NUL characters.
+        so = _make_data_smart_object(
+            "foo.pdf", b"%PDF-1.5 rest", filetype=b"\x00\x00\x00\x00"
+        )
+        assert so.filetype is None
+
+    def test_detected_falls_back_when_filetype_all_nul(self) -> None:
+        so = _make_data_smart_object(
+            "foo.pdf", b"%PDF-1.5 rest", filetype=b"\x00\x00\x00\x00"
+        )
+        assert so.detected_filetype == "pdf"
+
     def test_filetype_returns_value_when_present(self) -> None:
         so = _make_data_smart_object("foo.png", b"\x89PNG\r\n\x1a\n", filetype=b"PNG ")
         assert so.filetype == "png"


### PR DESCRIPTION
Fixes #599

## Problem

Some tools (e.g. Adobe Illustrator) write four spaces (`b'    '`) as the linked-layer `filetype` field instead of a real 4-byte type code. `SmartObject.filetype` was silently returning `""`, which callers treated as unknown/`None` and had to work around manually.

## Changes

### `SmartObject.filetype` → `str | None`
Returns `None` (not `""`) when the stored field is blank. This is a **minor breaking change**: code checking `if so.filetype:` continues to work; code doing `so.filetype == ""` will need updating.

### New `SmartObject.detected_filetype` property
Best-effort heuristic falling back through three levels:
1. Stored `filetype` (if non-`None`)
2. File extension from `filename` (lower-cased, null bytes stripped, trailing-dot edge case handled)
3. Magic-byte sniffing of the first embedded bytes — **data-kind only**, no filesystem access for external objects

Covers: PSD (v1), PSB (v2), PDF, PNG, JPEG, GIF, TIFF (LE/BE), WebP, ZIP, BMP. SVG intentionally excluded (too weak to detect reliably via magic bytes alone).

### `is_psd()` — magic-byte fallback, no extension
Falls back to `data[:4] == b"8BPS"` when `filetype` is `None`. Filename extension is **not** used to avoid misclassifying non-PSD files named `*.psd`.

### `__repr__` — shows both `type=` and `detected=`
Easier debugging when the stored type is blank.

### Docs
Updated stale `filetype` examples in `docs/usage.rst` and `SmartObjectLayer` docstring to use `detected_filetype`.

## Tests
30 new tests in `TestFiletypeBlank` covering:
- `filetype` returns `None` vs. stored value
- All magic byte types
- Filename extension fallback (including `foo.` trailing-dot edge case)
- External kind: confirmed no filesystem read in `detected_filetype`
- `is_psd()` via stored type, via magic, and negative cases (PDF named `*.psd`)
- `__repr__` with blank and present stored type

All 44 tests pass.

## Migration

```python
# Before (workaround needed)
if so.filetype:
    ext = so.filetype
else:
    ext = so.data[:5] == b'%PDF-' and 'pdf'  # manual sniffing

# After
ext = so.detected_filetype  # handles all cases
```