### PR TITLE
chore: add investigate-issue skill and expand CLAUDE.md workflow docs

### DIFF
--- a/.claude/skills/investigate-issue/SKILL.md
+++ b/.claude/skills/investigate-issue/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: investigate-issue
 description: Investigate a GitHub issue and post structured findings as a comment. Use when the user wants to analyze a bug report, reproduce it, and share findings on the issue thread.
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(uv:*), Bash(grep:*), Bash(find:*), Read, WebFetch(domain:github.com)
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(uv:*), Bash(grep:*), Bash(find:*), Bash(cat:*), Read, WebFetch(domain:github.com)
 ---
 
 ## Step 0 — Identify the issue
 
 **Provided issue**: $ARGUMENTS
 
-If an issue number was provided, continue to Step 1.
-If no issue number was provided, ask the user which issue to investigate.
+If an issue number was provided, store it as **ISSUE_NUMBER** and continue to Step 1.
+If no issue number was provided, ask the user which issue to investigate, then store the answer as **ISSUE_NUMBER**.
 
 ## Step 1 — Fetch the issue
 

--- a/.claude/skills/investigate-issue/SKILL.md
+++ b/.claude/skills/investigate-issue/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: investigate-issue
+description: Investigate a GitHub issue and post structured findings as a comment. Use when the user wants to analyze a bug report, reproduce it, and share findings on the issue thread.
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(uv:*), Bash(grep:*), Bash(find:*), Read, WebFetch(domain:github.com)
+---
+
+## Step 0 — Identify the issue
+
+**Provided issue**: $ARGUMENTS
+
+If an issue number was provided, continue to Step 1.
+If no issue number was provided, ask the user which issue to investigate.
+
+## Step 1 — Fetch the issue
+
+```bash
+gh issue view ISSUE_NUMBER --repo psd-tools/psd-tools --comments
+```
+
+Read the full issue body, title, and all comments. Understand:
+- What behavior the reporter expected
+- What behavior they observed
+- Any reproduction steps or sample files mentioned
+- The version of psd-tools they used
+
+## Step 2 — Reproduce or locate the root cause
+
+Based on the issue description, investigate the codebase:
+
+1. Search for relevant code using `grep` or `find` in `src/psd_tools/`
+2. If the issue has a code snippet, try to reproduce it:
+   ```bash
+   uv run python -c "..."
+   ```
+3. If the issue mentions a specific PSD feature, trace the code path:
+   - High-level API: `src/psd_tools/api/`
+   - Low-level parsing: `src/psd_tools/psd/`
+   - Compositing: `src/psd_tools/composite/`
+4. Look for related tests in `tests/` that may already cover (or fail to cover) the case
+
+Classify the issue into one of these categories before writing the comment:
+
+| Classification | When it applies |
+| -------------- | --------------- |
+| **Bug (parsing)** | Wrong data read from the PSD binary |
+| **Bug (API)** | Wrong value exposed to the user |
+| **Missing feature** | Behavior not implemented |
+| **Already fixed** | The bug no longer reproduces on `main` |
+| **Unreproducible** | Cannot reproduce without a sample file or more detail |
+| **By design / known limitation** | Documented or intentional constraint (see Known Limitations in CLAUDE.md) |
+| **Needs composite deps** | Only affects users without `psd-tools[composite]` installed |
+| **Documentation** | User misunderstood the API |
+| **Duplicate** | Same root cause as an existing issue |
+
+## Step 3 — Draft investigation findings
+
+Write a clear, structured comment in Markdown. Tailor the content to the classification:
+
+```markdown
+## Investigation findings
+
+**Classification**: [one of the categories above]
+
+### Analysis
+
+[2–4 paragraphs: what you found, where in the code the issue originates, and why it happens.
+For "Already fixed", note the commit/PR that fixed it.
+For "Unreproducible", list what you tried and what additional info is needed (sample PSD file, version, Python version, etc.).
+For "By design / known limitation", cite the relevant Known Limitations entry.
+For "Needs composite deps", explain which optional packages are required and how to install them.]
+
+### Relevant code
+
+[Point to specific files and line numbers, e.g. `src/psd_tools/psd/smart_object.py:123`.
+Omit if not applicable.]
+
+### Reproduction
+
+[Minimal code that reproduces the bug. If unreproducible, omit this section.]
+
+### Suggested fix
+
+[Brief description of the approach to fix it.
+Omit for "By design", "Already fixed", "Duplicate", and "Unreproducible" — use the Analysis section instead.]
+```
+
+Omit sections that are not applicable. Keep the tone neutral and technical.
+
+## Step 4 — Ask before posting
+
+Show the user the draft comment and ask: "Ready to post this as a comment on issue #NUMBER?"
+
+Do NOT post without explicit user confirmation.
+
+## Step 5 — Post the comment
+
+Once the user confirms, write the comment body to a temp file and post via `--body-file` to
+safely handle multiline Markdown, backticks, and special characters:
+
+```bash
+cat > /tmp/issue_comment.md << 'EOF'
+COMMENT_BODY
+EOF
+gh issue comment ISSUE_NUMBER --repo psd-tools/psd-tools --body-file /tmp/issue_comment.md
+```
+
+Print the URL of the posted comment.

--- a/.claude/skills/investigate-issue/SKILL.md
+++ b/.claude/skills/investigate-issue/SKILL.md
@@ -88,7 +88,7 @@ Omit sections that are not applicable. Keep the tone neutral and technical.
 
 ## Step 4 — Ask before posting
 
-Show the user the draft comment and ask: "Ready to post this as a comment on issue #NUMBER?"
+Show the user the draft comment and ask: "Ready to post this as a comment on issue #ISSUE_NUMBER?"
 
 Do NOT post without explicit user confirmation.
 
@@ -98,10 +98,10 @@ Once the user confirms, write the comment body to a temp file and post via `--bo
 safely handle multiline Markdown, backticks, and special characters:
 
 ```bash
-cat > /tmp/issue_comment.md << 'EOF'
+cat > "${TMPDIR:-/tmp}/issue_comment_ISSUE_NUMBER.md" << 'EOF'
 COMMENT_BODY
 EOF
-gh issue comment ISSUE_NUMBER --repo psd-tools/psd-tools --body-file /tmp/issue_comment.md
+gh issue comment ISSUE_NUMBER --repo psd-tools/psd-tools --body-file "${TMPDIR:-/tmp}/issue_comment_ISSUE_NUMBER.md"
 ```
 
 Print the URL of the posted comment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,9 @@ gh pr checks
 # List open PRs
 gh pr list
 
+# Parse JSON output with jq (more efficient than python3 for simple field extraction)
+gh issue view 123 --repo psd-tools/psd-tools --json title,body,comments | jq '.comments[].body'
+
 # Mark a PR review comment thread as resolved (GraphQL)
 gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "..."}) { thread { isResolved } } }'
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,65 @@ uv run --group docs make -C docs html
 # Output in docs/_build/html/
 ```
 
+## Available Skills
+
+These slash commands are available in Claude Code. Invoke them by typing `/<name>` in the chat.
+
+**Project-defined** (`.claude/skills/`):
+
+| Skill                         | When to use                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| `/release [version]`          | Cut a new version: updates changelog, bumps version, opens a release PR.          |
+| `/investigate-issue <number>` | Investigate a GitHub issue, trace the root cause, and post findings as a comment. |
+
+**Built-in Claude Code commands**:
+
+| Skill                  | When to use                                                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `/code-review [--fix]` | Review the current diff for bugs and simplification opportunities. Pass `--fix` to apply findings automatically. |
+| `/review`              | Review the open PR on the current branch — reads PR description, diff, and CI state.                             |
+| `/security-review`     | Run a focused security review of pending changes on the current branch.                                          |
+
+## GitHub Workflow
+
+### Common `gh` CLI patterns
+
+```bash
+# View an issue with all comments
+gh issue view 123 --repo psd-tools/psd-tools --comments
+
+# Post a comment (use --body-file for multiline Markdown to avoid shell escaping issues)
+gh issue comment 123 --repo psd-tools/psd-tools --body-file /tmp/comment.md
+
+# View a PR (current branch)
+gh pr view
+
+# Check CI status for the current PR
+gh pr checks
+
+# List open PRs
+gh pr list
+
+# Mark a PR review comment thread as resolved (GraphQL)
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "..."}) { thread { isResolved } } }'
+```
+
+### Typical fix workflow
+
+1. `gh issue view <N> --comments` — read the issue and comments, understand the bug
+1. `git checkout -b fix/short-description` — create the branch before editing any files
+1. Investigate code, write the fix, run `uv run pytest`
+1. Commit and push → `gh pr create`
+1. Address PR review comments → push follow-up commits
+1. After merge: `git checkout main && git pull && git branch -d fix/short-description`
+
+### Branch naming conventions
+
+- `fix/<short-description>` — bug fixes
+- `feature/<short-description>` — new features
+- `release/vX.Y.Z` — release PRs (required by auto-tag workflow)
+- `chore/<short-description>` — tooling, deps, CI
+
 ## Release Workflow
 
 1. **Decide the version number** following [PEP 440](https://peps.python.org/pep-0440/) based on the changes since the last release. The auto-tag workflow recognises these forms: `v1.2.3` (release), `v1.2.3a1` / `v1.2.3b1` / `v1.2.3rc1` (pre-releases), `v1.2.3.post1` (post-release).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ These slash commands are available in Claude Code. Invoke them by typing `/<name
 gh issue view 123 --repo psd-tools/psd-tools --comments
 
 # Post a comment (use --body-file for multiline Markdown to avoid shell escaping issues)
-gh issue comment 123 --repo psd-tools/psd-tools --body-file /tmp/comment.md
+gh issue comment 123 --repo psd-tools/psd-tools --body-file "${TMPDIR:-/tmp}/comment.md"
 
 # View a PR (current branch)
 gh pr view


### PR DESCRIPTION
## Summary

- New `/investigate-issue` project skill: given an issue number, fetches the issue and all comments, traces the root cause in the codebase, drafts structured findings with explicit classification (bug/missing feature/unreproducible/by-design/needs-composite-deps/duplicate), and posts via `--body-file` for safe multiline Markdown handling. Requires user confirmation before posting.
- Adds an **Available Skills** section to `CLAUDE.md` distinguishing project-defined skills (`.claude/skills/`) from built-in Claude Code commands.
- Adds a **GitHub Workflow** section documenting common `gh` CLI patterns, the typical fix workflow (with branch creation before editing), and branch naming conventions.

## Test plan

- [ ] `/investigate-issue` skill content reviewed for accuracy and completeness
- [ ] `CLAUDE.md` sections render correctly and are placed logically
- [ ] `gh issue view --comments` flag verified in skill and CLAUDE.md examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)