### PR TITLE
fix: compute relative dimensions in VirtualMemoryArray.get_data()

### DIFF
--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -125,7 +125,8 @@ def get_layer_data(
 
 def get_pattern(pattern: Pattern) -> np.ndarray:
     """Get pattern array."""
-    height, width = pattern.data.rectangle[2], pattern.data.rectangle[3]
+    top, left, bottom, right = pattern.data.rectangle
+    height, width = bottom - top, right - left
     return np.stack(
         [
             _parse_array(c.get_data(), c.pixel_depth)  # type: ignore

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -179,7 +179,8 @@ def convert_pattern_to_pil(pattern: Pattern) -> Image.Image:
     """Convert Pattern to PIL Image."""
     mode = get_pil_mode(pattern.image_mode)
     # The order is different here.
-    size = pattern.data.rectangle[3], pattern.data.rectangle[2]
+    top, left, bottom, right = pattern.data.rectangle
+    size = right - left, bottom - top
     channels = [
         _create_image(size, c.get_data() or b"", c.pixel_depth or 8).convert("L")
         for c in pattern.data.channels

--- a/src/psd_tools/psd/patterns.py
+++ b/src/psd_tools/psd/patterns.py
@@ -232,7 +232,9 @@ class VirtualMemoryArray(BaseElement):
             return None
         assert self.rectangle is not None
         assert self.depth is not None
-        width, height = self.rectangle[3], self.rectangle[2]
+        top, left, bottom, right = self.rectangle
+        width = right - left
+        height = bottom - top
         return decompress(
             self.data, self.compression, width, height, self.depth, version=1
         )

--- a/tests/psd_tools/psd/test_patterns.py
+++ b/tests/psd_tools/psd/test_patterns.py
@@ -42,6 +42,24 @@ def test_virtual_memory_array_data(fixture: bytes) -> None:
     assert value.rectangle is not None
     assert data is not None
     assert value.pixel_depth is not None
-    width, height = value.rectangle[3], value.rectangle[2]
+    top, left, bottom, right = value.rectangle
+    width = right - left
+    height = bottom - top
     value.set_data((width, height), data, value.pixel_depth, value.compression)
     assert value.tobytes() == fixture
+
+
+def test_virtual_memory_array_get_data_non_zero_origin() -> None:
+    """get_data() must use relative dimensions (right-left, bottom-top), not absolute coords."""
+    # rectangle (top=10, left=20, bottom=18, right=28) => width=8, height=8
+    vma = VirtualMemoryArray(
+        is_written=1,
+        depth=8,
+        rectangle=(10, 20, 18, 28),
+        pixel_depth=8,
+        compression=0,
+        data=b"\x00" * 64,
+    )
+    data = vma.get_data()
+    assert data is not None
+    assert len(data) == 8 * 8  # 64 bytes, not 28*18=504


### PR DESCRIPTION
## Summary

- Fixes #671: `VirtualMemoryArray.get_data()` was using `rectangle[3]` (absolute `right`) and `rectangle[2]` (absolute `bottom`) as `width` and `height`, instead of computing the relative pixel grid dimensions (`right - left`, `bottom - top`).
- This was harmless for standard PSD patterns whose bounding boxes start at `(0, 0)`, but caused decompression failures or massive buffer bloat for ABR brush tips with non-zero origins.
- Also fixes the same issue in the existing `test_virtual_memory_array_data` test, and adds a dedicated regression test with a non-zero-origin rectangle.

## Test plan

- [x] `uv run pytest tests/psd_tools/psd/test_patterns.py -v` — all 5 tests pass, including the new `test_virtual_memory_array_get_data_non_zero_origin`
- [x] `uv run pytest --no-cov` — full suite (1388 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)