### PR TITLE
feat: render outer glow layer effect

### DIFF
--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -1,6 +1,7 @@
 """Composite implementation for layer rendering and blending."""
 
 import logging
+import math
 from typing import Callable, cast
 
 import numpy as np
@@ -13,7 +14,7 @@ from psd_tools.api.utils import EXPECTED_CHANNELS, check_pixel_size
 from psd_tools.composite import paint, utils, vector
 from psd_tools.composite.adjustments import ADJUSTMENT_FUNC
 from psd_tools.composite.blend import BLEND_FUNC, normal
-from psd_tools.composite.effects import draw_stroke_effect
+from psd_tools.composite.effects import draw_drop_shadow, draw_stroke_effect
 from psd_tools.constants import BlendMode, ColorMode, Resource, Tag
 
 logger = logging.getLogger(__name__)
@@ -353,6 +354,9 @@ class Compositor(object):
         alpha *= mask
 
         # TODO: Tag.BLEND_INTERIOR_ELEMENTS controls how inner effects apply.
+
+        # Outer effects paint behind the layer's own source.
+        self._apply_drop_shadow(layer, color, shape, alpha)
 
         full_passthrough = (
             layer.blend_mode == BlendMode.PASS_THROUGH
@@ -705,6 +709,34 @@ class Compositor(object):
         opacity = desc.get("strokeStyleOpacity", 100.0) / 100.0
         alpha = shape * opacity
         return color, shape, alpha
+
+    def _apply_drop_shadow(self, layer, color, shape, alpha):
+        for effect in layer.effects.find("dropshadow"):
+            # The shadow is blurred/offset beyond the layer, so grow the working viewport.
+            grow = int(math.ceil(effect.distance + effect.size + 2))
+            bbox = cast(
+                tuple[int, int, int, int],
+                tuple(x + d for x, d in zip(layer.bbox, (-grow, -grow, grow, grow))),
+            )
+            shape_in_bbox = paste(bbox, self._viewport, shape)
+            mask = draw_drop_shadow(
+                bbox,
+                shape_in_bbox,
+                distance=effect.distance,
+                angle=effect.angle,
+                size=effect.size,
+                choke=effect.choke,
+            )
+            if effect.layer_knocks_out:
+                # The shadow is concealed under the layer's own coverage.
+                mask = mask * (1.0 - shape_in_bbox)
+            shadow_color, _ = paint.draw_solid_color_fill(
+                bbox, layer._psd.color_mode, effect.value
+            )
+            shadow_color = paste(self._viewport, bbox, shadow_color, 1.0)
+            mask = paste(self._viewport, bbox, mask)
+            opacity = effect.opacity / 100.0
+            self._apply_source(shadow_color, mask, mask * opacity, effect.blend_mode)
 
     def _apply_color_overlay(self, layer, color, shape, alpha):
         for effect in layer.effects.find("coloroverlay"):

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -14,7 +14,11 @@ from psd_tools.api.utils import EXPECTED_CHANNELS, check_pixel_size
 from psd_tools.composite import paint, utils, vector
 from psd_tools.composite.adjustments import ADJUSTMENT_FUNC
 from psd_tools.composite.blend import BLEND_FUNC, normal
-from psd_tools.composite.effects import draw_drop_shadow, draw_stroke_effect
+from psd_tools.composite.effects import (
+    draw_drop_shadow,
+    draw_outer_glow,
+    draw_stroke_effect,
+)
 from psd_tools.constants import BlendMode, ColorMode, Resource, Tag
 
 logger = logging.getLogger(__name__)
@@ -357,6 +361,7 @@ class Compositor(object):
 
         # Outer effects paint behind the layer's own source.
         self._apply_drop_shadow(layer, color, shape, alpha)
+        self._apply_outer_glow(layer, color, shape, alpha)
 
         full_passthrough = (
             layer.blend_mode == BlendMode.PASS_THROUGH
@@ -737,6 +742,29 @@ class Compositor(object):
             mask = paste(self._viewport, bbox, mask)
             opacity = effect.opacity / 100.0
             self._apply_source(shadow_color, mask, mask * opacity, effect.blend_mode)
+
+    def _apply_outer_glow(self, layer, color, shape, alpha):
+        for effect in layer.effects.find("outerglow"):
+            # OuterGlow.spread reads the wrong descriptor key upstream; the Photoshop
+            # "Spread" lives in the choke (ChokeMatte) slot.
+            spread = effect.choke
+            spread_px = spread / 100.0 * effect.size
+            grow = int(math.ceil(effect.size + spread_px + 2))
+            bbox = cast(
+                tuple[int, int, int, int],
+                tuple(x + d for x, d in zip(layer.bbox, (-grow, -grow, grow, grow))),
+            )
+            shape_in_bbox = paste(bbox, self._viewport, shape)
+            mask = draw_outer_glow(bbox, shape_in_bbox, size=effect.size, spread=spread)
+            # Outer glow only shows outside the layer's own coverage.
+            mask = mask * (1.0 - shape_in_bbox)
+            glow_color, _ = paint.draw_solid_color_fill(
+                bbox, layer._psd.color_mode, effect.value
+            )
+            glow_color = paste(self._viewport, bbox, glow_color, 1.0)
+            mask = paste(self._viewport, bbox, mask)
+            opacity = effect.opacity / 100.0
+            self._apply_source(glow_color, mask, mask * opacity, effect.blend_mode)
 
     def _apply_color_overlay(self, layer, color, shape, alpha):
         for effect in layer.effects.find("coloroverlay"):

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -16,10 +16,16 @@ Currently supported effects:
   - Supports solid color, gradient, and pattern fills
   - Position: inside, outside, or centered
   - Limited compared to Photoshop's full implementation
+- **Drop shadow**: Offset, choked and blurred silhouette painted behind the layer
+  - Solid color fill; honors distance, angle (incl. global light), size, choke,
+    opacity, blend mode and "layer knocks out drop shadow"
+  - The falloff is a gaussian approximation of Photoshop's proprietary blur, so the
+    placement is faithful but the shadow intensity can differ — large, soft shadows
+    tend to render somewhat darker than Photoshop
 
 Partially supported or limited effects:
 
-- Drop shadow, inner shadow, outer glow, inner glow
+- Inner shadow, outer glow, inner glow
 - These may render but with reduced accuracy
 
 The main function :py:func:`draw_stroke_effect` handles stroke rendering by:
@@ -52,12 +58,13 @@ automatically applied when rendering layers that have effects enabled.
 """
 
 import logging
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from psd_tools.composite import paint, utils
-from psd_tools.composite._compat import require_skimage
+from psd_tools.composite._compat import require_scipy, require_skimage
 from psd_tools.psd.descriptor import Descriptor
 from psd_tools.terminology import Enum, Key
 
@@ -65,6 +72,48 @@ if TYPE_CHECKING:
     from psd_tools.api.protocols import PSDProtocol
 
 logger = logging.getLogger(__name__)
+
+# Maps Photoshop's "Size" parameter to a gaussian blur sigma. Photoshop's blur is a
+# proprietary approximation; sigma = size / 3 is a close, widely-used heuristic.
+_SIGMA_PER_SIZE = 1.0 / 3.0
+
+
+@require_scipy
+def draw_drop_shadow(
+    viewport: tuple[int, int, int, int],
+    shape: np.ndarray,
+    *,
+    distance: float,
+    angle: float,
+    size: float,
+    choke: float,
+) -> np.ndarray:
+    """Synthesize a drop-shadow coverage mask from a layer silhouette.
+
+    The layer's ``shape`` (silhouette) is offset along the cast direction of a light
+    at ``angle`` degrees. Returns an ``(H, W, 1)`` float32 coverage mask in the same
+    ``viewport`` as ``shape``; the caller tints and blends it behind the layer.
+    """
+    from scipy import ndimage  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    a = shape[:, :, 0].astype(np.float32)
+    # Choke contracts the matte before blurring. In Photoshop's UI choke is a percentage
+    # of size, even though the descriptor stores both in pixels.
+    choke_px = max(0, int(round(choke / 100.0 * size)))
+    if choke_px > 0:
+        a = ndimage.grey_erosion(a, size=2 * choke_px + 1)
+    # Blur. Photoshop "Size" is a soft falloff radius; sigma ~= size / 3 places ~3 sigma
+    # of the gaussian within the stated size (heuristic, see module notes).
+    sigma = max(0.0, size * _SIGMA_PER_SIZE)
+    if sigma > 1e-3:
+        a = ndimage.gaussian_filter(a, sigma)
+    # Photoshop angle is the light direction; the shadow casts in the opposite
+    # direction. Image coordinates are y-down, so a positive sin moves the shadow down.
+    theta = math.radians(angle)
+    dx = -distance * math.cos(theta)
+    dy = +distance * math.sin(theta)
+    a = ndimage.shift(a, (dy, dx), order=1, mode="constant", cval=0.0)
+    return np.clip(a, 0.0, 1.0)[:, :, None]
 
 
 @require_skimage

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -22,10 +22,15 @@ Currently supported effects:
   - The falloff is a gaussian approximation of Photoshop's proprietary blur, so the
     placement is faithful but the shadow intensity can differ — large, soft shadows
     tend to render somewhat darker than Photoshop
+- **Outer glow**: Spread (dilated) and blurred silhouette painted behind the layer,
+  knocked out under the layer's own coverage
+  - Solid color fill; honors size, spread, opacity and blend mode (gradient glow is
+    not yet supported)
+  - Same gaussian-approximation caveat as drop shadow
 
 Partially supported or limited effects:
 
-- Inner shadow, outer glow, inner glow
+- Inner shadow, inner glow
 - These may render but with reduced accuracy
 
 The main function :py:func:`draw_stroke_effect` handles stroke rendering by:
@@ -113,6 +118,34 @@ def draw_drop_shadow(
     dx = -distance * math.cos(theta)
     dy = +distance * math.sin(theta)
     a = ndimage.shift(a, (dy, dx), order=1, mode="constant", cval=0.0)
+    return np.clip(a, 0.0, 1.0)[:, :, None]
+
+
+@require_scipy
+def draw_outer_glow(
+    viewport: tuple[int, int, int, int],
+    shape: np.ndarray,
+    *,
+    size: float,
+    spread: float,
+) -> np.ndarray:
+    """Synthesize an outer-glow coverage mask from a layer silhouette.
+
+    Unlike a drop shadow, an outer glow is centered on the layer (no offset) and grows
+    *outward*: the silhouette is dilated by ``spread`` then blurred by ``size``. Returns
+    an ``(H, W, 1)`` float32 coverage mask; the caller knocks it out under the layer.
+    """
+    from scipy import ndimage  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    a = shape[:, :, 0].astype(np.float32)
+    # Spread expands the glow's solid core before blurring (the inverse of a shadow's
+    # choke). In Photoshop's UI spread is a percentage of size.
+    spread_px = max(0, int(round(spread / 100.0 * size)))
+    if spread_px > 0:
+        a = ndimage.grey_dilation(a, size=2 * spread_px + 1)
+    sigma = max(0.0, size * _SIGMA_PER_SIZE)
+    if sigma > 1e-3:
+        a = ndimage.gaussian_filter(a, sigma)
     return np.clip(a, 0.0, 1.0)[:, :, None]
 
 

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -6,7 +6,7 @@ import pytest
 
 from psd_tools import PSDImage
 from psd_tools.composite import composite
-from psd_tools.composite.effects import draw_drop_shadow
+from psd_tools.composite.effects import draw_drop_shadow, draw_outer_glow
 
 from ..utils import full_name
 from .test_composite import _mse, check_composite_quality
@@ -70,6 +70,29 @@ def test_draw_drop_shadow_choke_tightens_matte():
     )
 
 
+def test_draw_outer_glow_spreads_symmetrically_no_offset():
+    """Outer glow has no light/offset — its halo stays centered on the silhouette."""
+    w = h = 200
+    shape = _disc_shape(w, h, 100, 100, 30)
+    mask = draw_outer_glow((0, 0, w, h), shape, size=14, spread=0)
+    cx, cy = _centroid(mask)
+    assert abs(cx - 100) < 2 and abs(cy - 100) < 2, f"glow off-centre: ({cx}, {cy})"
+    assert (mask[:, :, 0] > 0.05).sum() > (shape[:, :, 0] > 0.5).sum() + 200, (
+        "glow did not spread a soft halo beyond the silhouette"
+    )
+
+
+def test_draw_outer_glow_spread_dilates_footprint():
+    """A nonzero spread grows the glow outward (dilation), unlike a shadow's choke."""
+    w = h = 200
+    shape = _disc_shape(w, h, 100, 100, 30)
+    tight = draw_outer_glow((0, 0, w, h), shape, size=14, spread=0)
+    wide = draw_outer_glow((0, 0, w, h), shape, size=14, spread=80)
+    assert (wide[:, :, 0] > 0.5).sum() > (tight[:, :, 0] > 0.5).sum() + 200, (
+        "spread did not dilate the glow outward"
+    )
+
+
 def _shadow_zone_mse(psd, ref):
     """MSE of a force=True recomposite vs the baked preview, restricted to the
     drop-shadow layer's neighbourhood in ``layer_effects.psd``."""
@@ -101,6 +124,38 @@ def test_drop_shadow_improves_composite_fidelity(monkeypatch):
 
     assert mse_real < mse_noop, (
         f"drop shadow did not improve fidelity: real={mse_real:.5f} noop={mse_noop:.5f}"
+    )
+
+
+def _glow_zone_mse(psd, ref):
+    """MSE of a force=True recomposite vs the baked preview, restricted to the
+    outer-glow layer's neighbourhood in ``layer_effects.psd``."""
+    color, _, _ = composite(psd, force=True)
+    # The "Outer Glow" layer sits at bbox (99, 98, 498, 146); crop its body + halo,
+    # clear of the bevel row above (y<81) and the inner-glow demo below (y>=164).
+    crop = (slice(95, 160), slice(55, 545))
+    return _mse(ref[crop], color[crop])
+
+
+def test_outer_glow_improves_composite_fidelity(monkeypatch):
+    """Rendering the outer glow moves the force=True composite closer to Photoshop's
+    baked preview than a no-op renderer does (falsifiable: a zero renderer ties)."""
+    composite_mod = sys.modules["psd_tools.composite.composite"]
+
+    psd = PSDImage.open(full_name("layer_effects.psd"))
+    ref = psd.numpy()[:, :, :3]
+
+    def _noop(viewport, shape, **kwargs):
+        h, w = viewport[3] - viewport[1], viewport[2] - viewport[0]
+        return np.zeros((h, w, 1), dtype=np.float32)
+
+    monkeypatch.setattr(composite_mod, "draw_outer_glow", _noop)
+    mse_noop = _glow_zone_mse(psd, ref)
+    monkeypatch.undo()
+    mse_real = _glow_zone_mse(psd, ref)
+
+    assert mse_real < mse_noop, (
+        f"outer glow did not improve fidelity: real={mse_real:.5f} noop={mse_noop:.5f}"
     )
 
 

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -1,10 +1,107 @@
 import logging
+import sys
 
+import numpy as np
 import pytest
 
-from .test_composite import check_composite_quality
+from psd_tools import PSDImage
+from psd_tools.composite import composite
+from psd_tools.composite.effects import draw_drop_shadow
+
+from ..utils import full_name
+from .test_composite import _mse, check_composite_quality
 
 logger = logging.getLogger(__name__)
+
+
+def _disc_shape(w, h, cx, cy, rad):
+    """A (h, w, 1) float32 silhouette: 1.0 inside a disc, else 0."""
+    yy, xx = np.mgrid[0:h, 0:w]
+    disc = ((xx - cx) ** 2 + (yy - cy) ** 2 <= rad**2).astype(np.float32)
+    return disc[:, :, None]
+
+
+def _centroid(mask):
+    m = mask[:, :, 0]
+    yy, xx = np.mgrid[0 : m.shape[0], 0 : m.shape[1]]
+    total = m.sum()
+    return (xx * m).sum() / total, (yy * m).sum() / total
+
+
+# ── Drop shadow / outer glow renderers (unit, synthetic) ────────────────────── #
+
+
+def test_draw_drop_shadow_casts_opposite_to_light():
+    """A 30deg light casts the shadow down-left (image coords, y-down)."""
+    w = h = 200
+    shape = _disc_shape(w, h, 100, 100, 30)
+    mask = draw_drop_shadow(
+        (0, 0, w, h), shape, distance=20, angle=30, size=1.0, choke=0
+    )
+    cx, cy = _centroid(mask)
+    assert cx < 100 - 5, f"shadow not cast left: cx={cx}"
+    assert cy > 100 + 5, f"shadow not cast down: cy={cy}"
+
+
+def test_draw_drop_shadow_blur_softens_and_spreads():
+    """A larger size produces a softer, wider shadow (partial coverage spreads out)."""
+    w = h = 200
+    shape = _disc_shape(w, h, 100, 100, 30)
+    hard = draw_drop_shadow((0, 0, w, h), shape, distance=0, angle=0, size=0, choke=0)
+    soft = draw_drop_shadow((0, 0, w, h), shape, distance=0, angle=0, size=18, choke=0)
+    soft_partial = ((soft[:, :, 0] > 0.05) & (soft[:, :, 0] < 0.95)).sum()
+    hard_partial = ((hard[:, :, 0] > 0.05) & (hard[:, :, 0] < 0.95)).sum()
+    assert soft_partial > hard_partial + 200, "size did not soften the shadow edge"
+    assert (soft[:, :, 0] > 0.05).sum() > (shape[:, :, 0] > 0.5).sum() + 200, (
+        "blur did not spread the shadow footprint"
+    )
+
+
+def test_draw_drop_shadow_choke_tightens_matte():
+    """Choke (a percent of size) erodes the matte before blur, shrinking coverage."""
+    w = h = 200
+    shape = _disc_shape(w, h, 100, 100, 40)
+    loose = draw_drop_shadow((0, 0, w, h), shape, distance=0, angle=0, size=20, choke=0)
+    tight = draw_drop_shadow(
+        (0, 0, w, h), shape, distance=0, angle=0, size=20, choke=80
+    )
+    assert (tight[:, :, 0] > 0.5).sum() < (loose[:, :, 0] > 0.5).sum() - 200, (
+        "choke did not tighten the matte"
+    )
+
+
+def _shadow_zone_mse(psd, ref):
+    """MSE of a force=True recomposite vs the baked preview, restricted to the
+    drop-shadow layer's neighbourhood in ``layer_effects.psd``."""
+    color, _, _ = composite(psd, force=True)
+    # The "Drop Shadow" text layer sits at bbox (99, 225, 564, 284); its cast shadow
+    # falls just around/below it, clear of the neighbouring effect demos.
+    crop = (slice(220, 296), slice(60, 580))
+    return _mse(ref[crop], color[crop])
+
+
+def test_drop_shadow_improves_composite_fidelity(monkeypatch):
+    """Rendering the drop shadow moves the force=True composite closer to Photoshop's
+    baked preview than a no-op shadow renderer does (falsifiable: a zero renderer ties)."""
+    # The package __init__ re-exports the composite() function, shadowing the submodule
+    # attribute, so reach the real module (where _apply_drop_shadow looks up the name).
+    composite_mod = sys.modules["psd_tools.composite.composite"]
+
+    psd = PSDImage.open(full_name("layer_effects.psd"))
+    ref = psd.numpy()[:, :, :3]
+
+    def _noop(viewport, shape, **kwargs):
+        h, w = viewport[3] - viewport[1], viewport[2] - viewport[0]
+        return np.zeros((h, w, 1), dtype=np.float32)
+
+    monkeypatch.setattr(composite_mod, "draw_drop_shadow", _noop)
+    mse_noop = _shadow_zone_mse(psd, ref)
+    monkeypatch.undo()
+    mse_real = _shadow_zone_mse(psd, ref)
+
+    assert mse_real < mse_noop, (
+        f"drop shadow did not improve fidelity: real={mse_real:.5f} noop={mse_noop:.5f}"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds **Outer Glow** rendering to `composite()`, the natural follow-up to drop shadow. `composite()`
already parses `OuterGlow` parameters but never rendered them, so the glow disappears on
`composite(force=True)`.

**Closes #382.**

> ⚠️ **Stacked on #679** (drop shadow). This branch is based on the drop-shadow branch, so until #679
> merges this PR's diff shows *both* commits. The net-new change here is the single commit
> **"feat: render outer glow layer effect"** — please review #679 first. Once #679 lands I'll rebase and
> the diff will reduce to just the glow change.

## Approach

Mirrors the drop-shadow renderer with three deltas that define an outer glow:

- **`composite/effects.py`** — new `draw_outer_glow(viewport, shape, *, size, spread)`: **dilates** the
  silhouette by spread (vs. a shadow's erode-choke), gaussian-blurs by size, and applies **no offset**
  (the glow is centered).
- **`composite/composite.py`** — `Compositor._apply_outer_glow()`, called right after
  `_apply_drop_shadow` so the glow paints *behind* the layer, then **unconditionally knocked out under
  the layer's own coverage** (`mask *= 1 - shape`), since an outer glow is by definition outside the
  layer. Reuses `_apply_source` + `BLEND_FUNC` (Screen) and `paint.draw_solid_color_fill`.

Solid color only; gradient glow (`OuterGlow.gradient`) is deferred. The module docstring promotes
outer glow to "supported".

## A heads-up on `OuterGlow.spread`

The renderer reads the spread amount from **`effect.choke`** (the `ChokeMatte` / `b'Ckmt'` descriptor
slot — where Photoshop actually stores a glow's "Spread"), **not** from `effect.spread`. The
`OuterGlow.spread` accessor currently reads `Key.ShadingNoise` (`b'ShdN'`, the *jitter* control), which
looks like a latent bug. I left the accessor alone to keep this PR focused — happy to send a separate
fix if you agree.

## Fidelity

Same honest caveat as drop shadow: placement is faithful (against `layer_effects.psd` the rendered
glow moves the `force=True` composite markedly closer to Photoshop's baked preview), but the falloff is
a gaussian approximation of Photoshop's proprietary blur, so intensity can differ.

## Tests

- Unit tests for `draw_outer_glow` (symmetric/no-offset spread; spread dilates the footprint).
- An integration test on `layer_effects.psd` asserting the glow moves the `force=True` composite closer
  to the baked preview than a no-op renderer (falsifiable — a zero renderer ties).
- Full `tests/psd_tools/composite/` suite passes (198); `ruff`, `ruff format`, `mypy` clean.
