### PR TITLE
fix: detect real user mask header from the channel list

### DIFF
--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -1012,12 +1012,13 @@ class MaskParameters(BaseElement):
     def read(
         cls: type[T_MaskParameters], fp: IO[bytes], **kwargs: Any
     ) -> T_MaskParameters:
-        parameters = read_fmt("B", fp)[0]
+        parameters = 0
         user_mask_density = None
         user_mask_feather = None
         vector_mask_density = None
         vector_mask_feather = None
         try:
+            parameters = read_fmt("B", fp)[0]
             if bool(parameters & 1):
                 user_mask_density = read_fmt("B", fp)[0]
             if bool(parameters & 2):

--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -608,7 +608,7 @@ class LayerRecord(BaseElement):
         )
         with io.BytesIO(data) as f:
             mask_data, blending_ranges, name, tagged_blocks = cls._read_extra(
-                f, encoding, version, has_real_mask
+                f, encoding, version, has_real_mask=has_real_mask
             )
             self = cls(
                 top=top,
@@ -681,6 +681,16 @@ class LayerRecord(BaseElement):
 
     def _write_extra(self, fp: IO[bytes], encoding: str, version: int) -> int:
         written = 0
+        if getattr(self.mask_data, "real_flags", None) is not None and not any(
+            channel.id == ChannelID.REAL_USER_LAYER_MASK
+            for channel in self.channel_info
+        ):
+            logger.warning(
+                "Layer %r carries real user mask data but no "
+                "REAL_USER_LAYER_MASK channel; the mask block will not read "
+                "back the same way.",
+                self.name,
+            )
         if self.mask_data and hasattr(self.mask_data, "write"):
             written += self.mask_data.write(fp)  # type: ignore[attr-defined]
         else:
@@ -785,6 +795,13 @@ class MaskData(BaseElement):
     Mask data.
 
     Real user mask is a final composite mask of vector and pixel masks.
+
+    The real user mask fields (:py:attr:`real_flags`,
+    :py:attr:`real_background_color` and the ``real_*`` rectangle) are present
+    only when the owning :py:class:`.LayerRecord` also carries a
+    :py:attr:`~psd_tools.constants.ChannelID.REAL_USER_LAYER_MASK` channel.
+    Keep the two in sync when building a record by hand, otherwise the written
+    mask block cannot be parsed back.
 
     .. py:attribute:: top
 
@@ -1012,7 +1029,7 @@ class MaskParameters(BaseElement):
     def read(
         cls: type[T_MaskParameters], fp: IO[bytes], **kwargs: Any
     ) -> T_MaskParameters:
-        parameters = 0
+        parameters: int | None = None
         user_mask_density = None
         user_mask_feather = None
         vector_mask_density = None
@@ -1029,8 +1046,8 @@ class MaskParameters(BaseElement):
                 vector_mask_feather = read_fmt("d", fp)[0]
         except OSError as exc:
             logger.warning(
-                "Truncated MaskParameters data (parameters=0x%02x); some fields will be missing: %s",
-                parameters,
+                "Truncated MaskParameters data (parameters=%s); some fields will be missing: %s",
+                "unknown" if parameters is None else "0x%02x" % parameters,
                 exc,
             )
         return cls(

--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -603,9 +603,12 @@ class LayerRecord(BaseElement):
 
         data = read_length_block(fp, fmt="xI")
         logger.debug("  read layer record, len=%d" % (fp.tell() - start_pos))
+        has_real_mask = any(
+            channel.id == ChannelID.REAL_USER_LAYER_MASK for channel in channel_info
+        )
         with io.BytesIO(data) as f:
             mask_data, blending_ranges, name, tagged_blocks = cls._read_extra(
-                f, encoding, version
+                f, encoding, version, has_real_mask
             )
             self = cls(
                 top=top,
@@ -632,9 +635,13 @@ class LayerRecord(BaseElement):
 
     @classmethod
     def _read_extra(
-        cls, fp: IO[bytes], encoding: str, version: int
+        cls,
+        fp: IO[bytes],
+        encoding: str,
+        version: int,
+        has_real_mask: bool | None = None,
     ) -> tuple["MaskData | None", LayerBlendingRanges, str, TaggedBlocks]:
-        mask_data = MaskData.read(fp)
+        mask_data = MaskData.read(fp, has_real_mask=has_real_mask)
         blending_ranges = LayerBlendingRanges.read(fp)
         name = read_pascal_string(fp, encoding, padding=4)
         tagged_blocks = TaggedBlocks.read(fp, version=version, padding=1)
@@ -847,16 +854,37 @@ class MaskData(BaseElement):
     real_right: int | None = None
 
     @classmethod
-    def read(cls: type[T_MaskData], fp: IO[bytes], **kwargs: Any) -> T_MaskData:  # type: ignore[return]
+    def read(  # type: ignore[return]
+        cls: type[T_MaskData],
+        fp: IO[bytes],
+        has_real_mask: bool | None = None,
+        **kwargs: Any,
+    ) -> T_MaskData:
+        """
+        Read the mask data block.
+
+        :param fp: file-like object.
+        :param has_real_mask: whether the layer stores a
+            :py:attr:`~psd_tools.constants.ChannelID.REAL_USER_LAYER_MASK`
+            channel, which is what determines the presence of the real user
+            mask header. When `None`, presence is guessed from the block
+            length, which is ambiguous for large
+            :py:class:`.MaskParameters` blocks.
+        """
         data = read_length_block(fp)
         if len(data) == 0:
             return None  # type: ignore[return-value]
 
         with io.BytesIO(data) as f:
-            return cls._read_body(f, len(data))
+            return cls._read_body(f, len(data), has_real_mask=has_real_mask)
 
     @classmethod
-    def _read_body(cls: type[T_MaskData], fp: IO[bytes], length: int) -> T_MaskData:
+    def _read_body(
+        cls: type[T_MaskData],
+        fp: IO[bytes],
+        length: int,
+        has_real_mask: bool | None = None,
+    ) -> T_MaskData:
         top, left, bottom, right, background_color = read_fmt("4iB", fp)
         flags = MaskFlags.read(fp)
 
@@ -866,9 +894,21 @@ class MaskData(BaseElement):
         #     read_fmt('2x', fp)
         #     return cls(top, left, bottom, right, background_color, flags)
 
+        # The real user mask header is present only when the layer actually
+        # stores a REAL_USER_LAYER_MASK (-3) channel. The block length alone
+        # cannot tell: a variable-length MaskParameters block can push the
+        # block to 36 bytes or more with no real mask header present at all,
+        # which used to make the parameters be read as a real mask header
+        # (#693). The length check is kept as a guard against malformed files
+        # that advertise a -3 channel but write a short mask block.
+        if has_real_mask is None:
+            read_real_mask = length >= 36
+        else:
+            read_real_mask = has_real_mask and length >= 36
+
         real_flags, real_background_color = None, None
         real_top, real_left, real_bottom, real_right = None, None, None, None
-        if length >= 36:
+        if read_real_mask:
             real_flags = MaskFlags.read(fp)
             real_background_color = read_fmt("B", fp)[0]
             real_top, real_left, real_bottom, real_right = read_fmt("4i", fp)

--- a/tests/psd_tools/psd/test_layer_and_mask.py
+++ b/tests/psd_tools/psd/test_layer_and_mask.py
@@ -373,6 +373,15 @@ def test_mask_parameters() -> None:
     assert len(MaskParameters(255, 1.0, 255, 1.0).tobytes()) == 19
 
 
+def test_mask_parameters_truncated_flag_byte(caplog: pytest.LogCaptureFixture) -> None:
+    """The truncation guard must also cover the parameter flag byte itself."""
+    with caplog.at_level(logging.WARNING):
+        with io.BytesIO(b"") as f:
+            parameters = MaskParameters.read(f)
+    assert parameters == MaskParameters()
+    assert "Truncated MaskParameters" in caplog.text
+
+
 def test_channel_image_data() -> None:
     check_write_read(ChannelImageData(), layer_records=LayerRecords())
 

--- a/tests/psd_tools/psd/test_layer_and_mask.py
+++ b/tests/psd_tools/psd/test_layer_and_mask.py
@@ -1,6 +1,7 @@
-from typing import Any, Tuple
+from typing import Any, Dict, Tuple
 import io
 import logging
+import struct
 
 import pytest
 
@@ -233,6 +234,133 @@ def test_mask_data_truncated_parameters(caplog: pytest.LogCaptureFixture) -> Non
     assert mask_data.parameters.user_mask_density == 0
     assert mask_data.parameters.vector_mask_density is None
     assert "Truncated MaskParameters" in caplog.text
+
+
+PARAMETER_FIELDS = (
+    "user_mask_density",
+    "user_mask_feather",
+    "vector_mask_density",
+    "vector_mask_feather",
+)
+
+PARAMETER_VALUES: Dict[str, Any] = {
+    "user_mask_density": 200,
+    "user_mask_feather": 3.5,
+    "vector_mask_density": 100,
+    "vector_mask_feather": 7.25,
+}
+
+
+def _build_mask_data_body(has_real_mask: bool, parameter_bits: int) -> bytes:
+    """Synthesize a MaskData body following the PSD byte layout."""
+    body = struct.pack(">4iB", 100, 100, 500, 500, 255)
+    body += struct.pack(">B", 0x10 if parameter_bits else 0x00)  # parameters_applied
+    if has_real_mask:
+        body += struct.pack(">BB4i", 0x00, 255, 90, 90, 510, 510)
+    if parameter_bits:
+        body += struct.pack(">B", parameter_bits)
+        if parameter_bits & 1:
+            body += struct.pack(">B", PARAMETER_VALUES["user_mask_density"])
+        if parameter_bits & 2:
+            body += struct.pack(">d", PARAMETER_VALUES["user_mask_feather"])
+        if parameter_bits & 4:
+            body += struct.pack(">B", PARAMETER_VALUES["vector_mask_density"])
+        if parameter_bits & 8:
+            body += struct.pack(">d", PARAMETER_VALUES["vector_mask_feather"])
+    return body + b"\x00" * (-len(body) % 4)
+
+
+@pytest.mark.parametrize("has_real_mask", [False, True])
+@pytest.mark.parametrize("parameter_bits", [0b1010, 0b1011, 0b1110, 0b1111])
+def test_mask_data_real_mask_detection(
+    has_real_mask: bool, parameter_bits: int
+) -> None:
+    """Real mask header presence follows the channel list, not the block length.
+
+    These are the parameter combinations whose block reaches 36 bytes or more
+    without a REAL_USER_LAYER_MASK channel, so the old ``length >= 36``
+    heuristic read the MaskParameters payload as a real mask header (#693).
+    """
+    body = _build_mask_data_body(has_real_mask, parameter_bits)
+    assert len(body) >= 36  # otherwise the case under test is not exercised
+
+    with io.BytesIO(body) as f:
+        mask_data = MaskData._read_body(f, len(body), has_real_mask=has_real_mask)
+
+    assert (mask_data.real_flags is not None) is has_real_mask
+    assert mask_data.parameters is not None
+    for i, key in enumerate(PARAMETER_FIELDS):
+        expected = PARAMETER_VALUES[key] if parameter_bits & (1 << i) else None
+        assert getattr(mask_data.parameters, key) == expected
+
+
+def test_mask_data_parameters_without_real_mask() -> None:
+    """Mask data captured from the real-world file reported in #693.
+
+    A layer with both a pixel mask and a vector mask carrying custom density
+    and feather, but no REAL_USER_LAYER_MASK channel. The block is 40 bytes,
+    so the old heuristic silently returned None for every parameter.
+    """
+    body = bytes.fromhex(
+        "00000a600000074100000d8500000b5bff100fe6"
+        "4014000000000000804024000000000000000000"
+    )
+    with io.BytesIO(body) as f:
+        mask_data = MaskData._read_body(f, len(body), has_real_mask=False)
+
+    assert mask_data.real_flags is None
+    assert mask_data.parameters == MaskParameters(230, 5.0, 128, 10.0)
+
+
+def test_mask_data_rw_parameters_without_real_mask() -> None:
+    mask_data = MaskData(
+        top=100,
+        left=100,
+        bottom=500,
+        right=500,
+        background_color=255,
+        flags=MaskFlags(parameters_applied=True),
+        parameters=MaskParameters(200, 3.5, 100, 7.25),
+    )
+    with io.BytesIO() as f:
+        mask_data.write(f)
+        data = f.getvalue()
+    with io.BytesIO(data) as f:
+        assert MaskData.read(f, has_real_mask=False) == mask_data
+
+
+def test_layer_record_rw_parameters_without_real_mask() -> None:
+    """LayerRecord must derive the real mask flag from its own channel list."""
+    parameters = MaskParameters(200, 3.5, 100, 7.25)
+    record = LayerRecord(
+        top=100,
+        left=100,
+        bottom=500,
+        right=500,
+        channel_info=[
+            ChannelInfo(id=ChannelID.CHANNEL_0, length=2),
+            ChannelInfo(id=ChannelID.USER_LAYER_MASK, length=2),
+        ],
+        mask_data=MaskData(
+            top=100,
+            left=100,
+            bottom=500,
+            right=500,
+            background_color=255,
+            flags=MaskFlags(parameters_applied=True),
+            parameters=parameters,
+        ),
+        name="mask parameters",
+    )
+    with io.BytesIO() as f:
+        record.write(f)
+        data = f.getvalue()
+    with io.BytesIO(data) as f:
+        parsed = LayerRecord.read(f)
+
+    assert isinstance(parsed.mask_data, MaskData)
+    assert parsed.mask_data.real_flags is None
+    assert parsed.mask_data.parameters == parameters
 
 
 def test_mask_parameters() -> None:

--- a/tests/psd_tools/psd/test_layer_and_mask.py
+++ b/tests/psd_tools/psd/test_layer_and_mask.py
@@ -211,28 +211,46 @@ def test_mask_data_rw(fixture: bytes) -> None:
     check_read_write(MaskData, fixture)
 
 
-def test_mask_data_truncated_parameters(caplog: pytest.LogCaptureFixture) -> None:
-    """Regression test: MaskData with truncated MaskParameters should not crash.
+# Mask data captured from the sample file attached to #573. The layer has
+# channels [-1, 0, 1, 2, -2] and no REAL_USER_LAYER_MASK channel, so the block
+# carries no real mask header and its 19-byte MaskParameters payload fills it
+# exactly: 18 + 19 + 1 byte of padding = 38.
+MASK_DATA_573 = (
+    b"\x00\x00\x00\x26"
+    b"\x00\x00\x03\x8b\x00\x00\x00\xdb\x00\x00\x03\xad\x00\x00\x02\x8c"
+    b"\x00\x18\x0f\xff\x00\x00\x00\x00\x00\x00\x00\x00\xff\x40\x36\xcc"
+    b"\xcc\xcc\xcc\xcc\xcd\x00"
+)
 
-    Some third-party PSD writers (e.g. game asset exporters on Windows) write a
-    MaskData block with parameters_applied=True but only a partial MaskParameters
-    payload, filling the remainder with uninitialized memory (MSVC debug patterns
-    0xCC/0xCD). psd-tools should tolerate this rather than raising OSError.
+
+def test_mask_data_parameters_573_sample() -> None:
+    """The #573 sample is not truncated data, it is the #693 bug.
+
+    The trailing ``cc cc cc cc cc cd`` bytes are the IEEE-754 mantissa of 22.8,
+    not uninitialized memory from a third-party writer. Reading them as part of
+    a real mask header is what made the block look truncated.
     """
-    fixture = (
-        b"\x00\x00\x00\x26"
-        b"\x00\x00\x03\x8b\x00\x00\x00\xdb\x00\x00\x03\xad\x00\x00\x02\x8c"
-        b"\x00\x18\x0f\xff\x00\x00\x00\x00\x00\x00\x00\x00\xff\x40\x36\xcc"
-        b"\xcc\xcc\xcc\xcc\xcd\x00"
-    )
+    with io.BytesIO(MASK_DATA_573) as f:
+        mask_data = MaskData.read(f, has_real_mask=False)
+    assert mask_data is not None
+    assert mask_data.flags.parameters_applied
+    assert mask_data.real_flags is None
+    assert mask_data.parameters == MaskParameters(255, 0.0, 255, 22.8)
+
+
+def test_mask_data_truncated_parameters(caplog: pytest.LogCaptureFixture) -> None:
+    """Without a channel list, the ambiguous length heuristic must not crash.
+
+    Callers that read a MaskData block on its own cannot know whether a real
+    mask header is present, so they fall back to the length heuristic and can
+    still misread a block like this one. That must degrade to a warning rather
+    than raise (#573).
+    """
     with caplog.at_level(logging.WARNING):
-        with io.BytesIO(fixture) as f:
+        with io.BytesIO(MASK_DATA_573) as f:
             mask_data = MaskData.read(f)
     assert mask_data is not None
     assert mask_data.flags.parameters_applied
-    assert mask_data.parameters is not None
-    assert mask_data.parameters.user_mask_density == 0
-    assert mask_data.parameters.vector_mask_density is None
     assert "Truncated MaskParameters" in caplog.text
 
 
@@ -292,6 +310,18 @@ def test_mask_data_real_mask_detection(
     for i, key in enumerate(PARAMETER_FIELDS):
         expected = PARAMETER_VALUES[key] if parameter_bits & (1 << i) else None
         assert getattr(mask_data.parameters, key) == expected
+
+
+def test_mask_data_short_block_ignores_real_mask_flag() -> None:
+    """A -3 channel cannot imply a real mask header the block has no room for."""
+    body = _build_mask_data_body(has_real_mask=False, parameter_bits=0)
+    assert len(body) == 20
+
+    with io.BytesIO(body) as f:
+        mask_data = MaskData._read_body(f, len(body), has_real_mask=True)
+
+    assert mask_data.real_flags is None
+    assert mask_data.parameters is None
 
 
 def test_mask_data_parameters_without_real_mask() -> None:
@@ -361,6 +391,47 @@ def test_layer_record_rw_parameters_without_real_mask() -> None:
     assert isinstance(parsed.mask_data, MaskData)
     assert parsed.mask_data.real_flags is None
     assert parsed.mask_data.parameters == parameters
+
+
+def test_layer_record_rw_parameters_with_real_mask() -> None:
+    """The real mask header round-trips when the -3 channel is present."""
+    parameters = MaskParameters(200, 3.5, 100, 7.25)
+    mask_data = MaskData(
+        top=100,
+        left=100,
+        bottom=500,
+        right=500,
+        background_color=255,
+        flags=MaskFlags(parameters_applied=True),
+        parameters=parameters,
+        real_flags=MaskFlags(parameters_applied=True),
+        real_background_color=255,
+        real_top=90,
+        real_left=90,
+        real_bottom=510,
+        real_right=510,
+    )
+    record = LayerRecord(
+        top=100,
+        left=100,
+        bottom=500,
+        right=500,
+        channel_info=[
+            ChannelInfo(id=ChannelID.CHANNEL_0, length=2),
+            ChannelInfo(id=ChannelID.USER_LAYER_MASK, length=2),
+            ChannelInfo(id=ChannelID.REAL_USER_LAYER_MASK, length=2),
+        ],
+        mask_data=mask_data,
+        name="real mask",
+    )
+    with io.BytesIO() as f:
+        record.write(f)
+        data = f.getvalue()
+    with io.BytesIO(data) as f:
+        parsed = LayerRecord.read(f)
+
+    assert isinstance(parsed.mask_data, MaskData)
+    assert parsed.mask_data == mask_data
 
 
 def test_mask_parameters() -> None:


### PR DESCRIPTION
Fixes #693.

## Problem

`MaskData._read_body()` decided whether the 18-byte *real user mask* header
(`real_flags` / `real_background_color` / `real_top` / `real_left` /
`real_bottom` / `real_right`) is present solely from `length >= 36`.

That header is actually present only when the layer stores a
`REAL_USER_LAYER_MASK` (`-3`) channel. Since the trailing `MaskParameters`
block is variable length (1–19 bytes), a layer with **both** a pixel mask and a
vector mask carrying custom density and feather, and **no** `-3` channel,
produces a block of 36 bytes or more with no real mask header at all. The
parameters payload was then consumed as the real mask header, so
`user_mask_density` / `user_mask_feather` / `vector_mask_density` /
`vector_mask_feather` came back as `None` — or the read raised `OSError` when
the misread header consumed the block exactly.

Enumerating all 32 combinations (`-3` channel present/absent × 16 parameter bit
patterns) shows 4 of the 16 no-real-channel cases misparse:

| parameter bits | block length | old behavior |
| --- | --- | --- |
| `0b1010`, `0b1011`, `0b1110` | 36 | `OSError` |
| `0b1111` | 40 | silently `None` × 4 |

## Fix

`LayerRecord.read()` already has `channel_info` in scope, so pass that ground
truth down through `_read_extra()` → `MaskData.read()` → `_read_body()`.

- The parameter is optional (`has_real_mask: bool | None = None`) and falls back
  to the old length heuristic when omitted, so direct `MaskData.read()` callers
  keep working.
- It is AND-ed with `length >= 36`, so a malformed file advertising a `-3`
  channel while writing a short mask block does not read past the block end.
- A leftover-byte consistency check would *not* have been sufficient on its own:
  in the 40-byte case both hypotheses consume the block to within the 4-byte
  padding slack, so the channel list is the only available ground truth.

A second commit moves the `MaskParameters` flag-byte read inside the truncation
`try`/`except` added in daa2382 — it previously sat outside, so a block ending
exactly where `MaskParameters` begins still raised instead of warning.

## Validation

- The real-world 40-byte block from #693 now decodes to
  `user_mask_density=230, user_mask_feather=5.0, vector_mask_density=128,
  vector_mask_feather=10.0`, matching the reporter's expected values.
- All 354 mask blocks across `tests/psd_files/` parse identically to before, and
  in every one of them the `-3` channel presence agrees with the real mask
  header presence (0 mismatches) — supporting the channel list as the correct
  discriminator.
- `mask_parameters.psd` confirms psd-tools' field ordering (real header *then*
  `MaskParameters`, contrary to the order the spec states).

## Also fixes #573

The sample file attached to #573 turns out to have the same root cause, not
truncated data. Its masked layer has channels `[-1, 0, 1, 2, -2]` — no `-3`
channel — and a 38-byte mask block. The trailing `cc cc cc cc cc cd` bytes that
daa2382 attributed to MSVC uninitialized-memory debug patterns are in fact the
IEEE-754 mantissa of `22.8`: `0x4036CCCCCCCCCCCD`. Parsed with the correct
header detection, that block decodes cleanly as
`MaskParameters(user_mask_density=255, user_mask_feather=0.0,
vector_mask_density=255, vector_mask_feather=22.8)`, and the file opens without
warnings.

The regression test added with daa2382 was asserting those misparsed values, so
it is split in two: one test pins the correct parse, the other keeps the
no-crash guarantee for callers that read a `MaskData` block on its own and must
fall back to the length heuristic.

## Notes

- `LayerRecord._write_extra()` now warns when a record carries real user mask
  data but no `-3` channel — the block it writes could not be read back the same
  way. Nothing in psd-tools' own API can produce that state; it only affects
  hand-built records.
- `MaskData.has_real()` at the API level is unaffected: `parameters_applied` is
  bit 4 and a `MaskParameters` flag byte only uses bits 0–3, so a misparsed real
  header never reported `has_real() == True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
