### PR TITLE
fix: correct pass-through group opacity compositing (fixes #703)

### DIFF
--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -403,10 +403,9 @@ class Compositor(object):
         # must happen in premultiplied space so a transparent (or partially
         # transparent) backdrop does not bleed its color into the result.
         #
-        # TODO: knockout is ignored here while _get_group() honors it, so a
-        # knockout pass-through group interpolates against a different backdrop
-        # than it was composited over. Photoshop effectively disables knockout
-        # for pass-through groups, so this combination is left unhandled.
+        # TODO(#707): knockout is ignored here while _get_group() honors it, so
+        # a knockout pass-through group interpolates against a different backdrop
+        # than it was composited over, and the result varies with nesting depth.
         color_b = self._color
         alpha_b = self._alpha
 

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -402,6 +402,11 @@ class Compositor(object):
         # between the backdrop and that result by the group opacity/mask, which
         # must happen in premultiplied space so a transparent (or partially
         # transparent) backdrop does not bleed its color into the result.
+        #
+        # TODO: knockout is ignored here while _get_group() honors it, so a
+        # knockout pass-through group interpolates against a different backdrop
+        # than it was composited over. Photoshop effectively disables knockout
+        # for pass-through groups, so this combination is left unhandled.
         color_b = self._color
         alpha_b = self._alpha
 
@@ -418,7 +423,8 @@ class Compositor(object):
             np.where(
                 self._alpha > 0.0,
                 utils.divide(color_t, self._alpha),
-                # Fully transparent: keep the backdrop that ``color`` carries.
+                # Fully transparent, so the color is arbitrary; ``color`` merely
+                # avoids utils.divide()'s 0 / 0 -> 1.0 (white) fallback.
                 color,
             )
         )

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -391,21 +391,37 @@ class Compositor(object):
         alpha: np.ndarray,
         mask: float | np.ndarray,
     ) -> None:
-        new_shape = cast(np.ndarray, utils.union(self._shape_g, shape))
+        if self._color_0.shape[2] == 1 and 1 < color.shape[2]:
+            self._color_0 = np.repeat(self._color_0, color.shape[2], axis=2)
+        if self._color.shape[2] == 1 and 1 < color.shape[2]:
+            self._color = np.repeat(self._color, color.shape[2], axis=2)
 
-        # this step is used to use over composing when no pixels are found in the backdrop, instead of linear interpolation composing
-        color_support = utils.clip(
-            utils.divide(
-                color * mask * (1.0 - self._shape_g) + self._color * self._shape_g,
-                new_shape,
-            )
-        )
+        # ``color`` is the group already composited over this backdrop, because a
+        # pass-through group is rendered by a non-isolated sub-compositor seeded
+        # with the backdrop. Re-applying the group therefore means interpolating
+        # between the backdrop and that result by the group opacity/mask, which
+        # must happen in premultiplied space so a transparent (or partially
+        # transparent) backdrop does not bleed its color into the result.
+        color_b = self._color
+        alpha_b = self._alpha
 
-        self._shape_g = new_shape
+        self._shape_g = cast(np.ndarray, utils.union(self._shape_g, shape))
         self._alpha_g = cast(np.ndarray, utils.union(self._alpha_g, alpha))
+        # union(alpha_b, alpha) -- ``alpha`` is the group alpha already scaled by
+        # ``mask``, which is what the premultiplied interpolation resolves to.
         self._alpha = cast(np.ndarray, utils.union(self._alpha_0, self._alpha_g))
 
-        self._color = utils.clip((color * mask + (1 - mask) * color_support))
+        color_t = (1.0 - mask) * alpha_b * color_b + (
+            mask * alpha_b + alpha * (1.0 - alpha_b)
+        ) * color
+        self._color = utils.clip(
+            np.where(
+                self._alpha > 0.0,
+                utils.divide(color_t, self._alpha),
+                # Fully transparent: keep the backdrop that ``color`` carries.
+                color,
+            )
+        )
 
     def _apply_source(
         self,

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -1,8 +1,13 @@
 import logging
 
+import numpy as np
 import pytest
+from PIL import Image
 
+from psd_tools import PSDImage
+from psd_tools.api.layers import GroupMixin, PixelLayer
 from psd_tools.composite.blend import BLEND_FUNC, lighter_color, normal
+from psd_tools.constants import BlendMode
 from .test_composite import check_composite_quality
 
 logger = logging.getLogger(__name__)
@@ -84,3 +89,97 @@ def test_blend_quality_xfail(filename: str) -> None:
 def test_passthrough_properties(property) -> None:
     filename = f"passthrough_{property}"
     check_composite_quality(f"{filename}.psd", 0.001, False)
+
+
+def _nested_passthrough_psd_with(
+    depth: int, opacity: int, layer_alpha: int, background_alpha: int
+) -> PSDImage:
+    """Build ``depth`` nested pass-through groups holding a single blue layer.
+
+    Only the innermost group carries ``opacity``; the outer ones are opaque, so
+    the rendered result must not depend on ``depth``.
+    """
+    psd = PSDImage.new(mode="RGB", size=(8, 8))
+    if background_alpha:
+        psd.create_pixel_layer(
+            image=Image.new("RGBA", (8, 8), (255, 0, 0, background_alpha)),
+            name="Background",
+        )
+
+    parent: GroupMixin = psd
+    for i in range(depth):
+        group = psd.create_group(name=f"Group {i}")
+        group.blend_mode = BlendMode.PASS_THROUGH
+        group.opacity = opacity if i == depth - 1 else 255
+        if parent is not psd:
+            psd.remove(group)
+            parent.append(group)
+        parent = group
+
+    blue = PixelLayer.frompil(Image.new("RGBA", (8, 8), (0, 0, 255, layer_alpha)), psd)
+    blue.name = "Blue"
+    parent.append(blue)
+    return psd
+
+
+def _nested_passthrough_psd(depth: int, opacity: int, background: bool) -> PSDImage:
+    return _nested_passthrough_psd_with(
+        depth, opacity, layer_alpha=128, background_alpha=255 if background else 0
+    )
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_passthrough_group_opacity_over_opaque_backdrop(depth: int) -> None:
+    """Group opacity must scale the effective alpha of the group's contents
+    instead of blending the backdrop in twice (issue #703)."""
+    psd = _nested_passthrough_psd(depth, opacity=128, background=True)
+    image = psd.composite(ignore_preview=True).convert("RGB")
+    pixel = tuple(np.array(image, dtype=int)[4, 4])
+    # 50% layer alpha * 50% group opacity = 25% blue over red.
+    assert pixel == pytest.approx((191, 0, 64), abs=2)
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_passthrough_group_opacity_over_transparent_backdrop(depth: int) -> None:
+    """Without a backdrop, group opacity only scales alpha; the initial
+    backdrop color must not bleed into the result (issue #703)."""
+    psd = _nested_passthrough_psd(depth, opacity=128, background=False)
+    image = psd.composite(ignore_preview=True).convert("RGBA")
+    pixel = tuple(np.array(image, dtype=int)[4, 4])
+    assert pixel == pytest.approx((0, 0, 255, 64), abs=2)
+
+
+def _flat_psd(alpha: int, background_alpha: int) -> PSDImage:
+    """The ungrouped counterpart of :py:func:`_nested_passthrough_psd`."""
+    psd = PSDImage.new(mode="RGB", size=(8, 8))
+    if background_alpha:
+        psd.create_pixel_layer(
+            image=Image.new("RGBA", (8, 8), (255, 0, 0, background_alpha)), name="BG"
+        )
+    psd.append(PixelLayer.frompil(Image.new("RGBA", (8, 8), (0, 0, 255, alpha)), psd))
+    return psd
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+@pytest.mark.parametrize("opacity", [255, 192, 128, 64, 0])
+@pytest.mark.parametrize("layer_alpha", [255, 128, 64])
+@pytest.mark.parametrize("background_alpha", [255, 128, 0])
+def test_passthrough_group_opacity_equivalence(
+    depth: int, opacity: int, layer_alpha: int, background_alpha: int
+) -> None:
+    """A pass-through group at opacity ``m`` around a single normal layer at
+    alpha ``a`` must render identically to that layer ungrouped at ``m * a``.
+
+    This is the invariant issue #703 violated: group opacity has to scale the
+    effective alpha of the contents rather than blend the backdrop in twice.
+    """
+    grouped = _nested_passthrough_psd_with(
+        depth, opacity, layer_alpha, background_alpha
+    )
+    flat = _flat_psd(round(opacity * layer_alpha / 255.0), background_alpha)
+
+    got = np.array(grouped.composite(ignore_preview=True).convert("RGBA"), dtype=int)
+    ref = np.array(flat.composite(ignore_preview=True).convert("RGBA"), dtype=int)
+    if got[4, 4, 3] == 0 and ref[4, 4, 3] == 0:
+        return  # Fully transparent; the color channels are undefined.
+    assert tuple(got[4, 4]) == pytest.approx(tuple(ref[4, 4]), abs=2)

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -149,6 +149,25 @@ def test_passthrough_group_opacity_over_transparent_backdrop(depth: int) -> None
     assert pixel == pytest.approx((0, 0, 255, 64), abs=2)
 
 
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_passthrough_group_opacity_over_partial_backdrop(depth: int) -> None:
+    """The interpolation has to happen in premultiplied space, so a partially
+    transparent backdrop contributes in proportion to its own alpha.
+
+    This is the case the pre-#703 code got wrong even without nesting, because
+    it keyed off ``_shape_g`` rather than the backdrop alpha.
+    """
+    psd = _nested_passthrough_psd_with(
+        depth, opacity=128, layer_alpha=128, background_alpha=128
+    )
+    image = psd.composite(ignore_preview=True).convert("RGBA")
+    pixel = tuple(np.array(image, dtype=int)[4, 4])
+    # backdrop 0.5 red, group result 0.25 blue over it, group opacity 0.5:
+    #   alpha = union(0.5, 0.5 * 0.5)   = 0.625  -> 159
+    #   color = (0.375 * red + 0.25 * blue) / 0.625 = 0.6 red + 0.4 blue
+    assert pixel == pytest.approx((153, 0, 102, 159), abs=2)
+
+
 def _flat_psd(alpha: int, background_alpha: int) -> PSDImage:
     """The ungrouped counterpart of :py:func:`_nested_passthrough_psd`."""
     psd = PSDImage.new(mode="RGB", size=(8, 8))


### PR DESCRIPTION
Fixes #703.

## Problem

`Compositor._apply_passthrough_source` chose between "over" compositing and backdrop interpolation by testing `self._shape_g` — whether anything had been drawn into *that* compositor yet. That is not a test for whether a backdrop exists:

- A pass-through group is rendered by a **non-isolated sub-`Compositor`** that is seeded with the backdrop color/alpha but starts with `_shape_g` at zero. Any **nested** pass-through group therefore took the "no backdrop" branch and computed `color * mask + (1 - mask) * color * mask`, an expression with no relation to the backdrop at all.
- Even at the top level the branch was wrong whenever the backdrop was **not fully opaque**, because `_shape_g` and the backdrop alpha diverge there.

The reported case — red background, nested pass-through group at 50% opacity holding a 50% alpha blue layer — rendered `(127, 0, 128)` instead of Photoshop's and GIMP's `(191, 0, 64)`.

## Fix

Replace the heuristic with the interpolation the model actually calls for, done in premultiplied space so a transparent backdrop cannot bleed its color in:

```
alpha_result = union(alpha_b, alpha)
color_result = ((1 - m) * alpha_b * color_b
                + (m * alpha_b + alpha * (1 - alpha_b)) * color) / alpha_result
```

where `color` is the group already composited over the backdrop and `alpha` is the group alpha pre-scaled by `m`. This holds because `m * alpha_b + alpha * (1 - alpha_b) == m * union(alpha_b, alpha_children)` when `alpha == m * alpha_children`, so the expression is exactly `(1-m)·α_b·C_b + m·α_R·C_R`. It reduces to the group result at `m = 1` and to the backdrop at `m = 0`.

## Validation

The invariant that motivates the formula: a pass-through group at opacity `m` around a single normal layer at alpha `a` must render identically to that layer **ungrouped** at `m * a`. Measured across 135 combinations (nesting depth 1–3 × group opacity 0/64/128/192/255 × layer alpha 64/128/255 × backdrop alpha 0/128/255):

| | wrong combinations |
|---|---|
| before | **72 / 135** — including `opacity=0` groups rendering fully black at depth 1 |
| after | **0 / 135** (max deviation 1/255) |

Composite MSE against the embedded Photoshop preview for all 236 PSD fixtures: 234 bit-identical, 2 differing by ~1e-8 (float reassociation only).

The scope is wider than the ticket: **any** pass-through group with opacity < 255 over a non-opaque backdrop was affected, not just nested ones.

## Tests

Added to `tests/psd_tools/composite/test_blend.py`:

- opacity over an opaque backdrop at depth 1–3 (the reported case)
- opacity over a **partially** transparent backdrop at depth 1–3 — the case the old code got wrong even without nesting, and what makes premultiplication necessary
- opacity over a fully transparent backdrop at depth 1–3
- the `m * a` equivalence invariant, parametrized over the grid above

77 of these fail against the previous implementation.

## Known limitation (pre-existing, tracked in #707)

`_apply_passthrough_source` ignores the `knockout` flag while `_get_group` honors it, so a knockout pass-through group interpolates against a different backdrop than it was composited over, and the result varies with nesting depth.

This is not a regression from this PR. Before it, the knockout cases returned a uniform `(127, 0, 128)` — but only because the *non*-knockout pass-through path was itself broken at depth ≥ 2 and produced the same wrong value. Fixing the non-knockout path is what makes the knockout inconsistency observable; the underlying omission predates it. Left unhandled behind a `TODO(#707)` rather than guessing at semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

