### PR TITLE
test: add a unit-test safety net for compositor primitives (closes #715)

### DIFF
--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -214,14 +214,14 @@ def test_apply_source_fully_transparent_source_leaves_the_backdrop() -> None:
     assert np.allclose(alpha, 0.0)
 
 
-def test_apply_source_half_alpha_over_transparent_backdrop_keeps_source_colour() -> (
-    None
-):
-    """The returned colour is the *isolated* source, not the blended result.
+def test_apply_source_returns_the_isolated_source_not_the_blend() -> None:
+    """Over an *opaque* backdrop, the returned colour is the isolated source.
 
     ``finish()`` returns ``Compositor.color``, which removes the initial
-    backdrop's contribution. Compositing this result over that backdrop is what
-    reproduces the visible pixel -- here 50% blue over red gives (0.5, 0, 0.5).
+    backdrop's contribution. Compositing this result back over that backdrop is
+    what reproduces the visible pixel -- here 50% blue over opaque red gives
+    (0.5, 0, 0.5), which ``test_color_correction_removes_an_opaque_backdrop``
+    checks explicitly.
     """
     color, _, alpha = apply_one(RED, 1.0, BLUE, 0.5, 0.5)
     assert np.allclose(color[0, 0], BLUE)

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -1,0 +1,351 @@
+"""Unit tests for the compositor's primitives.
+
+The rest of the composite suite is end-to-end: render a fixture, compare MSE
+against a reference. That is a good acceptance suite and a poor refactoring
+suite -- a broken transparency term surfaces as a threshold miss on some
+fixture, with no indication of which equation moved.
+
+These tests pin the primitives directly, so a change to the compositing maths
+fails with a specific, hand-checkable number. See #715.
+"""
+
+import numpy as np
+import pytest
+
+from psd_tools.composite import utils
+from psd_tools.composite.composite import Compositor, _blend_backdrop, paste
+from psd_tools.constants import BlendMode, ColorMode, Knockout
+
+RED = (1.0, 0.0, 0.0)
+GREEN = (0.0, 1.0, 0.0)
+BLUE = (0.0, 0.0, 1.0)
+WHITE = (1.0, 1.0, 1.0)
+
+
+def gray(value: float, size: tuple[int, int] = (2, 2)) -> np.ndarray:
+    """A single-channel array filled with ``value``."""
+    return np.full((size[0], size[1], 1), value, dtype=np.float32)
+
+
+def rgb(
+    color: tuple[float, float, float], size: tuple[int, int] = (2, 2)
+) -> np.ndarray:
+    """A three-channel array filled with ``color``."""
+    return np.tile(np.array(color, dtype=np.float32), (size[0], size[1], 1))
+
+
+# ---------------------------------------------------------------------------
+# paste()
+# ---------------------------------------------------------------------------
+
+
+def test_paste_identity() -> None:
+    values = np.arange(4, dtype=np.float32).reshape(2, 2, 1)
+    assert np.array_equal(paste((0, 0, 2, 2), (0, 0, 2, 2), values), values)
+
+
+def test_paste_inset_places_values_at_the_offset() -> None:
+    values = np.arange(4, dtype=np.float32).reshape(2, 2, 1)
+    result = paste((0, 0, 4, 4), (1, 1, 3, 3), values)
+    assert result.shape == (4, 4, 1)
+    assert np.array_equal(result[1:3, 1:3, :], values)
+    # Everything outside the bbox is background.
+    assert result[0, :, :].sum() == 0.0
+    assert result[3, :, :].sum() == 0.0
+
+
+def test_paste_crops_when_bbox_overhangs_the_viewport() -> None:
+    values = np.arange(4, dtype=np.float32).reshape(2, 2, 1)
+    result = paste((0, 0, 1, 1), (0, 0, 2, 2), values)
+    assert result.shape == (1, 1, 1)
+    assert result[0, 0, 0] == values[0, 0, 0]
+
+
+def test_paste_disjoint_bbox_is_all_background() -> None:
+    values = np.ones((2, 2, 1), dtype=np.float32)
+    assert np.array_equal(
+        paste((0, 0, 2, 2), (5, 5, 7, 7), values, 1.0), np.ones((2, 2, 1), np.float32)
+    )
+    assert np.array_equal(
+        paste((0, 0, 2, 2), (5, 5, 7, 7), values), np.zeros((2, 2, 1), np.float32)
+    )
+
+
+@pytest.mark.parametrize("background", [None, 0.0])
+def test_paste_background_none_and_zero_agree(background: float | None) -> None:
+    """``paste`` selects its fill by truthiness, so 0.0 takes the zeros path.
+
+    The two are numerically identical today. Pinned so that a change to the
+    guard (``if background`` -> ``if background is not None``) stays a no-op
+    rather than silently altering output. See the checklist in #711.
+    """
+    values = np.ones((1, 1, 1), dtype=np.float32)
+    result = paste((0, 0, 3, 3), (0, 0, 1, 1), values, background)
+    assert result[2, 2, 0] == 0.0
+
+
+def test_paste_background_fills_the_uncovered_region() -> None:
+    values = np.zeros((1, 1, 1), dtype=np.float32)
+    result = paste((0, 0, 3, 3), (0, 0, 1, 1), values, 1.0)
+    assert result[0, 0, 0] == 0.0  # the pasted value survives
+    assert result[2, 2, 0] == 1.0  # the rest is background
+
+
+def test_paste_preserves_channel_count() -> None:
+    assert paste((0, 0, 4, 4), (1, 1, 3, 3), rgb(BLUE)).shape == (4, 4, 3)
+
+
+# ---------------------------------------------------------------------------
+# utils
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("a", "b"), [(0.0, 0.0), (0.0, 1.0), (0.25, 0.5), (0.5, 0.5), (1.0, 1.0)]
+)
+def test_union_matches_its_definition_and_commutes(a: float, b: float) -> None:
+    assert utils.union(a, b) == pytest.approx(a + b - a * b)
+    assert utils.union(a, b) == pytest.approx(utils.union(b, a))
+
+
+@pytest.mark.parametrize("x", [0.0, 0.25, 1.0])
+def test_union_identities(x: float) -> None:
+    assert utils.union(x, 0.0) == pytest.approx(x)
+    assert utils.union(x, 1.0) == pytest.approx(1.0)
+
+
+def test_divide_falls_back_to_one_on_non_finite() -> None:
+    """Division by zero yields 1.0, i.e. white in normalised colour space.
+
+    This is a deliberate policy rather than an accident, and callers depend on
+    it -- see the ``np.where`` guard in ``_apply_passthrough_source``. #714
+    proposes making the fallback caller-specified; this test is what that
+    change has to consciously update.
+    """
+    assert np.array_equal(utils.divide(gray(1.0), gray(0.0)), gray(1.0))
+    assert np.array_equal(utils.divide(gray(0.0), gray(0.0)), gray(1.0))
+
+
+def test_divide_is_ordinary_where_the_divisor_is_non_zero() -> None:
+    assert np.allclose(utils.divide(gray(1.0), gray(4.0)), gray(0.25))
+
+
+def test_clip_bounds() -> None:
+    values = np.array([[-1.0, 0.0, 0.5, 1.0, 2.0]], dtype=np.float32)
+    assert np.array_equal(utils.clip(values), np.array([[0.0, 0.0, 0.5, 1.0, 1.0]]))
+
+
+def test_intersect() -> None:
+    assert utils.intersect((0, 0, 4, 4), (1, 1, 3, 3)) == (1, 1, 3, 3)
+    assert utils.intersect((0, 0, 2, 2), (1, 1, 4, 4)) == (1, 1, 2, 2)
+    # Disjoint and merely-touching boxes both collapse to the empty box.
+    assert utils.intersect((0, 0, 2, 2), (5, 5, 7, 7)) == (0, 0, 0, 0)
+    assert utils.intersect((0, 0, 2, 2), (2, 2, 4, 4)) == (0, 0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# _blend_backdrop()
+# ---------------------------------------------------------------------------
+
+
+def test_blend_backdrop_over_opaque_backdrop() -> None:
+    color, alpha = _blend_backdrop(rgb(BLUE), gray(0.5), RED, 1.0, ColorMode.RGB)
+    # 50% blue over opaque red.
+    assert np.allclose(color[0, 0], (0.5, 0.0, 0.5))
+    assert np.allclose(alpha, 1.0)
+
+
+def test_blend_backdrop_accepts_scalar_tuple_and_array_backdrops() -> None:
+    """Equivalent backdrops expressed three ways must agree.
+
+    ``composite()`` accepts a scalar, a per-channel tuple or an ndarray; #708
+    proposes normalising all three at the API boundary. This pins that the
+    three spellings are interchangeable so that refactor stays a no-op.
+    """
+    expected, _ = _blend_backdrop(rgb(BLUE), gray(0.5), WHITE, 1.0, ColorMode.RGB)
+    from_scalar, _ = _blend_backdrop(rgb(BLUE), gray(0.5), 1.0, 1.0, ColorMode.RGB)
+    from_array, _ = _blend_backdrop(
+        rgb(BLUE), gray(0.5), rgb(WHITE), 1.0, ColorMode.RGB
+    )
+    assert np.allclose(expected, from_scalar)
+    assert np.allclose(expected, from_array)
+
+
+def test_blend_backdrop_transparent_backdrop_keeps_source_colour() -> None:
+    """A transparent backdrop must not bleed its colour into the result."""
+    color, alpha = _blend_backdrop(rgb(BLUE), gray(1.0), WHITE, 0.0, ColorMode.RGB)
+    assert np.allclose(color[0, 0], BLUE)
+    assert np.allclose(alpha, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Compositor._apply_source() -- the PDF 1.4 union / knockout equations
+# ---------------------------------------------------------------------------
+
+
+def apply_one(
+    backdrop_color: tuple[float, float, float],
+    backdrop_alpha: float,
+    source_color: tuple[float, float, float],
+    shape: float,
+    alpha: float,
+    blend_mode: BlendMode = BlendMode.NORMAL,
+    knockout: Knockout = Knockout.NONE,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Composite a single uniform source and return ``finish()``."""
+    compositor = Compositor((0, 0, 2, 2), backdrop_color, backdrop_alpha)
+    compositor._apply_source(
+        rgb(source_color), gray(shape), gray(alpha), blend_mode, knockout
+    )
+    return compositor.finish()
+
+
+def test_apply_source_opaque_source_replaces_the_backdrop() -> None:
+    color, shape, alpha = apply_one(WHITE, 1.0, BLUE, 1.0, 1.0)
+    assert np.allclose(color[0, 0], BLUE)
+    assert np.allclose(shape, 1.0)
+    assert np.allclose(alpha, 1.0)
+
+
+def test_apply_source_fully_transparent_source_leaves_the_backdrop() -> None:
+    color, shape, alpha = apply_one(RED, 1.0, BLUE, 0.0, 0.0)
+    assert np.allclose(color[0, 0], RED)
+    assert np.allclose(shape, 0.0)
+    assert np.allclose(alpha, 0.0)
+
+
+def test_apply_source_half_alpha_over_transparent_backdrop_keeps_source_colour() -> (
+    None
+):
+    """The returned colour is the *isolated* source, not the blended result.
+
+    ``finish()`` returns ``Compositor.color``, which removes the initial
+    backdrop's contribution. Compositing this result over that backdrop is what
+    reproduces the visible pixel -- here 50% blue over red gives (0.5, 0, 0.5).
+    """
+    color, _, alpha = apply_one(RED, 1.0, BLUE, 0.5, 0.5)
+    assert np.allclose(color[0, 0], BLUE)
+    assert np.allclose(alpha, 0.5)
+
+
+def test_apply_source_over_transparent_backdrop_is_not_contaminated_toward_white() -> (
+    None
+):
+    """Regression guard for ``utils.divide``'s 0/0 -> white fallback."""
+    color, _, alpha = apply_one(WHITE, 0.0, BLUE, 0.5, 0.5)
+    assert np.allclose(color[0, 0], BLUE)
+    assert np.allclose(alpha, 0.5)
+
+
+@pytest.mark.parametrize("source_alpha", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_apply_source_matches_the_textbook_over_operator(source_alpha: float) -> None:
+    """Cross-check against straight-alpha "over" computed independently.
+
+    With a transparent initial backdrop the compositor's group equations must
+    reduce to plain source-over-backdrop compositing.
+    """
+    backdrop_alpha = 0.75
+    compositor = Compositor((0, 0, 2, 2), WHITE, 0.0)
+    compositor._apply_source(
+        rgb(RED), gray(backdrop_alpha), gray(backdrop_alpha), BlendMode.NORMAL
+    )
+    compositor._apply_source(
+        rgb(BLUE), gray(source_alpha), gray(source_alpha), BlendMode.NORMAL
+    )
+    color, _, alpha = compositor.finish()
+
+    expected_alpha = source_alpha + backdrop_alpha * (1.0 - source_alpha)
+    src = np.array(BLUE) * source_alpha
+    bkd = np.array(RED) * backdrop_alpha * (1.0 - source_alpha)
+    expected_color = (src + bkd) / expected_alpha if expected_alpha else np.zeros(3)
+
+    assert np.allclose(alpha, expected_alpha, atol=1e-6)
+    assert np.allclose(color[0, 0], expected_color, atol=1e-6)
+
+
+def test_apply_source_blend_mode_is_applied_against_the_backdrop() -> None:
+    """MULTIPLY must see the running backdrop, unlike NORMAL which ignores it."""
+    half_gray = (0.5, 0.5, 0.5)
+    color, _, _ = apply_one(half_gray, 1.0, half_gray, 1.0, 1.0, BlendMode.MULTIPLY)
+    assert np.allclose(color[0, 0], (0.25, 0.25, 0.25))
+
+
+# ---------------------------------------------------------------------------
+# Knockout
+# ---------------------------------------------------------------------------
+
+
+def build_two_layer(knockout: Knockout) -> tuple[np.ndarray, np.ndarray]:
+    """Transparent backdrop, an opaque red layer, then blue at 50% alpha.
+
+    With knockout the blue punches through the red to the initial backdrop;
+    without it, blue composites over red.
+    """
+    compositor = Compositor((0, 0, 2, 2), WHITE, 0.0)
+    compositor._apply_source(rgb(RED), gray(1.0), gray(1.0), BlendMode.NORMAL)
+    compositor._apply_source(
+        rgb(BLUE), gray(1.0), gray(0.5), BlendMode.NORMAL, knockout
+    )
+    color, _, alpha = compositor.finish()
+    return color, alpha
+
+
+def test_knockout_punches_through_to_the_initial_backdrop() -> None:
+    color, alpha = build_two_layer(Knockout.SHALLOW)
+    # Red is gone: the result is blue at the source's own alpha.
+    assert np.allclose(color[0, 0], BLUE)
+    assert np.allclose(alpha, 0.5)
+
+
+def test_without_knockout_the_source_composites_over_the_running_backdrop() -> None:
+    color, alpha = build_two_layer(Knockout.NONE)
+    # Red is retained, so the result is opaque and half red / half blue.
+    assert np.allclose(color[0, 0], (0.5, 0.0, 0.5))
+    assert np.allclose(alpha, 1.0)
+
+
+def test_deep_knockout_without_a_document_backdrop_matches_shallow() -> None:
+    """DEEP degrades to SHALLOW when no document backdrop has been supplied."""
+    assert np.allclose(
+        build_two_layer(Knockout.DEEP)[0], build_two_layer(Knockout.SHALLOW)[0]
+    )
+
+
+def test_deep_knockout_uses_the_document_backdrop_when_present() -> None:
+    compositor = Compositor(
+        (0, 0, 2, 2),
+        WHITE,
+        0.0,
+        document_backdrop=lambda: (rgb(GREEN), gray(1.0)),
+    )
+    compositor._apply_source(rgb(RED), gray(1.0), gray(1.0), BlendMode.NORMAL)
+    compositor._apply_source(
+        rgb(BLUE), gray(1.0), gray(0.5), BlendMode.NORMAL, Knockout.DEEP
+    )
+    color, _, alpha = compositor.finish()
+    # Knocked through red down to the green document backdrop, which is opaque.
+    assert np.allclose(color[0, 0], (0.0, 0.5, 0.5))
+    assert np.allclose(alpha, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Compositor.color -- the backdrop-removal correction
+# ---------------------------------------------------------------------------
+
+
+def test_color_correction_is_a_no_op_for_a_transparent_backdrop() -> None:
+    compositor = Compositor((0, 0, 2, 2), WHITE, 0.0)
+    compositor._apply_source(rgb(BLUE), gray(0.5), gray(0.5), BlendMode.NORMAL)
+    assert np.allclose(compositor.color, compositor._color)
+
+
+def test_color_correction_removes_an_opaque_backdrop() -> None:
+    """Over an opaque backdrop the raw and corrected results differ."""
+    compositor = Compositor((0, 0, 2, 2), RED, 1.0)
+    compositor._apply_source(rgb(BLUE), gray(0.5), gray(0.5), BlendMode.NORMAL)
+    # Raw: what the pixel looks like, blue at 50% over red.
+    assert np.allclose(compositor._color[0, 0], (0.5, 0.0, 0.5))
+    # Corrected: the isolated source, which re-composites to the raw value.
+    assert np.allclose(compositor.color[0, 0], BLUE)
+    recomposited = compositor.color[0, 0] * 0.5 + np.array(RED) * 0.5
+    assert np.allclose(recomposited, compositor._color[0, 0])

--- a/tools/benchmark_composite.py
+++ b/tools/benchmark_composite.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Benchmark compositing on a synthetic large document.
+
+The fixture suite is too small to show the compositor's memory behaviour: the
+largest canvas in ``tests/psd_files`` is 1200x628, while the cost that matters
+is driven by the *number* of layers, since every layer, mask and effect is
+expanded to the full viewport by ``paste()`` regardless of its own size.
+
+Use this to get a before/after number for changes motivated by that behaviour
+-- notably #212 (composite over the source-backdrop intersection) and #708
+(normalise the backdrop at the API boundary).
+
+Usage::
+
+    uv run python tools/benchmark_composite.py
+    uv run python tools/benchmark_composite.py --size 4000 --layers 100
+
+Cost grows as canvas area x layer count, so raising either argument gets
+expensive quickly -- the defaults are deliberately modest.
+
+Reports wall time, peak Python allocation, and the total bytes returned by
+``paste()`` expressed as a multiple of one full-canvas RGBA float32 buffer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import time
+import tracemalloc
+from typing import Any
+
+from PIL import Image
+
+from psd_tools import PSDImage
+
+
+def build_document(size: int, layers: int, layer_size: int) -> PSDImage:
+    """A ``size`` x ``size`` canvas holding ``layers`` small tiles."""
+    psd = PSDImage.new(mode="RGB", size=(size, size))
+    step = max(1, (size - layer_size) // max(1, layers))
+    for index in range(layers):
+        offset = (index * step) % max(1, size - layer_size)
+        tile = Image.new(
+            "RGBA",
+            (layer_size, layer_size),
+            (index * 5 % 256, index * 11 % 256, index * 17 % 256, 128),
+        )
+        psd.create_pixel_layer(image=tile, name=f"L{index}", top=offset, left=offset)
+    return psd
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--size", type=int, default=2000, help="canvas edge in px")
+    parser.add_argument("--layers", type=int, default=50, help="number of layers")
+    parser.add_argument("--layer-size", type=int, default=200, help="tile edge in px")
+    args = parser.parse_args()
+
+    # importlib, not a plain import: ``psd_tools.composite.composite`` is
+    # shadowed by the ``composite`` *function* re-exported from the package
+    # __init__, so ``from psd_tools.composite import composite`` binds the
+    # function and never the module. Typed Any so patching paste() is allowed.
+    module: Any = importlib.import_module("psd_tools.composite.composite")
+
+    print(f"Building {args.size}x{args.size} with {args.layers} layers...")
+    build_started = time.perf_counter()
+    psd = build_document(args.size, args.layers, args.layer_size)
+    print(f"  built in {time.perf_counter() - build_started:.1f}s")
+
+    stats = {"calls": 0, "bytes": 0}
+    original_paste = module.paste
+
+    def counting_paste(viewport, bbox, values, background=None):  # type: ignore[no-untyped-def]
+        result = original_paste(viewport, bbox, values, background)
+        stats["calls"] += 1
+        stats["bytes"] += result.nbytes
+        return result
+
+    module.paste = counting_paste
+    try:
+        tracemalloc.start()
+        started = time.perf_counter()
+        module.composite(psd)
+        elapsed = time.perf_counter() - started
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    finally:
+        module.paste = original_paste
+
+    canvas_bytes = args.size * args.size * 4 * 4  # RGBA float32
+    print(f"\n  wall time         {elapsed:8.2f} s")
+    print(f"  peak allocation   {peak / 1e6:8.1f} MB")
+    print(f"  paste() calls     {stats['calls']:8d}")
+    print(
+        f"  paste() bytes     {stats['bytes'] / 1e6:8.1f} MB"
+        f"  ({stats['bytes'] / canvas_bytes:.1f}x one RGBA float32 canvas)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Phase 0 of the #716 roadmap. Closes #715.

The composite suite is almost entirely end-to-end: render a fixture, compare MSE against a reference. That is a good acceptance suite and a poor refactoring suite — a broken transparency term surfaces as *"MSE 0.02 > 0.017 on `advanced-blending.psd`"*, with no indication of which equation moved. Every remaining issue on the roadmap touches these equations, so this lands first.

## Coverage

39 unit tests in a new `tests/psd_tools/composite/test_primitives.py`:

| Area | What is pinned |
| --- | --- |
| `paste()` | identity, inset offset, cropping on overhang, empty intersection, background handling, channel preservation |
| `utils` | `union` algebra + commutativity + identities, `divide`'s zero-divisor policy, `clip` bounds, `intersect` (including merely-touching boxes) |
| `_blend_backdrop()` | over an opaque backdrop, over a transparent one, and scalar/tuple/ndarray equivalence |
| `_apply_source()` | opaque replace, transparent no-op, half-alpha, transparent-backdrop contamination, blend mode against the backdrop, and a cross-check against the textbook straight-alpha `over` operator across five alphas |
| Knockout | punch-through to the initial backdrop, non-knockout contrast case, DEEP degrading to SHALLOW without a document backdrop, DEEP using one when present |
| `Compositor.color` | correction is a no-op for a transparent backdrop; removes an opaque one, and the corrected result re-composites to the raw value |

## Verified the suite actually has teeth

Passing on the first run is exactly when a safety net deserves suspicion, so I mutated the source and confirmed each break is caught:

| Mutation | Tests failed |
| --- | --- |
| `union` drops its `- a*b` term | 15 |
| `divide` falls back to `0.0` instead of `1.0` | 1 |
| knockout ignored (always use the running backdrop) | 3 |
| `Compositor.color` correction removed | 3 |
| `paste` background forced to zeros | 3 |

## Three tests deliberately pin behaviour the roadmap intends to change

So those changes are conscious rather than silent:

- **`divide`'s `0/0 -> 1.0` fallback** — #714 proposes making it caller-specified. The docstring says so, and names the `np.where` guard in `_apply_passthrough_source` that exists purely to work around it.
- **`paste`'s truthiness guard on `background`** — #711's checklist changes `if background` to `if background is not None`. The two are numerically identical today; this pins that the change stays a no-op.
- **scalar / tuple / ndarray backdrop equivalence** — #708 normalises all three at the API boundary. This pins that they are interchangeable so that refactor cannot alter output.

## Benchmark

`tools/benchmark_composite.py` covers the memory behaviour the fixtures are too small to show — the largest fixture canvas is 1200×628, while the cost that matters scales with *layer count*, since `paste()` expands every layer to the full viewport regardless of its own size.

```
$ uv run python tools/benchmark_composite.py
Building 2000x2000 with 50 layers...

  wall time             4.24 s
  peak allocation      476.1 MB
  paste() calls          150
  paste() bytes       4000.0 MB  (62.5x one RGBA float32 canvas)
```

That is the baseline #212 and #708 need. Defaults are deliberately modest since cost grows as canvas area × layer count; `--size` and `--layers` scale it up.

## Notes

- No changelog entry — test-only plus a dev tool, no user-visible change, per the convention added in #718.
- The benchmark uses `importlib` rather than a plain import because `psd_tools.composite.composite` is shadowed by the `composite` *function* re-exported from the package `__init__`, so `from psd_tools.composite import composite` binds the function and never the module. That gotcha is commented in the source.

`1668 passed, 27 xfailed, 2 xpassed` — the two xpasses (`vector-mask2.psd`, `effects/shape-fx2.psd`) are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
