### PR TITLE
fix: normalize the composite backdrop at the API boundary

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,30 @@ Changelog
   record length alone. ``MaskData`` misidentified its presence, so
   ``user_mask_density``, ``user_mask_feather``, ``vector_mask_density`` and
   ``vector_mask_feather`` returned ``None`` for affected files (#693, #704).
+- [fix] Accept every scalar spelling of the composite backdrop. ``color=1`` and
+  ``color=np.float32(1.0)`` raised ``TypeError`` because only ``float`` was
+  recognised as a scalar. The backdrop is now normalised once at the API
+  boundary rather than reinterpreted at each point of use (#708, #709).
+- [fix] Recognise a transparent backdrop given as a NumPy scalar or a 0-d
+  array. Compositing a document with no layers used ``alpha=np.float32(0.0)``
+  as if it were opaque, which whitened every uncovered pixel (#708).
+- [fix] Composite a layerless multichannel document over a backdrop. The
+  backdrop was sized from ``EXPECTED_CHANNELS``, which reports 64 channels for
+  multichannel documents regardless of how many the file actually carries, so
+  the blend raised ``ValueError`` (#708).
+- [api] Widen the ``color`` parameter of ``composite()``, ``composite_pil()``,
+  ``Layer.composite()``, ``Group.composite()``, ``Artboard.composite()`` and
+  ``PSDImage.composite()`` -- and of ``LayerProtocol`` and ``PSDProtocol`` --
+  from ``float | tuple[float, ...] | np.ndarray`` to
+  ``float | Sequence[float] | np.ndarray``, matching what is accepted at
+  runtime. This is a widening; existing calls are unaffected (#708).
+
+  **Backwards incompatible**: a per-channel backdrop whose length disagrees
+  with the document's colour mode now raises ``ValueError`` instead of being
+  silently accepted. ``psd.composite(color=(1.0, 1.0, 1.0))`` against a
+  grayscale or bitmap document previously produced a three-channel result that
+  was then reduced to its first channel; pass a scalar, or a sequence matching
+  ``psd.color_mode``.
 - [fix] Implement Knockout compositing (#707). Groups and layers with Knockout
   enabled previously rendered as if the setting were absent. Shallow knockout
   now punches through to the enclosing group's backdrop, and deep knockout to

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,9 +16,14 @@ Changelog
   ``color=np.float32(1.0)`` raised ``TypeError`` because only ``float`` was
   recognised as a scalar. The backdrop is now normalised once at the API
   boundary rather than reinterpreted at each point of use (#708, #709).
-- [fix] Recognise a transparent backdrop given as a NumPy scalar or a 0-d
-  array. Compositing a document with no layers used ``alpha=np.float32(0.0)``
-  as if it were opaque, which whitened every uncovered pixel (#708).
+- [fix] Recognise a transparent backdrop given as a NumPy scalar, a 0-d array,
+  or a per-pixel array of zeros. Compositing a document with no layers used
+  ``alpha=np.float32(0.0)`` as if it were opaque, which whitened every
+  uncovered pixel (#708).
+- [fix] Reject a multi-channel backdrop ``alpha``. Alpha is single-channel by
+  definition, but a wider array was accepted and reached ``composite_pil()``,
+  which concatenates it onto the colour array and built an image of the wrong
+  width (#708).
 - [fix] Composite a layerless multichannel document over a backdrop. The
   backdrop was sized from ``EXPECTED_CHANNELS``, which reports 64 channels for
   multichannel documents regardless of how many the file actually carries, so

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -744,7 +744,7 @@ class Layer(LayerProtocol):
         self,
         viewport: tuple[int, int, int, int] | None = None,
         force: bool = False,
-        color: float | tuple[float, ...] | np.ndarray = 1.0,
+        color: float | Sequence[float] | np.ndarray = 1.0,
         alpha: float | np.ndarray = 0.0,
         layer_filter: Callable | None = None,
         apply_icc: bool = True,
@@ -755,7 +755,8 @@ class Layer(LayerProtocol):
         :param viewport: Viewport bounding box specified by (x1, y1, x2, y2)
             tuple. Default is the layer's bbox.
         :param force: Boolean flag to force vector drawing.
-        :param color: Backdrop color specified by scalar or tuple of scalar.
+        :param color: Backdrop color, as a scalar, a per-channel sequence, or a
+            full ``(height, width, channels)`` array.
             The color value should be in [0.0, 1.0]. For example, (1., 0., 0.)
             specifies red in RGB color mode.
         :param alpha: Backdrop alpha in [0.0, 1.0].
@@ -1415,7 +1416,7 @@ class Group(GroupMixin, Layer):
         self,
         viewport: tuple[int, int, int, int] | None = None,
         force: bool = False,
-        color: float | tuple[float, ...] | np.ndarray = 1.0,
+        color: float | Sequence[float] | np.ndarray = 1.0,
         alpha: float | np.ndarray = 0.0,
         layer_filter: Callable | None = None,
         apply_icc: bool = True,
@@ -1426,7 +1427,8 @@ class Group(GroupMixin, Layer):
         :param viewport: Viewport bounding box specified by (x1, y1, x2, y2)
             tuple. Default is the layer's bbox.
         :param force: Boolean flag to force vector drawing.
-        :param color: Backdrop color specified by scalar or tuple of scalar.
+        :param color: Backdrop color, as a scalar, a per-channel sequence, or a
+            full ``(height, width, channels)`` array.
             The color value should be in [0.0, 1.0]. For example, (1., 0., 0.)
             specifies red in RGB color mode.
         :param alpha: Backdrop alpha in [0.0, 1.0].
@@ -1616,7 +1618,7 @@ class Artboard(Group):
         self,
         viewport: tuple[int, int, int, int] | None = None,
         force: bool = False,
-        color: float | tuple[float, ...] | np.ndarray | None = None,
+        color: float | Sequence[float] | np.ndarray | None = None,
         alpha: float | np.ndarray | None = None,
         layer_filter: Callable | None = None,
         apply_icc: bool = True,

--- a/src/psd_tools/api/protocols.py
+++ b/src/psd_tools/api/protocols.py
@@ -6,6 +6,7 @@ PSDImage without requiring concrete imports. These protocols allow other modules
 to properly type hint their parameters while avoiding circular dependency issues.
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable, Iterator, Literal, Protocol
 
 if TYPE_CHECKING:
@@ -270,7 +271,7 @@ class LayerProtocol(Protocol):
         self,
         viewport: tuple[int, int, int, int] | None = None,
         force: bool = False,
-        color: float | tuple[float, ...] | np.ndarray = 1.0,
+        color: float | Sequence[float] | np.ndarray = 1.0,
         alpha: float | np.ndarray = 0.0,
         layer_filter: Callable | None = None,
         apply_icc: bool = True,
@@ -477,7 +478,7 @@ class PSDProtocol(GroupMixinProtocol, Protocol):
         self,
         viewport: tuple[int, int, int, int] | None = None,
         force: bool = False,
-        color: float | tuple[float, ...] | np.ndarray | None = 1.0,
+        color: float | Sequence[float] | np.ndarray | None = 1.0,
         alpha: float | np.ndarray = 0.0,
         layer_filter: Callable | None = None,
         ignore_preview: bool = False,

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -314,7 +314,7 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         self,
         viewport: tuple[int, int, int, int] | None = None,
         force: bool = False,
-        color: float | tuple[float, ...] | np.ndarray | None = 1.0,
+        color: float | Sequence[float] | np.ndarray | None = 1.0,
         alpha: float | np.ndarray = 0.0,
         layer_filter: Callable | None = None,
         ignore_preview: bool = False,
@@ -328,7 +328,8 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         :param ignore_preview: Boolean flag to whether skip compositing when a
             pre-composited preview is available.
         :param force: Boolean flag to force vector drawing.
-        :param color: Backdrop color specified by scalar or tuple of scalar.
+        :param color: Backdrop color, as a scalar, a per-channel sequence, or a
+            full ``(height, width, channels)`` array.
             The color value should be in [0.0, 1.0]. For example, (1., 0., 0.)
             specifies red in RGB color mode.
         :param alpha: Backdrop alpha in [0.0, 1.0].

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -1,6 +1,7 @@
 """Composite implementation for layer rendering and blending."""
 
 import logging
+from collections.abc import Sequence
 from typing import Callable, cast
 
 import numpy as np
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 def composite_pil(
     layer: Layer | PSDImage,
-    color: float | tuple[float, ...] | np.ndarray,
+    color: float | Sequence[float] | np.ndarray,
     alpha: float | np.ndarray,
     viewport: tuple[int, int, int, int] | None,
     layer_filter: Callable[[Layer], bool] | None,
@@ -45,7 +46,8 @@ def composite_pil(
 
     Args:
         layer: Layer or PSDImage to composite
-        color: Initial backdrop color (0.0-1.0). Can be scalar, tuple, or ndarray
+        color: Initial backdrop color (0.0-1.0). Can be a scalar, a
+            per-channel sequence, or an ndarray
         alpha: Initial backdrop alpha (0.0-1.0). Can be scalar or ndarray
         viewport: Bounding box (left, top, right, bottom) to composite. If None, uses layer bounds
         layer_filter: Optional callable to filter which layers to composite. Should return True to include
@@ -88,10 +90,8 @@ def composite_pil(
     # Skip alpha when the color mode requires deferred alpha handling, or
     # when the backdrop is fully opaque (the result is guaranteed opaque).
     delay_alpha_application = color_mode not in (ColorMode.GRAYSCALE, ColorMode.RGB)
-    has_opaque_backdrop = (
-        isinstance(backdrop_alpha, (int, float, np.integer, np.floating))
-        and backdrop_alpha >= 1.0
-    )
+    uniform_alpha = _uniform_alpha(backdrop_alpha)
+    has_opaque_backdrop = uniform_alpha is not None and uniform_alpha >= 1.0
     skip_alpha = not force and (delay_alpha_application or has_opaque_backdrop)
     logger.debug("Skipping alpha: %s", skip_alpha)
     if not skip_alpha:
@@ -118,7 +118,7 @@ def composite_pil(
 
 def composite(
     group: Layer | PSDImage,
-    color: float | tuple[float, ...] | np.ndarray = 1.0,
+    color: float | Sequence[float] | np.ndarray = 1.0,
     alpha: float | np.ndarray = 0.0,
     viewport: tuple[int, int, int, int] | None = None,
     layer_filter: Callable[[Layer], bool] | None = None,
@@ -135,7 +135,8 @@ def composite(
     Args:
         group: Layer or PSDImage to composite
         color: Initial backdrop color (0.0-1.0, default: 1.0). Can be a scalar
-            float applied to all channels, a tuple of per-channel values, or an ndarray.
+            applied to all channels, a per-channel sequence, or a full
+            (height, width, channels) ndarray.
         alpha: Initial backdrop alpha (0.0-1.0, default: 0.0). Can be scalar or ndarray.
         viewport: Bounding box (left, top, right, bottom) to composite. If None, uses layer bounds
         layer_filter: Optional callable(layer) -> bool to filter which layers to composite
@@ -185,10 +186,16 @@ def composite(
         if viewport != group.viewbox:
             color = paste(viewport, group.bbox, color, 1.0)
             shape = paste(viewport, group.bbox, shape)
-        if not (isinstance(backdrop_alpha, (int, float)) and backdrop_alpha == 0.0):
-            color, shape = _blend_backdrop(
-                color, shape, backdrop_color, backdrop_alpha, group.color_mode
-            )
+        # A uniformly transparent backdrop contributes nothing, and blending it
+        # in anyway would turn fully uncovered pixels white via divide()'s
+        # 0 / 0 fallback. Normalize only once past that check, so the backdrop
+        # is not expanded to a full canvas for the common default.
+        if _uniform_alpha(backdrop_alpha) != 0.0:
+            # Sized from the array in hand rather than from the color mode:
+            # a multichannel document carries a channel count of its own that
+            # EXPECTED_CHANNELS does not predict.
+            backdrop = _normalize_backdrop(backdrop_color, backdrop_alpha, *color.shape)
+            color, shape = _blend_backdrop(color, shape, *backdrop)
         return color, shape, shape
 
     _w = viewport[2] - viewport[0]
@@ -201,23 +208,29 @@ def composite(
         max_alloc_bytes=_psd._max_alloc_bytes if _psd is not None else None,
     )
 
-    if isinstance(color, float):
-        assert _psd is not None
-        color_mode = _psd.color_mode
-        assert isinstance(color_mode, ColorMode)
-        color = (color,) * EXPECTED_CHANNELS[color_mode]
-
     isolated = False
     if not isinstance(group, PSDImage):
         isolated = group.blend_mode != BlendMode.PASS_THROUGH
+
+    # The compositor works exclusively in full-canvas arrays; the scalar and
+    # per-channel spellings are a convenience of the public signature, so they
+    # are resolved here, once, rather than at each point of use. An isolated
+    # group starts transparent, so the caller's alpha is dropped before the
+    # canvas is built rather than after.
+    backdrop_color, backdrop_alpha = _normalize_backdrop(
+        color,
+        0.0 if isolated else alpha,
+        _h,
+        _w,
+        EXPECTED_CHANNELS[_psd.color_mode] if _psd is not None else None,
+    )
 
     layer_filter = layer_filter or Layer.is_visible
 
     compositor = Compositor(
         viewport,
-        color,
-        alpha,
-        isolated,
+        backdrop_color,
+        backdrop_alpha,
         layer_filter,
         force,
         document_backdrop=lambda: _document_backdrop(_psd, viewport),
@@ -318,22 +331,84 @@ def _document_backdrop(
     return color, alpha
 
 
+def _uniform_alpha(alpha: float | np.ndarray) -> float | None:
+    """The backdrop alpha as a plain float when it is a single scalar.
+
+    Returns None for an array-valued backdrop, whose per-pixel alpha cannot be
+    reduced to one number. Tested by dimensionality rather than by type so that
+    ``1``, ``1.0``, ``np.float32(1.0)`` and ``np.array(1.0)`` all behave alike.
+    """
+    return float(alpha) if np.ndim(alpha) == 0 else None
+
+
+def _to_canvas(
+    value: float | Sequence[float] | np.ndarray,
+    shape: tuple[int, int, int],
+    name: str,
+) -> np.ndarray:
+    """Expand a backdrop component to a full ``(height, width, channels)`` array.
+
+    An array that is already per-pixel is taken as given -- including one whose
+    channel count differs from the document's, which the compositor widens on
+    demand. Anything else (a scalar, a per-channel sequence) is broadcast.
+    """
+    array = np.asarray(value, dtype=np.float32)
+    if array.ndim == 3:
+        if array.shape[:2] != shape[:2]:
+            raise ValueError(
+                "Backdrop %s covers %r, expected %r to match the viewport"
+                % (name, array.shape[:2], shape[:2])
+            )
+        return array
+    try:
+        return np.full(shape, array, dtype=np.float32)
+    except ValueError:
+        raise ValueError(
+            "Backdrop %s %r cannot be expanded to %r; pass a scalar, a "
+            "per-channel sequence, or a full (height, width, channels) array"
+            % (name, value, shape)
+        ) from None
+
+
+def _normalize_backdrop(
+    color: float | Sequence[float] | np.ndarray,
+    alpha: float | np.ndarray,
+    height: int,
+    width: int,
+    channels: int | None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Resolve a backdrop given in any accepted spelling to a pair of arrays.
+
+    The public entry points accept the backdrop as a scalar, a per-channel
+    sequence or a ready-made array because that is convenient to call; the
+    compositor only ever works with arrays. Converting once here keeps the
+    three spellings from being re-interpreted -- inconsistently -- at each use
+    site.
+
+    This does materialize a full canvas even for a constant backdrop, exactly
+    as ``Compositor`` did before: the scalar spelling is an API convenience,
+    not an allocation-avoidance path. (``_get_mask``/``_get_const`` keep their
+    scalars for that reason instead.)
+
+    ``channels`` is the document's channel count, or None to infer it from
+    ``color`` where no document is available to name a color mode -- the same
+    defensive fallback ``check_pixel_size()`` is given in ``composite()``.
+    """
+    if channels is None:
+        channels = 1 if np.ndim(color) == 0 else int(np.shape(color)[-1])
+    return (
+        _to_canvas(color, (height, width, channels), "color"),
+        _to_canvas(alpha, (height, width, 1), "alpha"),
+    )
+
+
 def _blend_backdrop(
     color: np.ndarray,
     shape: np.ndarray,
-    backdrop_color: float | tuple[float, ...] | np.ndarray,
-    backdrop_alpha: float | np.ndarray,
-    color_mode: ColorMode,
+    backdrop_color: np.ndarray,
+    backdrop_alpha: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Blend foreground color/shape over a backdrop using standard "over" compositing."""
-    if isinstance(backdrop_color, float):
-        backdrop_color = (backdrop_color,) * EXPECTED_CHANNELS[color_mode]
-    if isinstance(backdrop_color, tuple):
-        backdrop_color = np.broadcast_to(
-            np.array(backdrop_color, dtype=np.float32), color.shape
-        )
-    if isinstance(backdrop_alpha, (int, float)):
-        backdrop_alpha = np.full_like(shape, backdrop_alpha)
     result_alpha = utils.union(shape, backdrop_alpha)
     result_color = utils.clip(
         utils.divide(
@@ -347,9 +422,17 @@ def _blend_backdrop(
 class Compositor(object):
     """Composite context.
 
+    ``color`` and ``alpha`` are the initial backdrop, and must already be
+    ``(height, width, channels)`` arrays covering ``viewport``; the public
+    entry points normalize the spellings they accept via
+    ``_normalize_backdrop()``. An isolated group composites against a
+    transparent backdrop, which the caller expresses by passing a zero
+    ``alpha`` -- so that canvas is never built only to be discarded.
+
     Example::
 
-        compositor = Compositor(group.bbox)
+        color, alpha = _normalize_backdrop(1.0, 0.0, height, width, channels)
+        compositor = Compositor(group.bbox, color, alpha)
         for layer in group:
             compositor.apply(layer)
         color, shape, alpha = compositor.finish()
@@ -358,9 +441,8 @@ class Compositor(object):
     def __init__(
         self,
         viewport: tuple[int, int, int, int],
-        color: float | tuple[float, ...] | np.ndarray = 1.0,
-        alpha: float | np.ndarray = 0.0,
-        isolated: bool = False,
+        color: np.ndarray,
+        alpha: np.ndarray,
         layer_filter: Callable[[Layer], bool] | None = None,
         force: bool = False,
         adjustment_isolated: bool = False,
@@ -383,22 +465,8 @@ class Compositor(object):
         self._document_backdrop_resolved = False
         self._document_backdrop: tuple[np.ndarray, np.ndarray] | None = None
 
-        if isolated:
-            self._alpha_0 = np.zeros((self.height, self.width, 1), dtype=np.float32)
-        elif isinstance(alpha, np.ndarray):
-            self._alpha_0 = alpha
-        else:
-            self._alpha_0 = np.full(
-                (self.height, self.width, 1), alpha, dtype=np.float32
-            )
-
-        if isinstance(color, np.ndarray):
-            self._color_0 = color
-        else:
-            channels = 1 if isinstance(color, float) else len(color)
-            self._color_0 = np.full(
-                (self.height, self.width, channels), color, dtype=np.float32
-            )
+        self._alpha_0 = alpha
+        self._color_0 = color
 
         self._shape_g = np.zeros((self.height, self.width, 1), dtype=np.float32)
         self._alpha_g = np.zeros((self.height, self.width, 1), dtype=np.float32)
@@ -693,11 +761,21 @@ class Compositor(object):
                     paste(viewport, parent_viewport, backdrop_alpha),
                 )
 
+        # Only a pass-through group inherits the enclosing alpha; an isolated
+        # one starts transparent, so that paste is skipped rather than made and
+        # thrown away.
+        group_alpha = (
+            paste(viewport, self._viewport, alpha_b)
+            if is_passthrough
+            else np.zeros(
+                (viewport[3] - viewport[1], viewport[2] - viewport[0], 1),
+                dtype=np.float32,
+            )
+        )
         group_compositor = Compositor(
             viewport,
             color=paste(viewport, self._viewport, color_b, 1.0),
-            alpha=paste(viewport, self._viewport, alpha_b),
-            isolated=(not is_passthrough),
+            alpha=group_alpha,
             layer_filter=self._layer_filter,
             force=self._force,
             adjustment_isolated=self._adjustment_isolated or isolate_adjustments,
@@ -780,7 +858,12 @@ class Compositor(object):
         return compositor._color
 
     def _get_mask(self, layer: Layer) -> tuple[float | np.ndarray, float]:
-        """Get mask attributes."""
+        """Get mask attributes.
+
+        The scalar 1.0 default is an allocation-avoidance path, not an API
+        convenience like the backdrop spellings: most layers have no mask, and
+        materializing an all-ones canvas for each of them is pure waste.
+        """
         shape: float | np.ndarray = 1.0
         opacity: float = 1.0
         if layer.mask is not None and not layer.mask.disabled:

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -186,11 +186,13 @@ def composite(
         if viewport != group.viewbox:
             color = paste(viewport, group.bbox, color, 1.0)
             shape = paste(viewport, group.bbox, shape)
-        # A uniformly transparent backdrop contributes nothing, and blending it
+        # A wholly transparent backdrop contributes nothing, and blending it
         # in anyway would turn fully uncovered pixels white via divide()'s
-        # 0 / 0 fallback. Normalize only once past that check, so the backdrop
+        # 0 / 0 fallback. np.any() covers every spelling at once -- scalar,
+        # NumPy scalar, or an array of zeros -- and short-circuits on the
+        # first nonzero. Normalize only once past that check, so the backdrop
         # is not expanded to a full canvas for the common default.
-        if _uniform_alpha(backdrop_alpha) != 0.0:
+        if np.any(backdrop_alpha):
             # Sized from the array in hand rather than from the color mode:
             # a multichannel document carries a channel count of its own that
             # EXPECTED_CHANNELS does not predict.
@@ -334,9 +336,11 @@ def _document_backdrop(
 def _uniform_alpha(alpha: float | np.ndarray) -> float | None:
     """The backdrop alpha as a plain float when it is a single scalar.
 
-    Returns None for an array-valued backdrop, whose per-pixel alpha cannot be
-    reduced to one number. Tested by dimensionality rather than by type so that
-    ``1``, ``1.0``, ``np.float32(1.0)`` and ``np.array(1.0)`` all behave alike.
+    Returns None for an array-valued backdrop rather than scanning it: the
+    caller decides the output mode from this, and reporting an all-ones array
+    as opaque would drop the alpha channel from images that carry one today.
+    Tested by dimensionality rather than by type so that ``1``, ``1.0``,
+    ``np.float32(1.0)`` and ``np.array(1.0)`` all behave alike.
     """
     return float(alpha) if np.ndim(alpha) == 0 else None
 
@@ -345,16 +349,26 @@ def _to_canvas(
     value: float | Sequence[float] | np.ndarray,
     shape: tuple[int, int, int],
     name: str,
+    exact_channels: bool = False,
 ) -> np.ndarray:
     """Expand a backdrop component to a full ``(height, width, channels)`` array.
 
-    An array that is already per-pixel is taken as given -- including one whose
-    channel count differs from the document's, which the compositor widens on
-    demand. Anything else (a scalar, a per-channel sequence) is broadcast.
+    An array that is already per-pixel is taken as given. Its channel count is
+    allowed to differ from the document's, because the compositor widens a
+    single-channel backdrop on demand; ``exact_channels`` withdraws that
+    licence for alpha, which is single-channel by definition and would
+    otherwise reach ``composite_pil()`` and be concatenated into a color array
+    of the wrong width. Anything else (a scalar, a per-channel sequence) is
+    broadcast.
     """
     array = np.asarray(value, dtype=np.float32)
     if array.ndim == 3:
-        if array.shape[:2] != shape[:2]:
+        if exact_channels:
+            if array.shape != shape:
+                raise ValueError(
+                    "Backdrop %s has shape %r, expected %r" % (name, array.shape, shape)
+                )
+        elif array.shape[:2] != shape[:2]:
             raise ValueError(
                 "Backdrop %s covers %r, expected %r to match the viewport"
                 % (name, array.shape[:2], shape[:2])
@@ -398,7 +412,7 @@ def _normalize_backdrop(
         channels = 1 if np.ndim(color) == 0 else int(np.shape(color)[-1])
     return (
         _to_canvas(color, (height, width, channels), "color"),
-        _to_canvas(alpha, (height, width, 1), "alpha"),
+        _to_canvas(alpha, (height, width, 1), "alpha", exact_channels=True),
     )
 
 

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -277,6 +277,121 @@ def test_composite_pil(
         assert isinstance(layer.composite(apply_icc=apply_icc), Image.Image)
 
 
+_BACKDROP_SPELLINGS = [
+    pytest.param(1, id="int"),
+    pytest.param(1.0, id="float"),
+    pytest.param(np.float32(1.0), id="numpy-scalar"),
+    pytest.param(np.int64(1), id="numpy-int"),
+    pytest.param((1.0, 1.0, 1.0), id="tuple"),
+    pytest.param([1.0, 1.0, 1.0], id="list"),
+    pytest.param(np.ones((4, 4, 3), dtype=np.float32), id="ndarray"),
+]
+
+
+@pytest.mark.parametrize("color", _BACKDROP_SPELLINGS)
+def test_composite_backdrop_spellings_agree(color: Any) -> None:
+    """Every accepted spelling of the same white backdrop must composite alike.
+
+    Regression test for #709: ``color=1`` and ``color=np.float32(1.0)`` raised
+    ``TypeError`` because only ``float`` was recognised as a scalar.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"))
+    reference, _, _ = composite(psd, color=1.0)
+    result, _, _ = composite(psd, color=color)
+    assert result.shape == reference.shape
+    assert np.array_equal(result, reference)
+
+
+@pytest.mark.parametrize("color", [1, 1.0, np.float32(1.0), (1.0,), [1.0]])
+def test_composite_backdrop_spellings_agree_grayscale(color: Any) -> None:
+    """Same as above for a single-channel document."""
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_grayscale.psd"))
+    reference, _, _ = composite(psd, color=1.0)
+    result, _, _ = composite(psd, color=color)
+    assert result.shape == reference.shape
+    assert np.array_equal(result, reference)
+
+
+@pytest.mark.parametrize("alpha", [1, 1.0, np.float32(1.0)])
+def test_composite_backdrop_alpha_spellings_agree(alpha: Any) -> None:
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgba.psd"))
+    reference, _, _ = composite(psd, color=0.0, alpha=1.0)
+    result, _, _ = composite(psd, color=0.0, alpha=alpha)
+    assert np.array_equal(result, reference)
+
+
+@pytest.mark.parametrize("alpha", [0, 0.0, np.float32(0.0), np.array(0.0)])
+def test_composite_transparent_backdrop_is_skipped_in_any_spelling(
+    alpha: Any,
+) -> None:
+    """A transparent backdrop must be recognised however it is spelled.
+
+    The zero-layer path skips the blend for a transparent backdrop, because
+    blending it in anyway sends ``utils.divide`` down its 0 / 0 -> 1.0 branch
+    and whitens every uncovered pixel. The old guard tested for ``int`` and
+    ``float`` only, so a NumPy scalar took the blend and came back white.
+    """
+    psd = PSDImage.new("RGBA", (4, 4), color=(0, 0, 0, 0))
+    assert len(psd) == 0
+    result, _, _ = composite(psd, color=1.0, alpha=alpha)
+    assert np.array_equal(result, np.zeros_like(result))
+
+
+def test_composite_backdrop_rejects_a_mismatched_channel_count() -> None:
+    """A wrong-width backdrop is an error rather than a silently odd canvas."""
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"))
+    with pytest.raises(ValueError, match="cannot be expanded"):
+        composite(psd, color=(1.0, 0.0))
+
+
+def test_composite_backdrop_rejects_a_wrong_width_sequence_for_the_color_mode() -> None:
+    """**Backwards incompatible.** A 3-tuple over a 1-channel document raises.
+
+    This used to produce a three-channel result for a grayscale document,
+    which ``composite_pil`` then silently reduced by taking channel 0. Pinned
+    deliberately: the loud failure is the intent, not an accident.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_grayscale.psd"))
+    with pytest.raises(ValueError, match="cannot be expanded"):
+        composite(psd, color=(1.0, 1.0, 1.0), alpha=1.0)
+
+
+def test_composite_does_not_mutate_a_caller_supplied_backdrop() -> None:
+    """The compositor stores the caller's array; it must never write to it."""
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"))
+    backdrop = np.full((psd.height, psd.width, 3), 0.25, dtype=np.float32)
+    composite(psd, color=backdrop, alpha=1.0)
+    assert np.array_equal(backdrop, np.full_like(backdrop, 0.25))
+
+
+def test_composite_empty_document_backdrop() -> None:
+    """The zero-layer path normalizes its backdrop like any other.
+
+    It is reached before any layer exists, so it sizes the backdrop from the
+    preview array rather than from the color mode.
+    """
+    psd = PSDImage.new("RGB", (4, 4), color=0)
+    assert len(psd) == 0
+    reference, _, _ = composite(psd, color=1.0, alpha=1.0)
+    spellings: list[Any] = [1, np.float32(1.0), (1.0, 1.0, 1.0)]
+    for color in spellings:
+        result, _, _ = composite(psd, color=color, alpha=1.0)
+        assert np.array_equal(result, reference), color
+
+
+def test_composite_layerless_multichannel_over_a_backdrop() -> None:
+    """A multichannel document has more channels than its color mode predicts.
+
+    ``EXPECTED_CHANNELS[MULTICHANNEL]`` is 64, so sizing the backdrop from the
+    color mode could not be blended against the document's own array and raised
+    ``ValueError``. The zero-layer path sizes from that array instead.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
+    assert len(psd) == 0
+    color, _, _ = composite(psd, color=1.0, alpha=1.0)
+    assert color.shape == (psd.height, psd.width, psd.numpy("color").shape[2])
+
+
 def test_composite_layer_filter() -> None:
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgba.psd"))
     # Check layer_filter.

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -320,7 +320,16 @@ def test_composite_backdrop_alpha_spellings_agree(alpha: Any) -> None:
     assert np.array_equal(result, reference)
 
 
-@pytest.mark.parametrize("alpha", [0, 0.0, np.float32(0.0), np.array(0.0)])
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        pytest.param(0, id="int"),
+        pytest.param(0.0, id="float"),
+        pytest.param(np.float32(0.0), id="numpy-scalar"),
+        pytest.param(np.array(0.0), id="0d-array"),
+        pytest.param(np.zeros((4, 4, 1), dtype=np.float32), id="array-of-zeros"),
+    ],
+)
 def test_composite_transparent_backdrop_is_skipped_in_any_spelling(
     alpha: Any,
 ) -> None:
@@ -329,7 +338,8 @@ def test_composite_transparent_backdrop_is_skipped_in_any_spelling(
     The zero-layer path skips the blend for a transparent backdrop, because
     blending it in anyway sends ``utils.divide`` down its 0 / 0 -> 1.0 branch
     and whitens every uncovered pixel. The old guard tested for ``int`` and
-    ``float`` only, so a NumPy scalar took the blend and came back white.
+    ``float`` only, so a NumPy scalar took the blend and came back white; a
+    per-pixel array of zeros did too (PR #721 review).
     """
     psd = PSDImage.new("RGBA", (4, 4), color=(0, 0, 0, 0))
     assert len(psd) == 0
@@ -354,6 +364,18 @@ def test_composite_backdrop_rejects_a_wrong_width_sequence_for_the_color_mode() 
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_grayscale.psd"))
     with pytest.raises(ValueError, match="cannot be expanded"):
         composite(psd, color=(1.0, 1.0, 1.0), alpha=1.0)
+
+
+def test_composite_backdrop_rejects_a_multi_channel_alpha() -> None:
+    """Alpha is single-channel by definition (PR #721 review).
+
+    A wider alpha survived to ``finish()`` on the zero-layer path, where
+    ``composite_pil()`` concatenates it onto the color array and would build an
+    image of the wrong width.
+    """
+    psd = PSDImage.new("RGBA", (4, 4), color=(0, 0, 0, 0))
+    with pytest.raises(ValueError, match=r"alpha has shape"):
+        composite(psd, color=1.0, alpha=np.ones((4, 4, 3), dtype=np.float32))
 
 
 def test_composite_does_not_mutate_a_caller_supplied_backdrop() -> None:

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -13,8 +13,13 @@ import numpy as np
 import pytest
 
 from psd_tools.composite import utils
-from psd_tools.composite.composite import Compositor, _blend_backdrop, paste
-from psd_tools.constants import BlendMode, ColorMode, Knockout
+from psd_tools.composite.composite import (
+    Compositor,
+    _blend_backdrop,
+    _normalize_backdrop,
+    paste,
+)
+from psd_tools.constants import BlendMode, Knockout
 
 RED = (1.0, 0.0, 0.0)
 GREEN = (0.0, 1.0, 0.0)
@@ -149,33 +154,85 @@ def test_intersect() -> None:
 
 
 def test_blend_backdrop_over_opaque_backdrop() -> None:
-    color, alpha = _blend_backdrop(rgb(BLUE), gray(0.5), RED, 1.0, ColorMode.RGB)
+    color, alpha = _blend_backdrop(rgb(BLUE), gray(0.5), rgb(RED), gray(1.0))
     # 50% blue over opaque red.
     assert np.allclose(color[0, 0], (0.5, 0.0, 0.5))
     assert np.allclose(alpha, 1.0)
 
 
-def test_blend_backdrop_accepts_scalar_tuple_and_array_backdrops() -> None:
-    """Equivalent backdrops expressed three ways must agree.
-
-    ``composite()`` accepts a scalar, a per-channel tuple or an ndarray; #708
-    proposes normalising all three at the API boundary. This pins that the
-    three spellings are interchangeable so that refactor stays a no-op.
-    """
-    expected, _ = _blend_backdrop(rgb(BLUE), gray(0.5), WHITE, 1.0, ColorMode.RGB)
-    from_scalar, _ = _blend_backdrop(rgb(BLUE), gray(0.5), 1.0, 1.0, ColorMode.RGB)
-    from_array, _ = _blend_backdrop(
-        rgb(BLUE), gray(0.5), rgb(WHITE), 1.0, ColorMode.RGB
-    )
-    assert np.allclose(expected, from_scalar)
-    assert np.allclose(expected, from_array)
-
-
 def test_blend_backdrop_transparent_backdrop_keeps_source_colour() -> None:
     """A transparent backdrop must not bleed its colour into the result."""
-    color, alpha = _blend_backdrop(rgb(BLUE), gray(1.0), WHITE, 0.0, ColorMode.RGB)
+    color, alpha = _blend_backdrop(rgb(BLUE), gray(1.0), rgb(WHITE), gray(0.0))
     assert np.allclose(color[0, 0], BLUE)
     assert np.allclose(alpha, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_backdrop()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "color",
+    [
+        1,
+        1.0,
+        np.float32(1.0),
+        np.int64(1),
+        WHITE,
+        list(WHITE),
+        np.array(WHITE, dtype=np.float32),
+        np.array(WHITE, dtype=np.float64),
+    ],
+    ids=repr,
+)
+def test_normalize_backdrop_accepts_every_scalar_and_sequence_spelling(
+    color: object,
+) -> None:
+    """Equivalent backdrops expressed any of these ways must agree (#709).
+
+    ``composite()`` accepts a scalar, a per-channel sequence or an ndarray;
+    this is where all of them become the one array the compositor works with.
+    """
+    result, _ = _normalize_backdrop(color, 0.0, 2, 3, 3)  # type: ignore[arg-type]
+    assert result.dtype == np.float32
+    assert np.array_equal(result, rgb(WHITE, size=(2, 3)))
+
+
+@pytest.mark.parametrize("alpha", [1, 1.0, np.float32(1.0)], ids=repr)
+def test_normalize_backdrop_accepts_every_alpha_spelling(alpha: object) -> None:
+    _, result = _normalize_backdrop(1.0, alpha, 2, 3, 3)  # type: ignore[arg-type]
+    assert result.dtype == np.float32
+    assert np.array_equal(result, gray(1.0, size=(2, 3)))
+
+
+def test_normalize_backdrop_passes_a_per_pixel_array_through() -> None:
+    """A full canvas is taken as given, including a narrower channel count."""
+    canvas = np.linspace(0.0, 1.0, 12, dtype=np.float32).reshape(2, 2, 3)
+    result, _ = _normalize_backdrop(canvas, 0.0, 2, 2, 3)
+    assert np.array_equal(result, canvas)
+    # One channel against a three-channel document: the compositor widens this
+    # on demand, so normalization must not force it here.
+    narrow = gray(0.25)
+    result, _ = _normalize_backdrop(narrow, 0.0, 2, 2, 3)
+    assert result.shape == (2, 2, 1)
+
+
+def test_normalize_backdrop_infers_channels_when_none_is_given() -> None:
+    """The defensive fallback for when no document names a color mode.
+
+    ``composite()`` mirrors the ``_psd is not None`` hedge it already makes for
+    ``check_pixel_size``; every current caller supplies a channel count.
+    """
+    assert _normalize_backdrop(1.0, 0.0, 2, 2, None)[0].shape == (2, 2, 1)
+    assert _normalize_backdrop(WHITE, 0.0, 2, 2, None)[0].shape == (2, 2, 3)
+
+
+def test_normalize_backdrop_rejects_a_mismatched_backdrop() -> None:
+    with pytest.raises(ValueError, match="cannot be expanded"):
+        _normalize_backdrop((1.0, 0.0), 0.0, 2, 2, 3)
+    with pytest.raises(ValueError, match="match the viewport"):
+        _normalize_backdrop(np.zeros((4, 4, 3), dtype=np.float32), 0.0, 2, 2, 3)
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +250,7 @@ def apply_one(
     knockout: Knockout = Knockout.NONE,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Composite a single uniform source and return ``finish()``."""
-    compositor = Compositor((0, 0, 2, 2), backdrop_color, backdrop_alpha)
+    compositor = Compositor((0, 0, 2, 2), rgb(backdrop_color), gray(backdrop_alpha))
     compositor._apply_source(
         rgb(source_color), gray(shape), gray(alpha), blend_mode, knockout
     )
@@ -245,7 +302,7 @@ def test_apply_source_matches_the_textbook_over_operator(source_alpha: float) ->
     reduce to plain source-over-backdrop compositing.
     """
     backdrop_alpha = 0.75
-    compositor = Compositor((0, 0, 2, 2), WHITE, 0.0)
+    compositor = Compositor((0, 0, 2, 2), rgb(WHITE), gray(0.0))
     compositor._apply_source(
         rgb(RED), gray(backdrop_alpha), gray(backdrop_alpha), BlendMode.NORMAL
     )
@@ -281,7 +338,7 @@ def build_two_layer(knockout: Knockout) -> tuple[np.ndarray, np.ndarray]:
     With knockout the blue punches through the red to the initial backdrop;
     without it, blue composites over red.
     """
-    compositor = Compositor((0, 0, 2, 2), WHITE, 0.0)
+    compositor = Compositor((0, 0, 2, 2), rgb(WHITE), gray(0.0))
     compositor._apply_source(rgb(RED), gray(1.0), gray(1.0), BlendMode.NORMAL)
     compositor._apply_source(
         rgb(BLUE), gray(1.0), gray(0.5), BlendMode.NORMAL, knockout
@@ -314,8 +371,8 @@ def test_deep_knockout_without_a_document_backdrop_matches_shallow() -> None:
 def test_deep_knockout_uses_the_document_backdrop_when_present() -> None:
     compositor = Compositor(
         (0, 0, 2, 2),
-        WHITE,
-        0.0,
+        rgb(WHITE),
+        gray(0.0),
         document_backdrop=lambda: (rgb(GREEN), gray(1.0)),
     )
     compositor._apply_source(rgb(RED), gray(1.0), gray(1.0), BlendMode.NORMAL)
@@ -334,14 +391,14 @@ def test_deep_knockout_uses_the_document_backdrop_when_present() -> None:
 
 
 def test_color_correction_is_a_no_op_for_a_transparent_backdrop() -> None:
-    compositor = Compositor((0, 0, 2, 2), WHITE, 0.0)
+    compositor = Compositor((0, 0, 2, 2), rgb(WHITE), gray(0.0))
     compositor._apply_source(rgb(BLUE), gray(0.5), gray(0.5), BlendMode.NORMAL)
     assert np.allclose(compositor.color, compositor._color)
 
 
 def test_color_correction_removes_an_opaque_backdrop() -> None:
     """Over an opaque backdrop the raw and corrected results differ."""
-    compositor = Compositor((0, 0, 2, 2), RED, 1.0)
+    compositor = Compositor((0, 0, 2, 2), rgb(RED), gray(1.0))
     compositor._apply_source(rgb(BLUE), gray(0.5), gray(0.5), BlendMode.NORMAL)
     # Raw: what the pixel looks like, blue at 50% over red.
     assert np.allclose(compositor._color[0, 0], (0.5, 0.0, 0.5))

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -235,6 +235,17 @@ def test_normalize_backdrop_rejects_a_mismatched_backdrop() -> None:
         _normalize_backdrop(np.zeros((4, 4, 3), dtype=np.float32), 0.0, 2, 2, 3)
 
 
+def test_normalize_backdrop_requires_single_channel_alpha() -> None:
+    """Color may be narrower than the document; alpha may not be wider than 1.
+
+    The compositor widens a single-channel color on demand, so that stays
+    permissive. A multi-channel alpha has no such meaning (PR #721 review).
+    """
+    assert _normalize_backdrop(gray(0.5), 0.0, 2, 2, 3)[0].shape == (2, 2, 1)
+    with pytest.raises(ValueError, match=r"alpha has shape"):
+        _normalize_backdrop(1.0, np.ones((2, 2, 3), dtype=np.float32), 2, 2, 3)
+
+
 # ---------------------------------------------------------------------------
 # Compositor._apply_source() -- the PDF 1.4 union / knockout equations
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 1 of the #716 roadmap. Closes #708, closes #709.

`color` was typed `float | tuple[float, ...] | np.ndarray` and `alpha` `float | np.ndarray` all the way from the public API down into `Compositor`. That union carried three unrelated concerns, and the one that supposedly justified it — avoiding a full-canvas allocation for a constant backdrop — was never realised: `Compositor.__init__` expanded whatever it received immediately. What it did buy was `isinstance` branching in three places that disagreed with each other.

Resolve the spellings once in `composite()`, then narrow the internals.

## What changed

| | before | after |
| --- | --- | --- |
| `composite()` | expands `float` to a per-channel tuple | `_normalize_backdrop()` → two arrays |
| `Compositor.__init__` | four branches over scalar / tuple / ndarray | stores the arrays it is given |
| `_blend_backdrop()` | three `isinstance` fixups + a `color_mode` parameter to expand scalars | pure array maths, `color_mode` gone |
| scalar guards | `(int, float)` here, `(int, float, np.integer, np.floating)` there | one `_uniform_alpha()` |

`_get_mask()` / `_get_const()` keep their scalars — that one *is* a real allocation-avoidance path, and now says so in the docstring.

## Bugs this fixes

**#709 — `composite(color=1)` raised `TypeError`.** `int` and NumPy scalars fell through the `isinstance(color, float)` guard into `len(color)`. This is the roadmap's only live user-facing bug.

**A transparent backdrop spelled as a NumPy scalar was treated as opaque.** The zero-layer path skips the blend for a transparent backdrop, because blending it anyway sends `utils.divide` down its `0 / 0 -> 1.0` branch and whitens every uncovered pixel. Its guard tested `(int, float)` only:

```python
composite(PSDImage.new("RGBA", (4, 4), color=(0, 0, 0, 0)), color=1.0, alpha=X)
  X=0.0             main [0 0 0]   branch [0 0 0]
  X=np.float32(0.)  main [1 1 1]   branch [0 0 0]   <- fixed
  X=np.array(0.)    main [1 1 1]   branch [0 0 0]   <- fixed
```

**A per-pixel alpha of all zeros was not recognised as transparent** (found in review). Same whitening as above, one spelling further out. The guard is now `np.any(backdrop_alpha)`, which collapses scalar, NumPy scalar, 0-d array and array-of-zeros into a single test and short-circuits on the first nonzero.

**A multi-channel backdrop `alpha` was accepted** (found in review). Alpha is single-channel by definition, but only the first two dimensions of a per-pixel array were validated, so a `(h, w, 3)` alpha survived to `finish()` on the zero-layer path — where `composite_pil()` concatenates it onto the colour array and would build an image of the wrong width. `_to_canvas()` gained an `exact_channels` flag: a narrower *colour* stays legitimate, since the compositor widens a single-channel backdrop on demand, but alpha does not get that licence.

**A layerless multichannel document could not be composited over a backdrop.** `EXPECTED_CHANNELS[MULTICHANNEL]` is `64` — the format's maximum, not any document's actual count — so the backdrop could not be blended against the document's own 3-channel array. That path now sizes from the array in hand. The *layered* case has no such array to consult and is still broken; filed as **#720**.

## Also: `Compositor.__init__` loses its `isolated` flag

Its only job was to discard the `alpha` argument and substitute zeros. So both call sites built a full-canvas alpha that was thrown away unread — measured at **1083.5 KB for a single `Layer.composite()`** on `advanced-blending.psd`, and it scales with canvas area. Callers now pass the backdrop they mean, which is the same principle as the rest of this change. The waste in `_get_group()` predates this PR; the one in `composite()` I would have introduced, and a reviewer caught it.

## Verification

Hashed `composite()` output across every fixture, on `main` and on this branch:

| | cases | identical |
| --- | --- | --- |
| documents (248 files × 3 backdrops) | 744 | 742 |
| layers (recursive, × 2 backdrops) | 3248 | **3248** |

The two document differences are `4x4_16bit_multichannel.psd`, which raised `ValueError` on `main` and now renders. The layer sweep matters because it is the `isolated=True` path — the document sweep never reaches it.

`tools/benchmark_composite.py` reports byte-identical allocation totals, confirming this neither costs nor saves memory at document level. `1708 passed, 27 xfailed, 2 xpassed`; the two xpasses are pre-existing.

New tests were each checked against `main` to confirm they fail there — `color=1`, `color=np.float32(1.0)` (RGB and grayscale), the NumPy-scalar transparent backdrop, the 0-d array, the multichannel document, and the mismatched-length rejection. Three of the new tests pass on `main` by design and are marked as consistency checks rather than regression guards.

## Backwards incompatible

A per-channel backdrop whose length disagrees with the document's colour mode now raises `ValueError`:

```python
psd = PSDImage.open("grayscale.psd")
psd.composite(color=(1.0, 1.0, 1.0))   # main: a 3-channel result, silently reduced to channel 0
                                       # now:  ValueError
```

`psd.composite(color=(1.0, 1.0, 1.0))` written without checking `psd.color_mode` is a plausible "white backdrop" idiom, so this is a real break rather than a theoretical one. Pinned deliberately by a test — the loud failure is the intent. Pass a scalar, or a sequence matching `psd.color_mode`.

The public `color` annotation also widens from `tuple[float, ...]` to `Sequence[float]`, so a type-checked caller can pass a list. Without it #709 would only be half-fixed. Both are in the changelog.

## Not in scope

**#710** does not fall out of this. Its `np.repeat` fixups handle 1-channel arrays arriving from `_get_object()`'s empty-layer fallbacks and from mixed-colourspace sources, not only from a scalar backdrop, so it stays its own issue.

`np.broadcast_to` would genuinely avoid the allocation for a constant backdrop, but the result is read-only and #212 is where memory belongs. `_normalize_backdrop` allocates exactly as `Compositor` did before, and its docstring says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
