### PR TITLE
fix: fix the compositor's channel count at construction

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,16 @@ Changelog
   definition, but a wider array was accepted and reached ``composite_pil()``,
   which concatenates it onto the colour array and built an image of the wrong
   width (#708).
+- [fix] Composite over a single-channel backdrop array in a multi-channel
+  document. The compositor's colour canvas was widened lazily at the first
+  source layer, so a document with no source to apply -- every layer filtered
+  out or invisible, or a document whose only layers are adjustments -- kept a
+  one-channel array and raised ``TypeError`` from ``Image.fromarray()`` or
+  ``ValueError: Channel count does not match colormode``. The channel count is
+  now fixed when the compositor is built (#710).
+- [fix] Reject a backdrop whose channel count is neither 1 nor the document's.
+  A three-channel backdrop against a CMYK document used to surface as a NumPy
+  broadcast error from inside the blend arithmetic (#710).
 - [fix] Composite a layerless multichannel document over a backdrop. The
   backdrop was sized from ``EXPECTED_CHANNELS``, which reports 64 channels for
   multichannel documents regardless of how many the file actually carries, so

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -345,6 +345,20 @@ def _uniform_alpha(alpha: float | np.ndarray) -> float | None:
     return float(alpha) if np.ndim(alpha) == 0 else None
 
 
+def _widen(color: np.ndarray, channels: int) -> np.ndarray:
+    """Replicate a single-channel canvas across ``channels``.
+
+    A grayscale source inside an RGB document arrives one channel wide.
+    Broadcasting would handle it in the blend arithmetic, but the compositor's
+    own canvases have to be a fixed width for their whole lifetime, so a
+    backdrop is widened once at the point it is handed over rather than
+    repeatedly patched mid-composite.
+    """
+    if color.shape[2] == 1 and 1 < channels:
+        return np.repeat(color, channels, axis=2)
+    return color
+
+
 def _to_canvas(
     value: float | Sequence[float] | np.ndarray,
     shape: tuple[int, int, int],
@@ -353,13 +367,13 @@ def _to_canvas(
 ) -> np.ndarray:
     """Expand a backdrop component to a full ``(height, width, channels)`` array.
 
-    An array that is already per-pixel is taken as given. Its channel count is
-    allowed to differ from the document's, because the compositor widens a
-    single-channel backdrop on demand; ``exact_channels`` withdraws that
-    licence for alpha, which is single-channel by definition and would
-    otherwise reach ``composite_pil()`` and be concatenated into a color array
-    of the wrong width. Anything else (a scalar, a per-channel sequence) is
-    broadcast.
+    An array that is already per-pixel is taken as given, except that a
+    single-channel one is widened to the document's channel count: the
+    compositor's canvases keep a fixed width for their whole lifetime.
+    ``exact_channels`` rejects any mismatch outright instead, for alpha, which
+    is single-channel by definition and would otherwise reach
+    ``composite_pil()`` and be concatenated into a color array of the wrong
+    width. Anything else (a scalar, a per-channel sequence) is broadcast.
     """
     array = np.asarray(value, dtype=np.float32)
     if array.ndim == 3:
@@ -373,6 +387,16 @@ def _to_canvas(
                 "Backdrop %s covers %r, expected %r to match the viewport"
                 % (name, array.shape[:2], shape[:2])
             )
+        elif array.shape[2] not in (1, shape[2]):
+            # A single channel replicates; any other width has no reading, and
+            # left alone it would surface as a broadcast error from inside the
+            # blend arithmetic instead.
+            raise ValueError(
+                "Backdrop %s has %d channels, expected 1 or %d for this "
+                "color mode" % (name, array.shape[2], shape[2])
+            )
+        else:
+            array = _widen(array, shape[2])
         return array
     try:
         return np.full(shape, array, dtype=np.float32)
@@ -443,6 +467,11 @@ class Compositor(object):
     transparent backdrop, which the caller expresses by passing a zero
     ``alpha`` -- so that canvas is never built only to be discarded.
 
+    ``color``'s channel count becomes ``self.channels`` and is fixed for this
+    compositor's lifetime, so a caller handing over a canvas narrower than the
+    document must widen it first (``_widen()``). A narrow *source* is fine --
+    the blend arithmetic broadcasts it -- and must not change the width.
+
     Example::
 
         color, alpha = _normalize_backdrop(1.0, 0.0, height, width, channels)
@@ -479,8 +508,23 @@ class Compositor(object):
         self._document_backdrop_resolved = False
         self._document_backdrop: tuple[np.ndarray, np.ndarray] | None = None
 
+        # Preconditions rather than documentation: the whole point of fixing
+        # the channel count is that nothing downstream has to re-check it.
+        assert color.ndim == 3, "backdrop color must be a (h, w, c) canvas"
+        assert color.shape[:2] == (self.height, self.width), (
+            "backdrop color %r does not cover viewport %r"
+            % (color.shape, self._viewport)
+        )
+        assert alpha.shape == (self.height, self.width, 1), (
+            "backdrop alpha %r must be single-channel over viewport %r"
+            % (alpha.shape, self._viewport)
+        )
+
         self._alpha_0 = alpha
         self._color_0 = color
+        # The channel count is fixed for this compositor's lifetime; every
+        # canvas it hands to or takes from the blend equations is this wide.
+        self._channels = color.shape[2]
 
         self._shape_g = np.zeros((self.height, self.width, 1), dtype=np.float32)
         self._alpha_g = np.zeros((self.height, self.width, 1), dtype=np.float32)
@@ -567,11 +611,7 @@ class Compositor(object):
         alpha: np.ndarray,
         mask: float | np.ndarray,
     ) -> None:
-        if self._color_0.shape[2] == 1 and 1 < color.shape[2]:
-            self._color_0 = np.repeat(self._color_0, color.shape[2], axis=2)
-        if self._color.shape[2] == 1 and 1 < color.shape[2]:
-            self._color = np.repeat(self._color, color.shape[2], axis=2)
-
+        self._assert_source_fits(color)
         # ``color`` is the group already composited over this backdrop, because a
         # pass-through group is rendered by a non-isolated sub-compositor seeded
         # with the backdrop. Re-applying the group therefore means interpolating
@@ -604,16 +644,39 @@ class Compositor(object):
             )
         )
 
+    def _assert_source_fits(self, color: np.ndarray) -> None:
+        """Check the fixed-width invariant where a source meets the canvases.
+
+        The blend arithmetic broadcasts a single-channel source, but a *wider*
+        one would silently widen ``_color`` and leave ``channels`` stale. That
+        is what the deleted ``np.repeat`` fixups used to paper over, so this is
+        the assertion that keeps them deleted: it fires if a caller ever builds
+        a compositor narrower than the sources it will be given.
+        """
+        assert self._color.shape[2] == self._channels, (
+            "canvas widened to %d channels, expected %d"
+            % (self._color.shape[2], self._channels)
+        )
+        assert color.shape[2] in (1, self._channels), (
+            "source has %d channels, expected 1 or %d"
+            % (color.shape[2], self._channels)
+        )
+
     def _resolve_document_backdrop(self) -> tuple[np.ndarray, np.ndarray] | None:
         if not self._document_backdrop_resolved:
             self._document_backdrop_resolved = True
             if self._document_backdrop_fn is not None:
-                self._document_backdrop = self._document_backdrop_fn()
+                resolved = self._document_backdrop_fn()
+                if resolved is not None:
+                    # The Background layer can be narrower than the document
+                    # it sits in; widen once here so knockout hands back a
+                    # backdrop of this compositor's width like any other.
+                    color_b, alpha_b = resolved
+                    resolved = (_widen(color_b, self.channels), alpha_b)
+                self._document_backdrop = resolved
         return self._document_backdrop
 
-    def _knockout_backdrop(
-        self, knockout: Knockout, color: np.ndarray
-    ) -> tuple[np.ndarray, np.ndarray]:
+    def _knockout_backdrop(self, knockout: Knockout) -> tuple[np.ndarray, np.ndarray]:
         """The (color, alpha) pair that ``knockout`` knocks out to.
 
         SHALLOW knocks out to this compositor's own initial backdrop, i.e. the
@@ -624,10 +687,7 @@ class Compositor(object):
         if knockout == Knockout.DEEP:
             resolved = self._resolve_document_backdrop()
             if resolved is not None:
-                color_b, alpha_b = resolved
-                if color_b.shape[2] == 1 and 1 < color.shape[2]:
-                    color_b = np.repeat(color_b, color.shape[2], axis=2)
-                return color_b, alpha_b
+                return resolved
         return self._color_0, self._alpha_0
 
     def _apply_source(
@@ -638,12 +698,8 @@ class Compositor(object):
         blend_mode: BlendMode,
         knockout: Knockout = Knockout.NONE,
     ) -> None:
-        if self._color_0.shape[2] == 1 and 1 < color.shape[2]:
-            self._color_0 = np.repeat(self._color_0, color.shape[2], axis=2)
-        if self._color.shape[2] == 1 and 1 < color.shape[2]:
-            self._color = np.repeat(self._color, color.shape[2], axis=2)
-
-        knockout_color, knockout_alpha = self._knockout_backdrop(knockout, color)
+        self._assert_source_fits(color)
+        knockout_color, knockout_alpha = self._knockout_backdrop(knockout)
 
         self._shape_g = cast(np.ndarray, utils.union(self._shape_g, shape))
         if knockout:
@@ -723,6 +779,11 @@ class Compositor(object):
         return self._viewport[3] - self._viewport[1]
 
     @property
+    def channels(self) -> int:
+        """The channel count every canvas in this compositor carries."""
+        return self._channels
+
+    @property
     def color(self) -> np.ndarray:
         return utils.clip(
             self._color
@@ -748,7 +809,7 @@ class Compositor(object):
             else utils.intersect(self._viewport, layer.bbox)
         )
         if knockout:
-            color_b, alpha_b = self._knockout_backdrop(knockout, self._color_0)
+            color_b, alpha_b = self._knockout_backdrop(knockout)
         else:
             color_b = self._color
             alpha_b = self._alpha
@@ -847,7 +908,7 @@ class Compositor(object):
             and layer.stroke.enabled
         ):
             color_s, shape_s, alpha_s = self._get_stroke(layer)
-            compositor = Compositor(self._viewport, color, alpha)
+            compositor = Compositor(self._viewport, _widen(color, self.channels), alpha)
             compositor._apply_source(color_s, shape_s, alpha_s, layer.stroke.blend_mode)
             color, _, _ = compositor.finish()
 
@@ -862,7 +923,7 @@ class Compositor(object):
         # TODO: Consider Tag.BLEND_CLIPPING_ELEMENTS.
         compositor = Compositor(
             self._viewport,
-            color,
+            _widen(color, self.channels),
             alpha,
             layer_filter=self._layer_filter,
             force=self._force,

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -285,6 +285,7 @@ _BACKDROP_SPELLINGS = [
     pytest.param((1.0, 1.0, 1.0), id="tuple"),
     pytest.param([1.0, 1.0, 1.0], id="list"),
     pytest.param(np.ones((4, 4, 3), dtype=np.float32), id="ndarray"),
+    pytest.param(np.ones((4, 4, 1), dtype=np.float32), id="single-channel-canvas"),
 ]
 
 
@@ -345,6 +346,42 @@ def test_composite_transparent_backdrop_is_skipped_in_any_spelling(
     assert len(psd) == 0
     result, _, _ = composite(psd, color=1.0, alpha=alpha)
     assert np.array_equal(result, np.zeros_like(result))
+
+
+@pytest.mark.parametrize(
+    ("filename", "kwargs"),
+    [
+        # Nothing to composite: every layer filtered out.
+        ("colormodes/4x4_8bit_rgb.psd", {"layer_filter": lambda layer: False}),
+        # Nothing to composite either: the only layer is an adjustment, which
+        # transforms the backdrop rather than applying a source over it.
+        ("layers/curves.psd", {}),
+        ("layers/levels.psd", {}),
+        ("layers/brightness-contrast.psd", {}),
+    ],
+)
+def test_composite_single_channel_backdrop_without_a_source(
+    filename: str, kwargs: Any
+) -> None:
+    """A one-channel backdrop must still produce a document-width image (#710).
+
+    The canvas used to be widened lazily at the first source, so a document
+    with no source to apply kept a one-channel color array and blew up on the
+    way out -- in ``Image.fromarray()``, or in ``_preserve_alpha`` for the
+    adjustment cases.
+    """
+    psd = PSDImage.open(full_name(filename))
+    backdrop = np.full((psd.height, psd.width, 1), 0.25, dtype=np.float32)
+    image = psd.composite(color=backdrop, alpha=1.0, ignore_preview=True, **kwargs)
+    assert image.mode == "RGB"
+    assert image.size == (psd.width, psd.height)
+
+
+def test_composite_backdrop_rejects_an_unresolvable_channel_count() -> None:
+    """Three channels against a four-channel document has no reading (#710)."""
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
+    with pytest.raises(ValueError, match="has 3 channels, expected 1 or 4"):
+        composite(psd, color=np.ones((4, 4, 3), dtype=np.float32), alpha=1.0)
 
 
 def test_composite_backdrop_rejects_a_mismatched_channel_count() -> None:

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -299,6 +299,9 @@ def test_a_narrow_source_leaves_the_canvas_width_alone(channels: int) -> None:
     assert compositor.finish()[0].shape == (2, 2, channels)
 
 
+@pytest.mark.skipif(
+    not __debug__, reason="the invariant checks are asserts, stripped under -O"
+)
 def test_a_source_wider_than_the_canvas_is_rejected() -> None:
     """The invariant is enforced in code, not just documented (#710).
 

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -9,6 +9,8 @@ These tests pin the primitives directly, so a change to the compositing maths
 fails with a specific, hand-checkable number. See #715.
 """
 
+from typing import Any, cast
+
 import numpy as np
 import pytest
 
@@ -17,6 +19,7 @@ from psd_tools.composite.composite import (
     Compositor,
     _blend_backdrop,
     _normalize_backdrop,
+    _widen,
     paste,
 )
 from psd_tools.constants import BlendMode, Knockout
@@ -207,14 +210,24 @@ def test_normalize_backdrop_accepts_every_alpha_spelling(alpha: object) -> None:
 
 
 def test_normalize_backdrop_passes_a_per_pixel_array_through() -> None:
-    """A full canvas is taken as given, including a narrower channel count."""
+    """A full canvas of the right width is taken as given."""
     canvas = np.linspace(0.0, 1.0, 12, dtype=np.float32).reshape(2, 2, 3)
     result, _ = _normalize_backdrop(canvas, 0.0, 2, 2, 3)
     assert np.array_equal(result, canvas)
-    # One channel against a three-channel document: the compositor widens this
-    # on demand, so normalization must not force it here.
-    narrow = gray(0.25)
-    result, _ = _normalize_backdrop(narrow, 0.0, 2, 2, 3)
+
+
+def test_normalize_backdrop_widens_a_single_channel_canvas() -> None:
+    """One channel against a three-channel document is replicated (#710).
+
+    The compositor used to widen this lazily at the first source, which left
+    ``_color_0``'s width only eventually correct. Normalization settles it, so
+    the canvas width is fixed for the compositor's whole lifetime.
+    """
+    result, _ = _normalize_backdrop(gray(0.25), 0.0, 2, 2, 3)
+    assert result.shape == (2, 2, 3)
+    assert np.array_equal(result, rgb((0.25, 0.25, 0.25)))
+    # A grayscale document leaves it alone.
+    result, _ = _normalize_backdrop(gray(0.25), 0.0, 2, 2, 1)
     assert result.shape == (2, 2, 1)
 
 
@@ -228,6 +241,12 @@ def test_normalize_backdrop_infers_channels_when_none_is_given() -> None:
     assert _normalize_backdrop(WHITE, 0.0, 2, 2, None)[0].shape == (2, 2, 3)
 
 
+def test_normalize_backdrop_rejects_an_unresolvable_channel_count() -> None:
+    """One channel replicates; any other width has no reading (#710)."""
+    with pytest.raises(ValueError, match="has 3 channels, expected 1 or 4"):
+        _normalize_backdrop(np.ones((2, 2, 3), dtype=np.float32), 0.0, 2, 2, 4)
+
+
 def test_normalize_backdrop_rejects_a_mismatched_backdrop() -> None:
     with pytest.raises(ValueError, match="cannot be expanded"):
         _normalize_backdrop((1.0, 0.0), 0.0, 2, 2, 3)
@@ -238,12 +257,109 @@ def test_normalize_backdrop_rejects_a_mismatched_backdrop() -> None:
 def test_normalize_backdrop_requires_single_channel_alpha() -> None:
     """Color may be narrower than the document; alpha may not be wider than 1.
 
-    The compositor widens a single-channel color on demand, so that stays
-    permissive. A multi-channel alpha has no such meaning (PR #721 review).
+    A narrow color is widened to the document's channel count, because
+    replicating a single channel across three is what compositing a grayscale
+    backdrop in RGB means. A multi-channel alpha has no such reading, so it is
+    rejected rather than reinterpreted (PR #721 review).
     """
-    assert _normalize_backdrop(gray(0.5), 0.0, 2, 2, 3)[0].shape == (2, 2, 1)
+    assert _normalize_backdrop(gray(0.5), 0.0, 2, 2, 3)[0].shape == (2, 2, 3)
     with pytest.raises(ValueError, match=r"alpha has shape"):
         _normalize_backdrop(1.0, np.ones((2, 2, 3), dtype=np.float32), 2, 2, 3)
+
+
+# ---------------------------------------------------------------------------
+# The fixed channel count (#710)
+# ---------------------------------------------------------------------------
+
+
+def test_widen_replicates_a_single_channel() -> None:
+    assert np.array_equal(_widen(gray(0.25), 3), rgb((0.25, 0.25, 0.25)))
+    # Already wide enough, or the document is single-channel: unchanged.
+    canvas = rgb(RED)
+    assert _widen(canvas, 3) is canvas
+    narrow = gray(0.25)
+    assert _widen(narrow, 1) is narrow
+
+
+@pytest.mark.parametrize("channels", [1, 3])
+def test_a_narrow_source_leaves_the_canvas_width_alone(channels: int) -> None:
+    """The blend arithmetic broadcasts a single-channel source (#710).
+
+    Applying one is therefore not a reason to reallocate. Consistency check:
+    this held before the fixups were deleted too.
+    """
+    backdrop = rgb(WHITE) if channels == 3 else gray(1.0)
+    compositor = Compositor((0, 0, 2, 2), backdrop, gray(0.0))
+    assert compositor.channels == channels
+
+    compositor._apply_source(gray(0.5), gray(1.0), gray(1.0), BlendMode.NORMAL)
+    assert compositor.channels == channels
+    assert compositor._color.shape == (2, 2, channels)
+    assert compositor._color_0.shape == (2, 2, channels)
+    assert compositor.finish()[0].shape == (2, 2, channels)
+
+
+def test_a_source_wider_than_the_canvas_is_rejected() -> None:
+    """The invariant is enforced in code, not just documented (#710).
+
+    This is the case the deleted ``np.repeat`` fixups existed for: they widened
+    ``_color_0`` in place. Without them the blend would silently widen
+    ``_color`` and leave ``channels`` stale, so building a compositor narrower
+    than the sources it will be given is now a caught bug rather than a quiet
+    one.
+    """
+    compositor = Compositor((0, 0, 2, 2), gray(1.0), gray(0.0))
+    assert compositor.channels == 1
+    with pytest.raises(AssertionError, match="source has 3 channels"):
+        compositor._apply_source(rgb(BLUE), gray(1.0), gray(1.0), BlendMode.NORMAL)
+
+
+class _ClipStub:
+    """The only attribute ``_apply_clip_layers`` reads off its layer."""
+
+    clip_layers: list = []
+
+
+def test_clip_layers_sub_compositor_uses_the_document_width() -> None:
+    """A grayscale layer in an RGB document seeds a clip sub-compositor.
+
+    Its own color is one channel wide, so it has to be widened before it
+    becomes another compositor's fixed-width canvas (#710).
+    """
+    compositor = Compositor((0, 0, 2, 2), rgb(WHITE), gray(0.0))
+    stub = cast(Any, _ClipStub())
+    result = compositor._apply_clip_layers(stub, gray(0.5), gray(1.0))
+    assert result.shape == (2, 2, 3)
+    assert np.array_equal(result, rgb((0.5, 0.5, 0.5)))
+
+
+def test_document_backdrop_is_widened_to_the_canvas() -> None:
+    """The Background layer can be narrower than the document it sits in.
+
+    Deep knockout hands its color straight to the blend, so it is widened once
+    at resolution rather than at every knockout (#710).
+    """
+    compositor = Compositor(
+        (0, 0, 2, 2),
+        rgb(WHITE),
+        gray(0.0),
+        document_backdrop=lambda: (gray(0.25), gray(1.0)),
+    )
+    color_b, alpha_b = compositor._knockout_backdrop(Knockout.DEEP)
+    assert color_b.shape == (2, 2, 3)
+    assert np.array_equal(color_b, rgb((0.25, 0.25, 0.25)))
+    assert alpha_b.shape == (2, 2, 1)
+
+
+def test_narrow_source_matches_a_pre_widened_one() -> None:
+    """Broadcasting a narrow source is the same as replicating it first."""
+
+    def run(source: np.ndarray) -> np.ndarray:
+        compositor = Compositor((0, 0, 2, 2), rgb(RED), gray(1.0))
+        compositor._apply_source(source, gray(0.5), gray(0.5), BlendMode.MULTIPLY)
+        return compositor.finish()[0]
+
+    assert np.allclose(run(gray(0.5)), run(rgb((0.5, 0.5, 0.5))))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 1 of the #716 roadmap. Closes #710.

`_apply_source` and `_apply_passthrough_source` each opened with the same runtime fixup that widened a 1-channel backdrop in place, and `_knockout_backdrop` had a third variant. So the compositor's channel count was only *eventually* correct, and "`_color` and `_color_0` always have the document's channel count" was an implicit claim rather than an enforced one.

Establish it instead: **a Compositor's channel count is set at construction and never changes.**

## The issue's premise had already shifted

#710 names its cause as `channels = 1 if isinstance(color, float) else len(color)` in `Compositor.__init__`. PR #721 deleted that line and now passes `EXPECTED_CHANNELS[color_mode]`, so the backdrop already arrives at the right width. I measured what was actually left before touching anything — all 248 fixtures, document and layer level, `force` off and on:

| Fixup site | Fired |
| --- | --- |
| `_apply_source` | 22 — all from `_get_object`'s stroke path, in two fixtures |
| `_apply_passthrough_source` | 0 |
| `_knockout_backdrop` | 0 |

That reframed the work: rather than threading a `channels` parameter through, widen at the few points a narrow canvas can *enter*, and delete all four fixups.

## What changed

A new `_widen()` runs at four places: `_to_canvas()` (a user-supplied backdrop), `_get_object()`'s stroke sub-compositor, `_apply_clip_layers()`, and once when the document backdrop resolves. `_knockout_backdrop` loses the `color` parameter it only needed to size its fixup. `Compositor.channels` is exposed.

Sources are deliberately **not** widened. The blend arithmetic broadcasts a single-channel source, so widening them would add allocations that don't exist today. Only canvases are.

## The invariant is enforced, not documented

`__init__` now checks the backdrop's shape, and `_assert_source_fits()` catches both a canvas widened by broadcasting and a source wider than the canvas. That matters — without them, three of the four `_widen()` calls could be deleted with the suite still fully green. Every mutation is now caught:

| `_widen()` call neutralised | Suite |
| --- | --- |
| `_to_canvas` | 7 failed |
| `_get_object` stroke | 3 failed |
| `_apply_clip_layers` | 1 failed |
| `_resolve_document_backdrop` | 1 failed |
| `_assert_source_fits` removed | 1 failed |

## A user-visible bug this fixes

Because the widening was lazy, a document with **no source to apply** kept a 1-channel colour array over a single-channel backdrop and then failed on the way out. That includes documents whose only layers are adjustments — with no filter involved:

```
psd.composite(color=np.full((h, w, 1), 0.25), alpha=1.0, ignore_preview=True)

  colormodes/4x4_8bit_rgb.psd  + layer_filter=False
      main   TypeError: Cannot handle this data type: (1, 1, 1), |u1
      branch RGB (4, 4)

  layers/curves.psd            (no filter at all)
      main   ValueError: Channel count does not match colormode.
      branch RGB (32, 32)
```

The second comes from `_preserve_alpha` in `adjustments.py`, not PIL. Nine adjustment-layer fixtures composite for the first time.

`_to_canvas()` also now rejects a backdrop whose channel count is neither 1 nor the document's, rather than letting it surface as a NumPy broadcast error from inside the blend arithmetic.

## Verification

Hashed `composite()` output over every fixture — documents and every layer, `force` off and on, four backdrop spellings, **5232 cases**:

| | cases | result |
| --- | --- | --- |
| scalar backdrop | 2480 | **all byte-identical** |
| single-channel backdrop | 487 comparable | 251 byte-identical, 236 = main's own values replicated across channels, **0 differing in value** |
| single-channel backdrop | 9 | raised on main, succeed now |

A runtime invariant probe over the same corpus — 3244 compositors, 4744 `_apply_source` and 850 `_apply_passthrough_source` calls — reports zero violations of "channels never changes" and "no source is wider than the canvas". `tools/benchmark_composite.py` shows identical allocation: the widening isn't new work, only moved earlier.

`1723 passed, 27 xfailed, 2 xpassed`.

## Two things a reviewer should know

**Deleting `_apply_passthrough_source`'s fixup is safe only because `_to_canvas` now widens** — the two are coupled. My initial "it never fires" measurement was a probe artifact: it used the default scalar backdrop, which `_normalize_backdrop` already expands, so `_color_0` was never narrow. Hand it a single-channel array and that fixup fires on nine fixtures on `main`. The deletion holds because a pass-through sub-compositor is seeded by `paste()` of the parent's canvas, so its width is structurally the parent's, and the parent is now always document-width.

**Widening replicates, which is wrong for CMYK and Lab.** A neutral CMYK grey is K-only, not `(g, g, g, g)`. That predates this change — the deleted fixups did the identical `np.repeat` — and composited values are unchanged, so fixing it belongs in its own PR with its own evidence. Filed as **#722**.

The layered-multichannel path stays broken by **#720**: `EXPECTED_CHANNELS[MULTICHANNEL]` is 64 rather than the file's real count. One narrow-backdrop spelling that accidentally worked there now raises like every other spelling already did on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
