### PR TITLE
chore: name the compositor's two results

### DIFF
--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -785,7 +785,7 @@ class Compositor(object):
             )
 
     def finish(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        return self.color, self.shape, self.alpha
+        return self.result_isolated(), self.shape, self.alpha
 
     @property
     def viewport(self) -> tuple[int, int, int, int]:
@@ -804,13 +804,36 @@ class Compositor(object):
         """The channel count every canvas in this compositor carries."""
         return self._channels
 
-    @property
-    def color(self) -> np.ndarray:
+    def result_isolated(self) -> np.ndarray:
+        """The composited color with the initial backdrop's contribution removed.
+
+        Correct when the result is handed back as a *source* in its own right
+        -- a group about to be composited by its parent, or the return value of
+        ``composite()`` -- because the caller will composite it over that same
+        backdrop again, and the backdrop must not be counted twice. Paired with
+        ``alpha``, this is straight (un-premultiplied) color: where the group
+        covers nothing, the backdrop it was seeded with is undone.
+
+        The correction is a no-op for the transparent backdrop an isolated
+        group starts from, and grows with ``_alpha_0``.
+        """
         return utils.clip(
             self._color
             + (self._color - self._color_0)
             * (utils.divide(self._alpha_0, self._alpha_g) - self._alpha_0)
         )
+
+    def result_over_backdrop(self) -> np.ndarray:
+        """The composited color *as it stands over* the initial backdrop.
+
+        Correct when the caller is continuing to composite onto the very
+        backdrop this compositor was seeded with, so that removing it would
+        drop a contribution the caller still wants: the pass-through path,
+        where the sub-compositor was seeded with the parent's own canvas, and
+        the clip-layer path, where the sub-compositor was seeded with the base
+        layer's color.
+        """
+        return self._color
 
     @property
     def shape(self) -> np.ndarray:
@@ -881,12 +904,18 @@ class Compositor(object):
         for sublayer in cast(GroupMixin, layer):
             group_compositor.apply(sublayer)
 
+        # When adjustments are isolated the group is composited as an ordinary
+        # source, so the backdrop it was seeded with has to come back out
+        # first; otherwise it stays in, because _apply_passthrough_source()
+        # interpolates the result against that same backdrop. For a
+        # non-pass-through group the two agree anyway -- it was seeded
+        # transparent, and the correction is a no-op there.
         if isolate_adjustments:
-            color = group_compositor.color  # prevents backdrop color contamination
+            color = group_compositor.result_isolated()
         else:
-            color = group_compositor._color
-        shape = group_compositor._shape_g
-        alpha = group_compositor._alpha_g
+            color = group_compositor.result_over_backdrop()
+        shape = group_compositor.shape
+        alpha = group_compositor.alpha
 
         color = paste(self._viewport, viewport, color, 1.0)
         shape = paste(self._viewport, viewport, shape)
@@ -945,7 +974,9 @@ class Compositor(object):
         )
         for clip_layer in layer.clip_layers:
             compositor.apply(clip_layer, clip_compositing=True)
-        return compositor._color
+        # Seeded with ``color`` itself, so the result is wanted as it stands on
+        # that seed -- the clipped layers paint onto the base layer's color.
+        return compositor.result_over_backdrop()
 
     def _get_mask(self, layer: Layer) -> float | np.ndarray:
         """The layer's mask coverage, with any mask density already folded in.

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -295,7 +295,7 @@ def test_a_narrow_source_leaves_the_canvas_width_alone(channels: int) -> None:
 
     compositor._apply_source(gray(0.5), gray(1.0), gray(1.0), BlendMode.NORMAL)
     assert compositor.channels == channels
-    assert compositor._color.shape == (2, 2, channels)
+    assert compositor.result_over_backdrop().shape == (2, 2, channels)
     assert compositor._color_0.shape == (2, 2, channels)
     assert compositor.finish()[0].shape == (2, 2, channels)
 
@@ -405,7 +405,7 @@ def test_apply_source_fully_transparent_source_leaves_the_backdrop() -> None:
 def test_apply_source_returns_the_isolated_source_not_the_blend() -> None:
     """Over an *opaque* backdrop, the returned colour is the isolated source.
 
-    ``finish()`` returns ``Compositor.color``, which removes the initial
+    ``finish()`` returns ``Compositor.result_isolated()``, which removes the initial
     backdrop's contribution. Compositing this result back over that backdrop is
     what reproduces the visible pixel -- here 50% blue over opaque red gives
     (0.5, 0, 0.5), which ``test_color_correction_removes_an_opaque_backdrop``
@@ -517,23 +517,25 @@ def test_deep_knockout_uses_the_document_backdrop_when_present() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Compositor.color -- the backdrop-removal correction
+# Compositor.result_isolated() -- the backdrop-removal correction
 # ---------------------------------------------------------------------------
 
 
 def test_color_correction_is_a_no_op_for_a_transparent_backdrop() -> None:
     compositor = Compositor((0, 0, 2, 2), rgb(WHITE), gray(0.0))
     compositor._apply_source(rgb(BLUE), gray(0.5), gray(0.5), BlendMode.NORMAL)
-    assert np.allclose(compositor.color, compositor._color)
+    assert np.allclose(compositor.result_isolated(), compositor.result_over_backdrop())
 
 
 def test_color_correction_removes_an_opaque_backdrop() -> None:
     """Over an opaque backdrop the raw and corrected results differ."""
     compositor = Compositor((0, 0, 2, 2), rgb(RED), gray(1.0))
     compositor._apply_source(rgb(BLUE), gray(0.5), gray(0.5), BlendMode.NORMAL)
-    # Raw: what the pixel looks like, blue at 50% over red.
-    assert np.allclose(compositor._color[0, 0], (0.5, 0.0, 0.5))
-    # Corrected: the isolated source, which re-composites to the raw value.
-    assert np.allclose(compositor.color[0, 0], BLUE)
-    recomposited = compositor.color[0, 0] * 0.5 + np.array(RED) * 0.5
-    assert np.allclose(recomposited, compositor._color[0, 0])
+    # Over the backdrop: what the pixel looks like, blue at 50% over red.
+    over_backdrop = compositor.result_over_backdrop()
+    assert np.allclose(over_backdrop[0, 0], (0.5, 0.0, 0.5))
+    # Isolated: the source on its own, which re-composites to the value above.
+    isolated = compositor.result_isolated()
+    assert np.allclose(isolated[0, 0], BLUE)
+    recomposited = isolated[0, 0] * 0.5 + np.array(RED) * 0.5
+    assert np.allclose(recomposited, over_backdrop[0, 0])


### PR DESCRIPTION
Closes #712. Phase 2 of #716.

## What

`Compositor.color` is not a plain accessor — it removes the initial backdrop's contribution — and two of the three internal consumers deliberately bypassed it to read `_color` instead. Both results are needed; the choice between them was a one-character difference explained by a five-word comment.

This names them:

- `result_isolated()` — the old `color` property. The result as a *source* in its own right: correct when the caller will composite it over the same backdrop again (`finish()`, and an isolated group handed to its parent).
- `result_over_backdrop()` — the raw `_color`. The result *as it stands on* the backdrop it was seeded with: correct for the pass-through path and the clip-layer path, where the caller keeps painting onto that same canvas.

Each carries a docstring saying which situation it is for and why. `_get_group()` also reads `shape` / `alpha` through the existing properties instead of `_shape_g` / `_alpha_g`, and the `isolate_adjustments` fork gets a comment that explains the choice rather than restating it.

## Behaviour

Unchanged — this is naming and documentation only. `finish()` returns the same three arrays, and the two accessors return exactly what `color` / `_color` returned before.

Note that the two agree for a non-pass-through group anyway: it is seeded transparent, and the correction is a no-op at `_alpha_0 == 0`. The distinction only bites where a sub-compositor was seeded with a non-transparent backdrop.

## Testing

`uv run pytest` — full suite green (1727 passed). The primitive tests that read `compositor.color` / `._color` now go through the named accessors; `test_color_correction_removes_an_opaque_backdrop` reads as a statement about the two results rather than about one public and one private attribute.

No changelog entry: `Compositor` is internal (not exported from `psd_tools.composite`, not in the docs) and no user-visible behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
