### PR TITLE
chore: let divide()'s callers name their own fallback

### DIFF
--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -655,15 +655,9 @@ class Compositor(object):
         color_t = (1.0 - mask) * alpha_b * color_b + (
             mask * alpha_b + alpha * (1.0 - alpha_b)
         ) * color
-        self._color = utils.clip(
-            np.where(
-                self._alpha > 0.0,
-                utils.divide(color_t, self._alpha),
-                # Fully transparent, so the color is arbitrary; ``color`` merely
-                # avoids utils.divide()'s 0 / 0 -> 1.0 (white) fallback.
-                color,
-            )
-        )
+        # Where the result is fully transparent the color is arbitrary, so fall
+        # back to the group's own color rather than to white.
+        self._color = utils.clip(utils.divide(color_t, self._alpha, fill=color))
 
     def _assert_source_fits(self, color: np.ndarray) -> None:
         """Check the fixed-width invariant where a source meets the canvases.
@@ -820,7 +814,12 @@ class Compositor(object):
         return utils.clip(
             self._color
             + (self._color - self._color_0)
-            * (utils.divide(self._alpha_0, self._alpha_g) - self._alpha_0)
+            * (
+                # A ratio of two alphas rather than a color, so the fill
+                # means "fully opaque" here and not "white": where the group
+                # covers nothing there is no coverage to divide out of.
+                utils.divide(self._alpha_0, self._alpha_g, fill=1.0) - self._alpha_0
+            )
         )
 
     def result_over_backdrop(self) -> np.ndarray:

--- a/src/psd_tools/composite/utils.py
+++ b/src/psd_tools/composite/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for composite operations."""
 
-from typing import overload
+from typing import Any, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -9,12 +9,39 @@ from psd_tools.api.layers import Layer
 from psd_tools.constants import Tag
 
 
-def divide(a: NDArray[np.floating], b: NDArray[np.floating]) -> NDArray[np.floating]:
-    """Safe division for color ops."""
-    with np.errstate(divide="ignore", invalid="ignore"):
-        c = np.true_divide(a, b)
-        c[~np.isfinite(c)] = 1.0
-    return c
+# A divisor or a fill is usually a canvas, but ``draw_stroke_effect()``
+# normalizes by a NumPy scalar and every caller may pass a plain float.
+_Scalable = NDArray[np.floating] | np.floating[Any] | float
+
+
+def divide(
+    a: NDArray[np.floating],
+    b: _Scalable,
+    fill: _Scalable = 1.0,
+) -> NDArray[np.floating]:
+    """Divide ``a`` by ``b``, substituting ``fill`` where ``b`` is not positive.
+
+    Every divisor in the compositor is an alpha or a coverage, so a zero one
+    means "nothing here" rather than an arithmetic accident, and the quotient
+    is undefined at exactly those pixels. What belongs there instead is the
+    caller's to say: un-premultiplying a color wants a color to fall back to,
+    while a ratio of two alphas wants an opacity. The default 1.0 reads as
+    white in normalized color space and as fully opaque in alpha, which is what
+    every caller that does not pass ``fill`` relies on.
+
+    ``fill`` may be a full canvas as well as a scalar, so a caller can fall
+    back per pixel to something it already has in hand.
+
+    Skipping those pixels via ``where=`` also avoids computing an invalid
+    quotient only to overwrite it -- the divisor is never negative here, so
+    ``b > 0`` and "b is nonzero" are the same test.
+    """
+    out = np.full(
+        np.broadcast_shapes(np.shape(a), np.shape(b)),
+        fill,
+        dtype=np.result_type(a, b),
+    )
+    return np.divide(a, b, out=out, where=np.asarray(b) > 0)
 
 
 def intersect(

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -123,20 +123,43 @@ def test_union_identities(x: float) -> None:
     assert utils.union(x, 1.0) == pytest.approx(1.0)
 
 
-def test_divide_falls_back_to_one_on_non_finite() -> None:
-    """Division by zero yields 1.0, i.e. white in normalised colour space.
+def test_divide_defaults_to_one_where_the_divisor_is_zero() -> None:
+    """Without a ``fill``, a zero divisor yields 1.0.
 
-    This is a deliberate policy rather than an accident, and callers depend on
-    it -- see the ``np.where`` guard in ``_apply_passthrough_source``. #714
-    proposes making the fallback caller-specified; this test is what that
-    change has to consciously update.
+    That is white in normalised colour space and fully opaque read as an
+    alpha; the callers that do not pass ``fill`` rely on one or the other.
     """
     assert np.array_equal(utils.divide(gray(1.0), gray(0.0)), gray(1.0))
     assert np.array_equal(utils.divide(gray(0.0), gray(0.0)), gray(1.0))
 
 
+def test_divide_substitutes_the_callers_fill() -> None:
+    assert np.array_equal(utils.divide(gray(1.0), gray(0.0), fill=0.25), gray(0.25))
+
+
+def test_divide_fill_may_be_a_canvas() -> None:
+    """A per-pixel fill, as ``_apply_passthrough_source`` passes."""
+    divisor = np.array([[[0.0], [2.0]]], dtype=np.float32)
+    result = utils.divide(rgb(WHITE, (1, 2)), divisor, fill=rgb(BLUE, (1, 2)))
+    assert np.allclose(result[0, 0], BLUE)  # divisor 0 -> the fill
+    assert np.allclose(result[0, 1], (0.5, 0.5, 0.5))  # divisor 2 -> the quotient
+
+
+def test_divide_fill_broadcasts_against_a_wider_numerator() -> None:
+    """A three-channel numerator over a single-channel divisor."""
+    result = utils.divide(rgb(RED), gray(0.0), fill=gray(0.5))
+    assert result.shape == (2, 2, 3)
+    assert np.allclose(result, 0.5)
+
+
 def test_divide_is_ordinary_where_the_divisor_is_non_zero() -> None:
     assert np.allclose(utils.divide(gray(1.0), gray(4.0)), gray(0.25))
+    assert np.allclose(utils.divide(gray(1.0), gray(4.0), fill=0.0), gray(0.25))
+
+
+def test_divide_keeps_the_numerator_dtype() -> None:
+    """float32 canvases must not be promoted to float64 by a scalar divisor."""
+    assert utils.divide(gray(1.0), np.float32(2.0)).dtype == np.float32
 
 
 def test_clip_bounds() -> None:
@@ -423,6 +446,18 @@ def test_apply_source_over_transparent_backdrop_is_not_contaminated_toward_white
     color, _, alpha = apply_one(WHITE, 0.0, BLUE, 0.5, 0.5)
     assert np.allclose(color[0, 0], BLUE)
     assert np.allclose(alpha, 0.5)
+
+
+def test_passthrough_over_nothing_keeps_the_group_colour() -> None:
+    """A pass-through group over a transparent backdrop is not whitened.
+
+    With nothing composited anywhere, ``color_t / self._alpha`` is 0 / 0 at
+    every pixel, and the group's own colour is what belongs there instead of
+    ``divide()``'s default white.
+    """
+    compositor = Compositor((0, 0, 2, 2), rgb(WHITE), gray(0.0))
+    compositor._apply_passthrough_source(rgb(BLUE), gray(0.0), gray(0.0), 1.0)
+    assert np.allclose(compositor.result_over_backdrop(), rgb(BLUE))
 
 
 @pytest.mark.parametrize("source_alpha", [0.0, 0.25, 0.5, 0.75, 1.0])


### PR DESCRIPTION
Closes #714. Phase 2 of #716.

## What

`utils.divide()` mapped every non-finite quotient to `1.0`. That is white in normalised colour space — a reasonable default for un-premultiplying a colour, but a *policy* baked into a utility whose four call sites divide for three different reasons, and one of them had already worked around it:

```python
self._color = utils.clip(
    np.where(
        self._alpha > 0.0,
        utils.divide(color_t, self._alpha),
        color,   # avoids divide()'s 0/0 -> white
    )
)
```

The fallback is now the caller's to name:

```python
def divide(a, b, fill=1.0):
    out = np.full(np.broadcast_shapes(np.shape(a), np.shape(b)), fill, dtype=np.result_type(a, b))
    return np.divide(a, b, out=out, where=np.asarray(b) > 0)
```

- `_apply_passthrough_source()` passes `fill=color` and drops the `np.where` wrapper, its explanatory comment, and the full-viewport division whose result it then partly threw away.
- `result_isolated()` passes `fill=1.0` explicitly, with a comment noting that there it divides two *alphas*, so the value means "fully opaque" and not "white".
- `_blend_backdrop()` and `_apply_source()` keep the default; for both, white is the historical value at pixels that are fully transparent, and changing it is not part of this issue.

`fill` accepts a full canvas as well as a scalar, which is what the pass-through path needs. `where=` also skips computing the invalid entries rather than computing and overwriting them.

## Behaviour

Numerically identical, including at the transparent pixels #714 flagged as the risk. `b > 0` and "b is nonzero" coincide here because every divisor is an alpha or a coverage; NaN divisors take the fill in both the old and the new form.

Checked rather than argued: composited all 248 fixture PSDs under `tests/psd_files/` on `main` and on this branch and compared colour/shape/alpha — **248/248 bitwise identical**. So the `test_composite_quality` MSE thresholds do not shift.

## Testing

`uv run pytest` — 1732 passed. New unit tests cover the default fill, a caller-supplied scalar fill, a per-pixel canvas fill, broadcasting a single-channel divisor against a three-channel numerator, and dtype preservation. `test_divide_falls_back_to_one_on_non_finite` — which #715 deliberately left as the tripwire for this change — is updated to say that 1.0 is now the *default* rather than the policy. A new `test_passthrough_over_nothing_keeps_the_group_colour` pins the pass-through fill at unit level, where previously only the end-to-end pass-through fixtures covered it.

No changelog entry: `utils.divide` is internal and no output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
