### PR TITLE
fix: size a multichannel backdrop from the header, not from EXPECTED_CHANNELS=64

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,10 +48,12 @@ Changelog
 - [fix] Never let the ``max_alloc_bytes`` estimate in ``composite()`` fall
   below the canvas it guards. The guard is there to reject a hostile file
   *before* it allocates, but it was given the header's channel count alone,
-  which under-counted a duotone document's two-channel canvas by half and an
-  indexed document's palette-expanded canvas by 3x. It is now given the wider
-  of the header count and the canvas width, so no mode under-estimates. This
-  can reject a document that a tight budget previously admitted (#720).
+  which under-counted a duotone document's two-channel canvas by half. It is
+  now given the wider of the header count and the canvas width, so no colour
+  mode under-estimates. This can reject a document that a very tight budget
+  previously admitted. Applies to ``composite()``'s own guard: a document with
+  no layers returns early, before that estimate, and stays covered by the check
+  in ``numpy()`` instead (#720).
 - [api] Widen the ``color`` parameter of ``composite()``, ``composite_pil()``,
   ``Layer.composite()``, ``Group.composite()``, ``Artboard.composite()`` and
   ``PSDImage.composite()`` -- and of ``LayerProtocol`` and ``PSDProtocol`` --

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,20 @@ Changelog
   backdrop was sized from ``EXPECTED_CHANNELS``, which reports 64 channels for
   multichannel documents regardless of how many the file actually carries, so
   the blend raised ``ValueError`` (#708).
+- [fix] Composite a multichannel document that *has* layers. The same
+  ``EXPECTED_CHANNELS`` count of 64 sized the backdrop on the layered path, so
+  the canvas was built 64 channels wide and the first layer met it with an
+  ``AssertionError``. The width now comes from the document header. Note that
+  this fixes the NumPy ``composite()`` entry point; ``PSDImage.composite()``
+  keeps only the first spot channel for multichannel documents, as it already
+  did for layerless ones (#720).
+- [fix] Never let the ``max_alloc_bytes`` estimate in ``composite()`` fall
+  below the canvas it guards. The guard is there to reject a hostile file
+  *before* it allocates, but it was given the header's channel count alone,
+  which under-counted a duotone document's two-channel canvas by half and an
+  indexed document's palette-expanded canvas by 3x. It is now given the wider
+  of the header count and the canvas width, so no mode under-estimates. This
+  can reject a document that a tight budget previously admitted (#720).
 - [api] Widen the ``color`` parameter of ``composite()``, ``composite_pil()``,
   ``Layer.composite()``, ``Group.composite()``, ``Artboard.composite()`` and
   ``PSDImage.composite()`` -- and of ``LayerProtocol`` and ``PSDProtocol`` --

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -255,6 +255,21 @@ option::
     Posterize, Threshold). The compositing result may look different from
     Photoshop.
 
+.. note::
+
+    Color mode caveats when compositing:
+
+    - Duotone and LAB blending is approximated, and warns when used.
+    - Multichannel documents come back as a single-channel image, because PIL
+      has no multichannel mode and only the first spot channel survives the
+      conversion. Use :py:func:`psd_tools.composite.composite` to get every
+      channel as a NumPy array.
+    - Photoshop discards the layer records when it opens a multichannel
+      document and displays the merged image data, so compositing a
+      multichannel document that has layers does not reproduce what Photoshop
+      shows for the same file. Use
+      :py:meth:`~psd_tools.api.psd_image.PSDImage.topil` for the merged data.
+
 Exporting data to NumPy
 -----------------------
 

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -124,6 +124,12 @@ def check_pixel_size(
 
 
 # Mapping of expected number of channels for each color mode.
+#
+# This is not the only such table: :py:meth:`psd_tools.constants.ColorMode.channels`
+# carries a second one, read by ``pil_io._check_channels()`` and
+# ``PSDImage._make_header()``. The two disagree for MULTICHANNEL -- 64 here, 1
+# there -- and neither is any document's real count, which only the file header
+# carries. ``get_color_channels()`` below is the one that asks the header.
 EXPECTED_CHANNELS = {
     ColorMode.BITMAP: 1,
     ColorMode.GRAYSCALE: 1,
@@ -134,6 +140,42 @@ EXPECTED_CHANNELS = {
     ColorMode.DUOTONE: 2,
     ColorMode.LAB: 3,
 }
+
+
+def get_color_channels(psdimage: "PSDProtocol") -> int:
+    """Number of color channels a document's pixel arrays carry.
+
+    :data:`EXPECTED_CHANNELS` names a constant per color mode, which is the
+    right answer for every mode whose channel count the mode itself fixes.
+    Multichannel is the exception: its entry is 64, the *format's maximum*
+    number of channels rather than any document's actual count, so a
+    multichannel document is the only one that has to be asked how many
+    channels it carries.
+
+    Leaving that 64 in place is deliberate. The one reader for which it is live
+    on a multichannel document is the defensive cap in
+    ``numpy_io._find_channel()``, where a layer record may declare more channels
+    than the header does; 64 never truncates there, which is what keeps a real
+    mismatch visible to the compositor instead of quietly trimmed. The
+    ``psdimage.channels > expected`` thresholds in :func:`has_transparency` and
+    :func:`get_transparency_index` are inert for the mode either way, since
+    ``FileHeader.channels`` is validated to at most 56, and
+    :func:`~psd_tools.api.numpy_io.get_image_data` special-cases multichannel
+    before it reaches the table at all.
+
+    So this is for the callers the constant cannot serve: the ones that must
+    *allocate* a canvas as wide as the document's own arrays.
+
+    Args:
+        psdimage: The PSD image protocol object
+    Returns:
+        The number of channels the color array carries, excluding transparency.
+        For a multichannel document these are spot channels rather than color
+        components in any colorimetric sense.
+    """
+    if psdimage.color_mode == ColorMode.MULTICHANNEL:
+        return psdimage.channels
+    return EXPECTED_CHANNELS[psdimage.color_mode]
 
 
 def has_transparency(psdimage: "PSDProtocol") -> bool:

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -152,16 +152,21 @@ def get_color_channels(psdimage: "PSDProtocol") -> int:
     multichannel document is the only one that has to be asked how many
     channels it carries.
 
-    Leaving that 64 in place is deliberate. The one reader for which it is live
-    on a multichannel document is the defensive cap in
-    ``numpy_io._find_channel()``, where a layer record may declare more channels
-    than the header does; 64 never truncates there, which is what keeps a real
-    mismatch visible to the compositor instead of quietly trimmed. The
-    ``psdimage.channels > expected`` thresholds in :func:`has_transparency` and
-    :func:`get_transparency_index` are inert for the mode either way, since
-    ``FileHeader.channels`` is validated to at most 56, and
+    Leaving that 64 in place is deliberate, though not harmless. The reader that
+    genuinely wants it is the defensive cap in ``numpy_io._find_channel()``,
+    where a layer record may declare more channels than the header does; 64
+    never truncates there, which is what keeps a real mismatch visible to the
+    compositor instead of quietly trimmed. Two more are inert rather than
+    correct -- the ``psdimage.channels > expected`` thresholds in
+    :func:`has_transparency` and :func:`get_transparency_index` can never fire,
+    because ``FileHeader.channels`` is validated to at most 56, and
     :func:`~psd_tools.api.numpy_io.get_image_data` special-cases multichannel
-    before it reaches the table at all.
+    before it reaches the table at all. And one is simply wrong:
+    ``_validate_color_input()`` requires a sequence of exactly 64 components, so
+    assigning a sequence to :py:attr:`PSDImage.background_color` on a
+    multichannel document raises. That is a separate bug, filed rather than
+    fixed here -- it takes a bare ``ColorMode`` where this takes a document, and
+    so cannot reach the header at all.
 
     So this is for the callers the constant cannot serve: the ones that must
     *allocate* a canvas as wide as the document's own arrays.
@@ -169,9 +174,12 @@ def get_color_channels(psdimage: "PSDProtocol") -> int:
     Args:
         psdimage: The PSD image protocol object
     Returns:
-        The number of channels the color array carries, excluding transparency.
-        For a multichannel document these are spot channels rather than color
-        components in any colorimetric sense.
+        The width of the document's color array. For every mode but multichannel
+        that is the mode's own color components, with any alpha excluded; for
+        multichannel it is the header's count, whose channels are spot channels.
+        Layer arrays drop their transparency channel and so can be narrower than
+        this in a malformed file -- deliberately, so that the compositor's width
+        assertion still sees the mismatch.
     """
     if psdimage.color_mode == ColorMode.MULTICHANNEL:
         return psdimage.channels

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -131,6 +131,9 @@ def composite_pil(
         - Requires optional composite dependencies (aggdraw, scipy, scikit-image)
         - LAB and Duotone color modes have limited blending support
         - Alpha channel handling varies by color mode
+        - Multichannel documents come back single-channel. PIL has no
+          multichannel mode, so only the first spot channel survives; use
+          :py:func:`psd_tools.composite.composite` to keep every channel.
     """
     UNSUPPORTED_MODES = {
         ColorMode.DUOTONE,
@@ -232,6 +235,13 @@ def composite(
           for vector shape rendering, gradient fills, and layer effects.
         - Adjustment layers have limited support.
         - Text rendering is not supported (text layers show as raster if available).
+        - Multichannel documents are composited over every spot channel the
+          file declares. That is more than Photoshop does: Photoshop discards
+          the layer records when it opens a multichannel document and displays
+          the merged image data instead, so a multichannel document that has
+          layers does not render here the way it looks there. Use
+          :py:meth:`~psd_tools.api.psd_image.PSDImage.topil` for the merged
+          data.
     """
     if viewport is None:
         if isinstance(group, PSDImage):

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -12,7 +12,7 @@ from psd_tools.api import pil_io
 from psd_tools.api.layers import AdjustmentLayer, GroupMixin, Layer
 from psd_tools.api.protocols import LayerProtocol, PSDProtocol
 from psd_tools.api.psd_image import PSDImage
-from psd_tools.api.utils import EXPECTED_CHANNELS, check_pixel_size
+from psd_tools.api.utils import check_pixel_size, get_color_channels
 from psd_tools.composite import paint, utils, vector
 from psd_tools.composite.adjustments import ADJUSTMENT_FUNC
 from psd_tools.composite.blend import BLEND_FUNC, normal
@@ -270,10 +270,28 @@ def composite(
     _w = viewport[2] - viewport[0]
     _h = viewport[3] - viewport[1]
     _psd = group if isinstance(group, PSDImage) else group._psd
+    # The width the backdrop canvas is allocated at, read from the document
+    # rather than from its color mode: EXPECTED_CHANNELS reports 64 for a
+    # multichannel document -- the format's maximum, not any file's own count --
+    # so the canvas came out ~21x too wide and the first layer met a canvas it
+    # could not be blended against.
+    _channels = get_color_channels(_psd) if _psd is not None else None
+    # The guard is there to reject a file *before* it allocates, so its estimate
+    # must never fall below what follows it. The wider of the two counts is that
+    # bound: `_channels` is the backdrop, and the header's own count covers the
+    # per-layer arrays read alongside it. Either can be the larger -- the header
+    # wherever a document carries alpha or spot channels beyond its color
+    # channels, `_channels` wherever a mode expands (indexed through its
+    # palette, duotone into two).
+    _estimate = (
+        max(_psd.channels, _channels)
+        if _psd is not None and _channels is not None
+        else 1
+    )
     check_pixel_size(
         _w,
         _h,
-        _psd.channels if _psd is not None else 1,
+        _estimate,
         max_alloc_bytes=_psd._max_alloc_bytes if _psd is not None else None,
     )
 
@@ -291,7 +309,7 @@ def composite(
         0.0 if isolated else alpha,
         _h,
         _w,
-        EXPECTED_CHANNELS[_psd.color_mode] if _psd is not None else None,
+        _channels,
     )
 
     layer_filter = layer_filter or Layer.is_visible
@@ -495,9 +513,10 @@ def _normalize_backdrop(
     not an allocation-avoidance path. (``_get_mask``/``_get_const`` keep their
     scalars for that reason instead.)
 
-    ``channels`` is the document's channel count, or None to infer it from
-    ``color`` where no document is available to name a color mode -- the same
-    defensive fallback ``check_pixel_size()`` is given in ``composite()``.
+    ``channels`` is the width of the canvas to build -- the document's own
+    color channel count, per ``get_color_channels()`` -- or None to infer it
+    from ``color`` where no document is available to ask, the same defensive
+    fallback ``check_pixel_size()`` is given in ``composite()``.
     """
     if channels is None:
         channels = 1 if np.ndim(color) == 0 else int(np.shape(color)[-1])

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -277,12 +277,14 @@ def composite(
     # could not be blended against.
     _channels = get_color_channels(_psd) if _psd is not None else None
     # The guard is there to reject a file *before* it allocates, so its estimate
-    # must never fall below what follows it. The wider of the two counts is that
-    # bound: `_channels` is the backdrop, and the header's own count covers the
-    # per-layer arrays read alongside it. Either can be the larger -- the header
-    # wherever a document carries alpha or spot channels beyond its color
-    # channels, `_channels` wherever a mode expands (indexed through its
-    # palette, duotone into two).
+    # must never fall below what follows it. `_channels` is the backdrop, and
+    # taking the wider of it and the header's own count keeps the modes that
+    # expand covered too -- indexed through its palette, duotone into two --
+    # without loosening the ones whose header count is the larger of the pair.
+    # It bounds the canvas, not everything downstream: per-layer arrays are read
+    # with no guard of their own, and a layer record's channel count is an
+    # unvalidated uint16, so a malformed file can still allocate past this
+    # before `_assert_source_fits` fires.
     _estimate = (
         max(_psd.channels, _channels)
         if _psd is not None and _channels is not None

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -8,7 +8,7 @@ from psd_tools.api.layers import AdjustmentLayer, GroupMixin, Layer, PixelLayer
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.composite import composite
 from psd_tools.composite.composite import Compositor
-from psd_tools.constants import BlendMode, CompatibilityMode, Tag
+from psd_tools.constants import BlendMode, ColorMode, CompatibilityMode, Tag
 from psd_tools.psd.base import ByteElement
 from PIL import Image
 
@@ -450,6 +450,101 @@ def test_composite_layerless_multichannel_over_a_backdrop() -> None:
     assert len(psd) == 0
     color, _, _ = composite(psd, color=1.0, alpha=1.0)
     assert color.shape == (psd.height, psd.width, psd.numpy("color").shape[2])
+
+
+def _layered_multichannel(**kwargs: Any) -> PSDImage:
+    """A multichannel document *with* layers, which no fixture provides.
+
+    Photoshop flattens on conversion to Multichannel, so this shape only comes
+    from a hand-built file -- which is exactly the input the allocation guard
+    exists for. Retagging the RGB fixture's color mode in place is the whole of
+    it: that fixture's three document channels and its layers' three color
+    channels already agree, as they would in a multichannel file with three
+    spot channels, so nothing else about the document has to change.
+
+    Built this way rather than with ``PSDImage.new`` + ``PixelLayer.frompil``
+    on purpose. ``frompil`` converts to the document's ``pil_mode``, which is
+    ``"LA"`` for a three-channel multichannel document, so the layer would
+    carry a single color channel against a header declaring three -- and a
+    one-channel source broadcasts, so the test would pass without ever
+    exercising the canvas width it is about.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"), **kwargs)
+    psd._record.header.color_mode = ColorMode.MULTICHANNEL
+    return psd
+
+
+def test_composite_layered_multichannel_uses_the_header_channel_count() -> None:
+    """A multichannel backdrop is as wide as the document says it is (#720).
+
+    ``EXPECTED_CHANNELS[MULTICHANNEL]`` is 64 -- the format's maximum, not any
+    document's count -- so the backdrop was allocated 64 channels wide and the
+    first three-channel layer met it with an ``AssertionError``. The zero-layer
+    path was fixed in #708 by sizing from the document's own array; the layered
+    path has no such array to consult, so it asks the header instead.
+    """
+    psd = _layered_multichannel()
+    assert psd.channels == 3
+    assert len(psd) > 0
+    color, _, _ = composite(psd)
+    assert color.shape == (psd.height, psd.width, psd.channels)
+    # Its one layer carrying pixel data covers the whole canvas opaquely, so
+    # the composite reproduces the document's own merged preview.
+    assert _mse(color, psd.numpy("color")) <= 1e-6
+
+
+def test_composite_layered_multichannel_within_a_budget() -> None:
+    """A budget that admits the real canvas is no longer overrun (#720).
+
+    The three-channel canvas needs 192 bytes where the 64-channel one needed
+    4096, so this budget sits between the two. It is not the guard that used to
+    reject the document -- the guard was told 3 all along -- it is the canvas
+    that used to be built ~21x wider than the guard was promised.
+    """
+    psd = _layered_multichannel(max_alloc_bytes=1024)
+    color, _, _ = composite(psd)
+    assert color.shape == (psd.height, psd.width, 3)
+
+
+def test_composite_guard_estimate_covers_a_mode_that_expands() -> None:
+    """The estimate never falls below the canvas that follows it (#720).
+
+    ``max_alloc_bytes`` is there to reject a file *before* it allocates, so the
+    number it is checked against has to bound what comes next. A duotone
+    document stores one channel and composites over two, so its header count
+    alone under-estimated the canvas by half; the guard is now given the wider
+    of the two counts.
+    """
+    psd = PSDImage.open(
+        full_name("colormodes/4x4_8bit_duotone.psd"), max_alloc_bytes=100
+    )
+    assert psd.channels == 1
+    # 4 * 4 * 2 * 4 = 128 bytes, over the budget; the header's own count would
+    # have estimated 64 and let it through.
+    with pytest.raises(ValueError, match="4x4x2"):
+        composite(psd)
+
+
+def test_composite_pil_layered_multichannel_truncates_like_the_layerless_one() -> None:
+    """Pinning what the PIL exit does now that this shape reaches it (#720).
+
+    ``get_pil_mode(MULTICHANNEL)`` is ``"L"``, so ``composite_pil()`` keeps the
+    first spot channel and drops the rest. That is not new -- it is what the
+    layerless fixture already does in ``test_composite_pil``, and a layered
+    document now lands on exactly the same two modes instead of raising. Pinned
+    here so the truncation is a recorded consequence of letting these documents
+    composite at all. Only the numpy ``composite()`` entry point returns every
+    channel.
+    """
+    psd = _layered_multichannel()
+    preview = psd.composite(apply_icc=False)
+    assert isinstance(preview, Image.Image)
+    assert preview.mode == "L"  # served from the stored preview, uncomposited
+    image = psd.composite(ignore_preview=True, apply_icc=False)
+    assert isinstance(image, Image.Image)
+    assert image.mode == "LA"  # first spot channel, plus the composite alpha
+    color, _, _ = composite(psd)
+    assert _mse(np.asarray(image)[:, :, 0] / 255.0, color[:, :, 0]) <= 1e-4
 
 
 def test_composite_layer_filter() -> None:

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -519,8 +519,8 @@ def test_composite_guard_estimate_covers_a_mode_that_expands() -> None:
         full_name("colormodes/4x4_8bit_duotone.psd"), max_alloc_bytes=100
     )
     assert psd.channels == 1
-    # 4 * 4 * 2 * 4 = 128 bytes, over the budget; the header's own count would
-    # have estimated 64 and let it through.
+    # 4 * 4 * 2 * 4 = 128 bytes, over the budget; the header's own count of one
+    # channel would have estimated 64 bytes and let it through.
     with pytest.raises(ValueError, match="4x4x2"):
         composite(psd)
 

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -455,9 +455,18 @@ def test_composite_layerless_multichannel_over_a_backdrop() -> None:
 def _layered_multichannel(**kwargs: Any) -> PSDImage:
     """A multichannel document *with* layers, which no fixture provides.
 
-    Photoshop flattens on conversion to Multichannel, so this shape only comes
-    from a hand-built file -- which is exactly the input the allocation guard
-    exists for. Retagging the RGB fixture's color mode in place is the whole of
+    Photoshop neither produces nor preserves this shape: converting to
+    Multichannel flattens, and *opening* a hand-built layered multichannel file
+    discards the layer records outright. Verified against Photoshop 2026, which
+    reduced a 13-layer retagged document to a single Background layer whose
+    three channels it presents as spot channels ("Alpha 1".."Alpha 3") holding
+    the file's merged image data bit-for-bit. So a document of this shape is
+    only ever hand-built -- which is exactly the input the allocation guard
+    exists for -- and there is no Photoshop render to check a layered
+    multichannel composite against, because Photoshop declines to composite
+    one.
+
+    Retagging the RGB fixture's color mode in place is the whole of
     it: that fixture's three document channels and its layers' three color
     channels already agree, as they would in a multichannel file with three
     spot channels, so nothing else about the document has to change.


### PR DESCRIPTION
Closes #720.

## The bug

`EXPECTED_CHANNELS[ColorMode.MULTICHANNEL]` is 64 — the format's *maximum*
number of channels, not any document's actual count. `composite()` used it for
two things, and both were wrong for a multichannel document.

**The backdrop was allocated 64 channels wide.** The first layer, carrying the
document's real channel count, then met it:

```
AssertionError: source has 3 channels, expected 1 or 64
```

The layerless path was fixed in #708 by sizing from the document's own array.
The layered path has no such array at that point, so it kept using the color
mode.

**`check_pixel_size` was told a number it did not allocate.** It got
`_psd.channels`, while the very next statement allocated
`EXPECTED_CHANNELS[...]` — up to ~21x more for multichannel. That guard exists
to reject a hostile file *before* it allocates, so an estimate that does not
bound the allocation is the one thing it must not be.

## The fix

New `get_color_channels()` in `api/utils.py`: the header's channel count for
`MULTICHANNEL`, `EXPECTED_CHANNELS[mode]` for everything else. `composite()`
sizes the backdrop from it, and gives `check_pixel_size` the wider of it and
the header count.

`EXPECTED_CHANNELS[MULTICHANNEL] = 64` stays, but for a narrower reason than I
first wrote down. Of its seven readers, exactly one *wants* the 64 for a
multichannel document: the defensive cap in `numpy_io._find_channel()`
(`numpy_io.py:98`), where a layer record may declare more channels than the
header. 64 never truncates there, which is what keeps a genuine mismatch visible
to `_assert_source_fits` instead of quietly trimmed.

Two others are inert rather than correct — `get_image_data()` special-cases
multichannel *before* the truncation (`numpy_io.py:69`), and the
`psdimage.channels > expected` thresholds in `has_transparency()` /
`get_transparency_index()` can never fire when `expected == 64`, because
`FileHeader.channels` is validated to at most 56 (`psd/header.py:68`).

And one is simply wrong. `_validate_color_input()` (`utils.py:269`) requires a
sequence of exactly `EXPECTED_CHANNELS[mode]` components, so on a multichannel
document:

```python
psd.background_color = (0.1, 0.2, 0.3)
# ValueError: Expected 64 color channel(s) for MULTICHANNEL, got 3.
```

That is a live bug on a three-channel document, reachable through a public
setter. It is *not* fixed here — it takes a bare `ColorMode` where the new
helper takes a document, so it cannot reach the header at all — but it is named
in the helper's docstring rather than left implied by a "only one reader is
live" claim that would have been false.

Both tables that answer "how many channels does this mode have" are now
cross-referenced at the `EXPECTED_CHANNELS` definition: `ColorMode.channels()`
(`constants.py:63`) says **1** for MULTICHANNEL where this one says **64**, and
neither is the header's count. Without the note the next reader fixes one and
inherits the other.

### Why `max()` for the guard

Passing the resolved canvas width *alone* would have loosened the guard for any
document whose header count includes alpha — RGBA goes 4 → 3, a 25% relaxation
of a control added for GHSA-8q6g-vjhf-jp8m — and #720 gains nothing from it,
since for multichannel the header count and the canvas width are the same
number once the backdrop is fixed. `max()` is the only option that is never an
undercount:

- `_channels` bounds the backdrop.
- `_psd.channels` bounds the per-layer arrays read alongside it.

Either can be the larger. It bounds the canvas, not everything downstream:
`get_layer_data()` has no guard of its own and a layer record's channel count is
an unvalidated `uint16`, so a malformed file can still allocate past the
estimate before `_assert_source_fits` fires. The comment says so rather than
claiming coverage it does not have.

This *tightens* duotone, which stores one channel against a two-channel canvas,
and loosens nothing. A document that a very tight budget previously admitted can
now be rejected; noted in the changelog.

Scope worth being precise about: this is `composite()`'s own guard, on the path
that has layers. A document with **no** layers returns early, before the
estimate, and stays covered by `numpy()`'s check — which still passes
`psdimage.channels`. So a *layered* indexed document is now estimated at its
palette-expanded three channels, while the flattened indexed document Photoshop
actually writes is untouched. The changelog says this; an earlier draft claimed
the indexed case outright and was wrong.

## Tests

No fixture exercises a multichannel document *with* layers — Photoshop flattens
on conversion to Multichannel, so this shape only arises from a hand-built file,
which is exactly the input the allocation guard exists for.

Rather than commit a synthetic binary, the helper retags the color mode of
`colormodes/4x4_8bit_rgb.psd` **in place**, with no `save()`/reopen: that
fixture's three document channels and its layers' three color channels already
agree, so the one line that makes the document unusual is visible in the test.
Two reasons for building it that way:

- `PSDImage.new` + `PixelLayer.frompil` would not work — `frompil` converts to
  the document's `pil_mode`, which is `"LA"` for a three-channel multichannel
  document, so the layer would carry one color channel against a header
  declaring three. A one-channel source broadcasts, so the test would pass
  without ever exercising the canvas width it is about.
- A `save()` round-trip is safe today only because `save()` guards its preview
  rebuild with `is_updated()`, and assigning straight to `_record.header` never
  sets that flag. One `_mark_updated()` away, `save()` would recomposite
  through the 1-channel PIL exit and hand `ImageData.set_data` two planes where
  the header declares three, silently truncating the merged preview. Dropping
  the round-trip removes the trap rather than asserting around it.

Four tests, all failing on `main`:

- `..._uses_the_header_channel_count` — the result is `(h, w, psd.channels)`
  and reproduces the document's own merged preview (MSE ≤ 1e-6).
- `..._within_a_budget` — a budget between the 3-channel canvas (192 bytes) and
  the old 64-channel one (4096) no longer gets overrun.
- `test_composite_guard_estimate_covers_a_mode_that_expands` — duotone, where
  the header's count alone estimated 64 bytes against a 128-byte canvas. This
  is the case that actually discriminates the guard; the multichannel one
  cannot, because there the guard was already being told 3.
- `test_composite_pil_layered_multichannel_truncates_like_the_layerless_one` —
  see below.

## What this does *not* fix

`get_pil_mode(MULTICHANNEL)` is `"L"`, so `composite_pil()` keeps the first spot
channel and drops the rest. A layered multichannel document now lands on exactly
the same two PIL modes as the layerless fixture already does in
`test_composite_pil` (`"L"` from the stored preview, `"LA"` composited) instead
of raising. That truncation is pinned in a test so it is a recorded consequence
rather than something discovered later, and the changelog scopes the fix to the
NumPy `composite()` entry point. Only that entry point returns every channel.

## Verification

- Full suite: 1742 passed, 27 xfailed, 2 xpassed. `ruff check`,
  `ruff format --check` and `mypy` clean; pre-commit hooks pass.
- Rendered every fixture under `tests/psd_files` at `force=False` and
  `force=True` (285 files, 570 renders) and hashed the `color`/`shape`/`alpha`
  arrays bitwise: **identical** before and after, no errors either side.

## Follow-ups worth filing separately

Found while tracing this, all pre-existing and none of them #720:

- `composite_pil()` with `force=True` on a multichannel document concatenates
  alpha onto the color array and hands the result to `Image.fromarray` as mode
  `"LA"` — a width mismatch PIL does not reject, so the image comes back
  garbled, matching neither spot channel. Already reachable on the existing
  layerless fixture; `test_composite_pil` asserts only `image.mode`, so it
  passes over the corrupt pixels.
- `_validate_color_input()` demands `EXPECTED_CHANNELS[mode]` components, so
  assigning a sequence to `background_color` on a multichannel document raises
  "Expected 64 color channel(s)" — and `background_color` is what `save()`
  composites against.
- `numpy()`'s own allocation guard (`numpy_io.py:41`) still passes
  `psdimage.channels`, so it under-counts an indexed document's
  palette-expanded canvas by 3x. Needs `max()` there too, not a bare swap:
  grayscale-with-alpha stores two planes and truncates to one.
- `ColorMode.MULTICHANNEL` is absent from `composite_pil`'s `UNSUPPORTED_MODES`,
  so dropping every spot channel but the first happens with no log line at all,
  where DUOTONE and LAB each get a warning.
- `paint.draw_solid_color_fill()` / `draw_gradient_fill()` take the fill width
  from the descriptor class (1/3/4) rather than from the document, so a fill or
  stroke effect in a multichannel document whose spot count differs from the
  descriptor's width trips `_assert_source_fits` — and an HSB descriptor raises
  `ValueError("Unexpected color mode for HSB color ...")` outright
  (`paint.py:85`). The fixtures happen to agree, so nothing fails today.
- `paint.draw_pattern_fill()` keys `EXPECTED_CHANNELS` on `pattern.image_mode`,
  so a multichannel-mode *pattern* gets the 64 and never splits its alpha out of
  the color array, then trips the `Inconsistent pattern channels.` assertion.
- `EXPECTED_CHANNELS[DUOTONE] = 2` while duotone pixel data is one channel, so
  `composite()` on the duotone fixture returns a two-channel array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
