### PR TITLE
fix: duotone stores one channel, not two

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,12 +48,32 @@ Changelog
 - [fix] Never let the ``max_alloc_bytes`` estimate in ``composite()`` fall
   below the canvas it guards. The guard is there to reject a hostile file
   *before* it allocates, but it was given the header's channel count alone,
-  which under-counted a duotone document's two-channel canvas by half. It is
-  now given the wider of the header count and the canvas width, so no colour
-  mode under-estimates. This can reject a document that a very tight budget
-  previously admitted. Applies to ``composite()``'s own guard: a document with
-  no layers returns early, before that estimate, and stays covered by the check
-  in ``numpy()`` instead (#720).
+  which under-counted an indexed document's canvas by 3x -- its single stored
+  channel becomes three through the palette. It is now given the wider of the
+  header count and the canvas width, so no colour mode under-estimates. This
+  can reject a document that a very tight budget previously admitted. Applies
+  to ``composite()``'s own guard: a document with no layers returns early,
+  before that estimate, and stays covered by the check in ``numpy()`` instead
+  (#720).
+- [fix] Composite duotone documents at their stored width.
+  ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
+  pixel data is a single grayscale channel, the one to four ink curves living
+  in the colour mode data section. Three consequences, all fixed:
+  ``composite()`` returned a two-channel array whose second channel was not
+  data from the file but the backdrop copied; ``PSDImage.composite(force=True)``
+  returned *wrong pixels*, because the over-wide array was handed to PIL as
+  ``"LA"`` and the planes came out shifted against each other; and the
+  ``ColorDodge``, ``ColorBurn`` and ``VividLight`` blend modes raised
+  ``IndexError`` on any duotone document (#733).
+- [api] ``PSDImage.new("DUOTONE", ...)`` now accepts a colour. It previously
+  rejected every sequence: the constructor demanded two components while the
+  header it built declared one channel, so no value satisfied both (#733).
+
+  **Backwards incompatible**: a per-channel ``background_color`` on a duotone
+  document now takes one component instead of two.
+  ``psd.background_color = (0.5, 0.5)`` raises ``ValueError``; pass ``(0.5,)``
+  or a scalar. The second component was inert -- it had no channel to be
+  written to, and the saved bytes are identical without it (#733).
 - [api] Widen the ``color`` parameter of ``composite()``, ``composite_pil()``,
   ``Layer.composite()``, ``Group.composite()``, ``Artboard.composite()`` and
   ``PSDImage.composite()`` -- and of ``LayerProtocol`` and ``PSDProtocol`` --

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,9 +52,10 @@ Changelog
   channel becomes three through the palette. It is now given the wider of the
   header count and the canvas width, so no colour mode under-estimates. This
   can reject a document that a very tight budget previously admitted. Applies
-  to ``composite()``'s own guard: a document with no layers returns early,
-  before that estimate, and stays covered by the check in ``numpy()`` instead
-  (#720).
+  to ``composite()``'s own guard only: a document with no layers returns early,
+  before that estimate, and falls to the check in ``numpy()``, which is still
+  header-based and so still under-counts an indexed canvas -- tracked
+  separately in #732 (#720).
 - [fix] Composite duotone documents at their stored width.
   ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
   pixel data is a single grayscale channel, the one to four ink curves living
@@ -62,9 +63,19 @@ Changelog
   ``composite()`` returned a two-channel array whose second channel was not
   data from the file but the backdrop copied; ``PSDImage.composite(force=True)``
   returned *wrong pixels*, because the over-wide array was handed to PIL as
-  ``"LA"`` and the planes came out shifted against each other; and the
-  ``ColorDodge``, ``ColorBurn`` and ``VividLight`` blend modes raised
-  ``IndexError`` on any duotone document (#733).
+  ``"LA"`` and the planes came out shifted against each other; and seven blend
+  modes -- ``ColorBurn``, ``ColorDodge``, ``HardLight``, ``LinearLight``,
+  ``PinLight``, ``SoftLight`` and ``VividLight`` -- raised ``IndexError`` on any
+  duotone document. Photoshop keeps layers in duotone mode, so every one of
+  these was reachable on ordinary files. ``Hue``, ``Saturation``, ``Color`` and
+  ``Luminosity`` still raise, identically to how they do on a grayscale
+  document; that is a separate single-channel issue (#733).
+- [fix] Read the alpha channel of a duotone document as alpha. Because the
+  colour array was taken to be two channels wide, a duotone file carrying a
+  transparency channel returned it as *colour* data from ``numpy("color")``,
+  and ``has_transparency()`` reported ``False`` -- while ``pil_mode`` said
+  ``"LA"``, so the document contradicted itself. No fixture has this shape
+  (#733).
 - [api] ``PSDImage.new("DUOTONE", ...)`` now accepts a colour. It previously
   rejected every sequence: the constructor demanded two components while the
   header it built declared one channel, so no value satisfied both (#733).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -67,9 +67,12 @@ Changelog
   modes -- ``ColorBurn``, ``ColorDodge``, ``HardLight``, ``LinearLight``,
   ``PinLight``, ``SoftLight`` and ``VividLight`` -- raised ``IndexError`` on any
   duotone document. Photoshop keeps layers in duotone mode, so every one of
-  these was reachable on ordinary files. ``Hue``, ``Saturation``, ``Color`` and
-  ``Luminosity`` still raise, identically to how they do on a grayscale
-  document; that is a separate single-channel issue (#733).
+  these was reachable on ordinary files (#733).
+
+  ``Hue``, ``Saturation``, ``Color`` and ``Luminosity`` still raise on a duotone
+  document. They raise identically on a grayscale one, so that is a pre-existing
+  limitation of single-channel documents rather than anything this entry
+  changes.
 - [fix] Read the alpha channel of a duotone document as alpha. Because the
   colour array was taken to be two channels wide, a duotone file carrying a
   transparency channel returned it as *colour* data from ``numpy("color")``,

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -127,9 +127,11 @@ def check_pixel_size(
 #
 # This is not the only such table: :py:meth:`psd_tools.constants.ColorMode.channels`
 # carries a second one, read by ``pil_io._check_channels()`` and
-# ``PSDImage._make_header()``. The two disagree for MULTICHANNEL -- 64 here, 1
-# there -- and neither is any document's real count, which only the file header
-# carries. ``get_color_channels()`` below is the one that asks the header.
+# ``PSDImage._make_header()``. The two still disagree for MULTICHANNEL -- 64
+# here, 1 there -- where neither is any document's real count, which only the
+# file header carries, and for INDEXED -- 3 here, 1 there -- where each is right
+# about a different thing, one stored channel expanding to three through the
+# palette. ``get_color_channels()`` below is the one that asks the header.
 EXPECTED_CHANNELS = {
     ColorMode.BITMAP: 1,
     ColorMode.GRAYSCALE: 1,
@@ -137,7 +139,10 @@ EXPECTED_CHANNELS = {
     ColorMode.RGB: 3,
     ColorMode.CMYK: 4,
     ColorMode.MULTICHANNEL: 64,
-    ColorMode.DUOTONE: 2,
+    # Duotone stores a single grayscale channel; its one to four inks live in
+    # the color mode data section, not in the image data, so no ink count is a
+    # channel count. This read 2 until #733.
+    ColorMode.DUOTONE: 1,
     ColorMode.LAB: 3,
 }
 

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -289,8 +289,9 @@ def composite(
     # The guard is there to reject a file *before* it allocates, so its estimate
     # must never fall below what follows it. `_channels` is the backdrop, and
     # taking the wider of it and the header's own count keeps the modes that
-    # expand covered too -- indexed through its palette, duotone into two --
-    # without loosening the ones whose header count is the larger of the pair.
+    # expand covered too -- indexed, whose single stored channel becomes three
+    # through its palette -- without loosening the ones whose header count is
+    # the larger of the pair.
     # It bounds the canvas, not everything downstream: per-layer arrays are read
     # with no guard of their own, and a layer record's channel count is an
     # unvalidated uint16, so a malformed file can still allocate past this

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -352,6 +352,13 @@ def test_background_color_setter_invalid_channel_count() -> None:
     with pytest.raises(ValueError, match="Expected 1 color channel"):
         gray.background_color = (0.5, 0.5)
 
+    # Duotone stores one grayscale channel, so it expects 1 like grayscale --
+    # not one per ink. This took a 2-tuple until #733, and the second component
+    # had no channel to be written to.
+    duotone = PSDImage.new("DUOTONE", (16, 16))
+    with pytest.raises(ValueError, match="Expected 1 color channel"):
+        duotone.background_color = (0.5, 0.5)
+
     # Scalar input is always valid regardless of color mode
     rgb.background_color = 1.0
     assert rgb.background_color == 1.0
@@ -363,6 +370,8 @@ def test_background_color_setter_invalid_channel_count() -> None:
     assert cmyk.background_color == (0.0, 0.0, 0.0, 0.0)
     gray.background_color = (0.5,)
     assert gray.background_color == (0.5,)
+    duotone.background_color = (0.5,)
+    assert duotone.background_color == (0.5,)
 
 
 def test_new_with_float_color() -> None:

--- a/tests/psd_tools/api/test_utils.py
+++ b/tests/psd_tools/api/test_utils.py
@@ -45,7 +45,10 @@ def test_get_color_channels_reads_the_header_only_for_multichannel() -> None:
     """Every other mode's count is fixed by the mode itself.
 
     Multichannel is the exception because ``EXPECTED_CHANNELS`` reports 64 for
-    it -- the format's maximum rather than any file's own count (#720).
+    it -- the format's maximum rather than any file's own count (#720). The
+    "only" half of that is carried by the parametrized cases above: the ``rgba``
+    row has a header count of 4 and resolves to 3, so a non-multichannel
+    document demonstrably ignores its header.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
     assert EXPECTED_CHANNELS[ColorMode.MULTICHANNEL] == 64

--- a/tests/psd_tools/api/test_utils.py
+++ b/tests/psd_tools/api/test_utils.py
@@ -1,0 +1,56 @@
+import pytest
+
+from psd_tools.api.psd_image import PSDImage
+from psd_tools.api.utils import EXPECTED_CHANNELS, get_color_channels
+from psd_tools.constants import ColorMode
+
+from ..utils import full_name
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("colormodes/4x4_1bit_bitmap.psd", 1),
+        ("colormodes/4x4_8bit_grayscale.psd", 1),
+        ("colormodes/4x4_8bit_rgb.psd", 3),
+        ("colormodes/4x4_8bit_rgba.psd", 3),  # the extra channel is alpha
+        ("colormodes/4x4_8bit_cmyk.psd", 4),
+        ("colormodes/4x4_8bit_lab.psd", 3),
+        ("colormodes/4x4_8bit_duotone.psd", 1),  # one stored channel, not two inks
+        ("colormodes/4x4_8bit_index_color.psd", 3),  # one channel, palette-expanded
+        ("colormodes/4x4_16bit_multichannel.psd", 3),  # whatever the header says
+    ],
+)
+def test_get_color_channels(filename: str, expected: int) -> None:
+    psd = PSDImage.open(full_name(filename))
+    assert get_color_channels(psd) == expected
+
+
+def test_get_color_channels_can_differ_from_the_header_either_way() -> None:
+    """The header's count is neither an upper nor a lower bound on the canvas.
+
+    This is why ``composite()`` guards its allocation with the wider of the two
+    rather than either one alone -- see
+    ``test_composite_guard_estimate_covers_a_mode_that_expands`` and
+    ``..._takes_the_header_when_it_is_wider``.
+    """
+    narrower = PSDImage.open(full_name("colormodes/4x4_8bit_index_color.psd"))
+    assert narrower.channels == 1 < get_color_channels(narrower) == 3
+
+    wider = PSDImage.open(full_name("colormodes/4x4_8bit_rgba.psd"))
+    assert wider.channels == 4 > get_color_channels(wider) == 3
+
+
+def test_get_color_channels_reads_the_header_only_for_multichannel() -> None:
+    """Every other mode's count is fixed by the mode itself.
+
+    Multichannel is the exception because ``EXPECTED_CHANNELS`` reports 64 for
+    it -- the format's maximum rather than any file's own count (#720).
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
+    assert EXPECTED_CHANNELS[ColorMode.MULTICHANNEL] == 64
+    assert get_color_channels(psd) == psd.channels == 3
+
+    # A retagged document follows its header rather than the table.
+    psd._record.header.channels = 5
+    assert get_color_channels(psd) == 5

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -576,17 +576,35 @@ def test_composite_duotone_is_one_channel_wide() -> None:
 
 @pytest.mark.parametrize(
     "blend_mode",
-    [BlendMode.COLOR_DODGE, BlendMode.COLOR_BURN, BlendMode.VIVID_LIGHT],
+    [
+        BlendMode.COLOR_BURN,
+        BlendMode.COLOR_DODGE,
+        BlendMode.HARD_LIGHT,
+        BlendMode.LINEAR_LIGHT,
+        BlendMode.PIN_LIGHT,
+        BlendMode.SOFT_LIGHT,
+        BlendMode.VIVID_LIGHT,
+    ],
 )
 def test_composite_duotone_with_a_channelwise_blend_mode(blend_mode: BlendMode) -> None:
     """These blend modes crashed on every duotone document (#733).
 
-    They index the color array with a mask derived from it
-    (``blend.py``'s ``B[Cs == 1] = 1``), which needs the operands to agree in
+    They index the color array with a mask derived from it -- ``blend.py``'s
+    ``B[Cs == 1] = 1`` and friends -- which needs the operands to agree in
     width. A two-channel canvas against a one-channel source did not::
 
         IndexError: boolean index did not match indexed array along axis 2;
         size of axis is 2 but size of corresponding boolean axis is 1
+
+    All seven of the blend modes listed here raised it. Photoshop keeps layers
+    in duotone mode, so this was reachable on ordinary documents rather than
+    only on hand-built ones.
+
+    ``Hue``, ``Saturation``, ``Color`` and ``Luminosity`` still raise, and are
+    deliberately not listed: they fail identically on
+    ``colormodes/4x4_8bit_grayscale.psd``, so that is a pre-existing
+    single-channel-document bug rather than anything duotone-specific. Duotone
+    now behaves exactly as grayscale does, which is the point.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_duotone.psd"))
     for layer in psd:

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -519,19 +519,103 @@ def test_composite_guard_estimate_covers_a_mode_that_expands() -> None:
     """The estimate never falls below the canvas that follows it (#720).
 
     ``max_alloc_bytes`` is there to reject a file *before* it allocates, so the
-    number it is checked against has to bound what comes next. A duotone
-    document stores one channel and composites over two, so its header count
-    alone under-estimated the canvas by half; the guard is now given the wider
-    of the two counts.
+    number it is checked against has to bound what comes next. An indexed
+    document stores one channel and composites over three, its palette having
+    expanded it, so the header count alone under-estimated the canvas by 3x.
+
+    Retagged rather than taken from a fixture for the same reason as
+    ``_layered_multichannel``: Photoshop flattens on conversion to Indexed
+    Color, so ``colormodes/4x4_8bit_index_color.psd`` has no layers and takes
+    ``composite()``'s zero-layer early return, never reaching this estimate.
+    Only the *layered* path consults the palette-expanded width, and it does not
+    read the palette itself, so retagging a layered grayscale document is
+    enough. This is the only mode left where the canvas is wider than the
+    header, so it is the only way to exercise that side of the ``max()``.
     """
     psd = PSDImage.open(
-        full_name("colormodes/4x4_8bit_duotone.psd"), max_alloc_bytes=100
+        full_name("colormodes/4x4_8bit_grayscale.psd"), max_alloc_bytes=100
     )
+    psd._record.header.color_mode = ColorMode.INDEXED
     assert psd.channels == 1
-    # 4 * 4 * 2 * 4 = 128 bytes, over the budget; the header's own count of one
+    assert len(psd) > 0
+    # 4 * 4 * 3 * 4 = 192 bytes, over the budget; the header's own count of one
     # channel would have estimated 64 bytes and let it through.
-    with pytest.raises(ValueError, match="4x4x2"):
+    with pytest.raises(ValueError, match="4x4x3"):
         composite(psd)
+
+
+def test_composite_guard_estimate_takes_the_header_when_it_is_wider() -> None:
+    """The other side of the same ``max()`` (#720).
+
+    ``4x4_8bit_rgba.psd`` declares four channels and composites over three, so
+    here it is the header that bounds the pair. Both sides are pinned because
+    the guard is a security control: an estimate below the allocation defeats
+    it, and one needlessly above it rejects files that would have been fine.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgba.psd"), max_alloc_bytes=200)
+    assert psd.channels == 4
+    with pytest.raises(ValueError, match="4x4x4"):
+        composite(psd)
+
+
+def test_composite_duotone_is_one_channel_wide() -> None:
+    """Duotone composites at its stored width, not its ink count (#733).
+
+    ``EXPECTED_CHANNELS[DUOTONE]`` was 2 -- the inks -- while duotone pixel data
+    is a single grayscale channel, the ink curves living in the color mode data
+    section. So the backdrop was built two channels wide and every real source
+    broadcast against it: the second channel of the result was not data from the
+    file at all, it was the backdrop copied.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_duotone.psd"))
+    assert psd.channels == 1
+    assert psd.numpy("color").shape[2] == 1
+    color, _, _ = composite(psd)
+    assert color.shape == (psd.height, psd.width, 1)
+
+
+@pytest.mark.parametrize(
+    "blend_mode",
+    [BlendMode.COLOR_DODGE, BlendMode.COLOR_BURN, BlendMode.VIVID_LIGHT],
+)
+def test_composite_duotone_with_a_channelwise_blend_mode(blend_mode: BlendMode) -> None:
+    """These blend modes crashed on every duotone document (#733).
+
+    They index the color array with a mask derived from it
+    (``blend.py``'s ``B[Cs == 1] = 1``), which needs the operands to agree in
+    width. A two-channel canvas against a one-channel source did not::
+
+        IndexError: boolean index did not match indexed array along axis 2;
+        size of axis is 2 but size of corresponding boolean axis is 1
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_duotone.psd"))
+    for layer in psd:
+        layer.blend_mode = blend_mode
+    color, _, _ = composite(psd)
+    assert color.shape == (psd.height, psd.width, 1)
+
+
+def test_composite_pil_duotone_force_keeps_the_luminance_plane_intact() -> None:
+    """``force=True`` returned sheared pixels for duotone documents (#733).
+
+    With the canvas two channels wide, ``composite_pil()`` concatenated alpha
+    onto it and handed ``Image.fromarray()`` a 3-byte-per-pixel buffer declared
+    as 2-byte ``"LA"``. PIL does not reject that, so the planes came out shifted
+    against each other -- the first row's luminance read ``[75, 255, 53, 179]``
+    where the composite says ``[75, 53, 179, 241]``, the 255 being an alpha byte
+    that had slid into the colour plane. This is a wrong-pixels bug, not a
+    width one, so it is pinned against the numpy composite rather than by shape.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_duotone.psd"))
+    image = psd.composite(ignore_preview=True, force=True, apply_icc=False)
+    assert isinstance(image, Image.Image)
+    assert image.mode == "LA"
+    color, _, _ = composite(psd, force=True)
+    luminance = np.asarray(image)[:, :, 0].astype(np.int16)
+    expected = (color[:, :, 0] * 255).round().astype(np.int16)
+    assert np.abs(luminance - expected).max() <= 2
+    # The document is opaque; the alpha plane must be alpha, not a colour byte.
+    assert (np.asarray(image)[:, :, 1] == 255).all()
 
 
 def test_composite_pil_layered_multichannel_truncates_like_the_layerless_one() -> None:


### PR DESCRIPTION
Closes #733.

## The change

One line: `EXPECTED_CHANNELS[ColorMode.DUOTONE]` goes from `2` to `1`.

## Why 1 is right

Duotone pixel data *is* grayscale — one stored channel. The one to four ink
curves live in the Color Mode Data section, never in the image data. The
shipped fixture proves it on its own:

- `colormodes/4x4_8bit_duotone.psd`'s header declares **1 channel**;
- the colour-mode block immediately after it declares **2 inks**, `Black` and
  `PANTONE 327 CVC`.

Two inks, one channel, same file. The mode spans monotone through quadtone, so
no ink count is ever a channel count.

Three other tables in this codebase already said 1 — `ColorMode.channels`
(`constants.py:64`), `get_pil_mode` → `"L"` (`pil_io.py:39`), and the header
`PSDImage._make_header()` builds. `EXPECTED_CHANNELS` was the lone outlier.

No `get_color_channels()` duotone branch (the issue's other option): with the
table corrected it already returns the right answer, and a branch would be a
second place to be wrong. Its multichannel branch stays, that being the one mode
whose count genuinely varies per file.

## It was doing more damage than the issue reported

The issue described a width disagreement between `composite()` and `numpy()`.
That was the visible symptom. Underneath:

**1. `PSDImage.composite(force=True)` returned wrong pixels.** The over-wide
array was concatenated with alpha and handed to `Image.fromarray` as `"LA"`, so
PIL read a 3-byte-per-pixel buffer as 2-byte and sheared the planes:

```
before:  L row0 = [75, 255, 53, 179]      A row0 = [75, 53, 255, 179]
after:   L row0 = [75,  53, 179, 241]     A row0 = [255, 255, 255, 255]
numpy composite ch0 row0 = [76, 54, 179, 241]
```

That `255` in the old luminance plane is an alpha byte that slid into the colour
plane. Not narrower — wrong.

**2. Seven blend modes raised `IndexError` on any duotone document.** From
`B[Cs == 1] = 1` and friends indexing a 2-wide array with a 1-wide mask:
`ColorBurn`, `ColorDodge`, `HardLight`, `LinearLight`, `PinLight`, `SoftLight`,
`VividLight`. Photoshop *does* keep layers in duotone mode, so this was
reachable on ordinary files rather than only hand-built ones.

`Hue`, `Saturation`, `Color` and `Luminosity` still raise. They raise
identically on `colormodes/4x4_8bit_grayscale.psd`, so that is a pre-existing
single-channel-document bug, not duotone's — post-fix, duotone's failure set is
*exactly* grayscale's, which is the outcome we want. Filed separately.

**3. A duotone file with a transparency channel returned it as colour.**
`numpy("color")` handed back the alpha as colour data and `has_transparency()`
said `False`, while `pil_mode` said `"LA"` — the document contradicted itself.
No fixture has this shape; verified by retagging a 2-channel grayscale document.

**4. `PSDImage.new("DUOTONE", ...)` rejected every sequence.** The constructor
demanded two components while the header it built declared one channel, so no
value satisfied both. A scalar always worked.

## Backwards incompatible

A per-channel `background_color` on a duotone document now takes one component
instead of two:

```python
psd.background_color = (0.5, 0.5)   # was accepted, now ValueError
psd.background_color = (0.5,)       # was ValueError, now accepted
```

The second component was inert — it had no channel to be written to, and the
saved bytes are byte-identical without it. Flagged in the changelog and pinned
in `test_background_color_setter_invalid_channel_count` alongside the RGB, CMYK
and grayscale cases already there.

## Amends an unreleased entry from #728

#728's changelog entry justified its `max()` allocation guard with *"under-counted
a duotone document's two-channel canvas by half"* — which this PR makes false.
1.19.0 has not shipped, so it is amended in place rather than left contradicting
the entry below it. The example is now indexed, and its closing sentence is
corrected too: a layerless indexed document does **not** "stay covered by the
check in `numpy()`", because that check is header-based and under-counts indexed
by the same 3x. Pointed at #732, which tracks it.

## Tests

`test_composite_guard_estimate_covers_a_mode_that_expands` (added by #728)
asserted duotone's canvas was two channels wide, so it could not survive in any
form. It is **re-pointed**, not dropped: after this change indexed is the only
mode where the canvas exceeds the header, and the indexed fixture has no layers
— so it is aimed at a layered grayscale fixture retagged to `INDEXED`. The
layered path never reads the palette, so retagging suffices. (I had claimed in
planning that this needed a palette grafted into the colour mode data section;
that was wrong.)

Added:

- `..._takes_the_header_when_it_is_wider` — the other side of the same `max()`,
  using rgba (header 4, canvas 3). Both sides are now pinned; the guard is a
  security control, and an estimate below the allocation defeats it while one
  needlessly above it rejects files that were fine.
- `tests/psd_tools/api/test_utils.py` — first direct coverage for
  `get_color_channels()`, over every colour mode.
- Three duotone regressions: the stored width, all seven blend modes, and the
  sheared luminance plane (pinned against the numpy composite, not by shape,
  because it was a wrong-pixels bug).

## Verification

- Full suite: 1763 passed, 27 xfailed, 2 xpassed. `ruff check`,
  `ruff format --check`, `mypy` and the pre-commit hooks clean. Sphinx builds
  with only the pre-existing `List` ambiguity warning.
- Corpus render diff — 285 fixtures × `force=False`/`force=True` through the
  NumPy `composite()`, hashing `color`/`shape`/`alpha` bitwise: **exactly two
  renders change, both of them the duotone fixture.** Every other render is
  identical.
- Each of the three duotone regression tests confirmed to fail against `HEAD~`'s
  source and pass here.

## Follow-up worth filing

`Hue`, `Saturation`, `Color` and `Luminosity` raise `IndexError` on any
single-channel document — grayscale as much as duotone. Pre-existing and out of
scope here; the test docstring records why those four are excluded from the
parametrized list so the omission reads as deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
