### PR TITLE
fix: size numpy()'s allocation estimate by the palette expansion

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,9 +53,20 @@ Changelog
   header count and the canvas width, so no colour mode under-estimates. This
   can reject a document that a very tight budget previously admitted. Applies
   to ``composite()``'s own guard only: a document with no layers returns early,
-  before that estimate, and falls to the check in ``numpy()``, which is still
-  header-based and so still under-counts an indexed canvas -- tracked
-  separately in #732 (#720).
+  before that estimate, and falls to the check in ``numpy()``, which was fixed
+  the same way separately (#720, #732).
+- [fix] Never let the ``max_alloc_bytes`` estimate in ``numpy()`` fall below
+  the array it guards. ``get_image_data()`` was given the header's channel
+  count, which is below what it goes on to allocate for a colour mode that
+  expands: an indexed document stores one channel and the palette lookup turns
+  it into three, so the estimate was 3x short. Flattened indexed documents are
+  what Photoshop ordinarily writes, and such a document takes ``composite()``'s
+  zero-layer early return, leaving this the only guard on the path -- so the
+  undercount was reachable through both entry points. It is now given the wider
+  of the header count and the resolved width, matching the fix applied to
+  ``composite()``'s own guard above. This can reject a document that a very
+  tight budget previously admitted; only indexed documents are affected, that
+  being the only mode whose stored count is below its allocated width (#732).
 - [fix] Composite duotone documents at their stored width.
   ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
   pixel data is a single grayscale channel, the one to four ink curves living
@@ -72,7 +83,7 @@ Changelog
   ``Hue``, ``Saturation``, ``Color`` and ``Luminosity`` still raise on a duotone
   document. They raise identically on a grayscale one, so that is a pre-existing
   limitation of single-channel documents rather than anything this entry
-  changes.
+  changes; it is tracked in #735.
 - [fix] Read the alpha channel of a duotone document as alpha. Because the
   colour array was taken to be two channels wide, a duotone file carrying a
   transparency channel returned it as *colour* data from ``numpy("color")``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -72,6 +72,13 @@ Changelog
   allocates twenty-four planes. The guard is sized for that, since it exists to
   bound hostile headers rather than well-formed ones.
 
+  The same entry point no longer over-estimates its synthesised results either.
+  ``numpy("mask")``, and ``numpy("shape")`` on a document with no transparency,
+  return a ``(h, w, 1)`` array without reading the image data, but were
+  estimated at the document's stored width -- so a budget that fitted such a
+  request four times over could still reject it on a CMYK document. That
+  over-estimate was not specific to indexed and predates this entry.
+
   The estimate bounds the array that is returned, which is what
   ``check_pixel_size()`` has always measured. Peak usage during parsing is a
   small multiple of it for every colour mode, and 1-bit documents are

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,19 +54,29 @@ Changelog
   can reject a document that a very tight budget previously admitted. Applies
   to ``composite()``'s own guard only: a document with no layers returns early,
   before that estimate, and falls to the check in ``numpy()``, which was fixed
-  the same way separately (#720, #732).
+  separately (#720, #732).
 - [fix] Never let the ``max_alloc_bytes`` estimate in ``numpy()`` fall below
   the array it guards. ``get_image_data()`` was given the header's channel
-  count, which is below what it goes on to allocate for a colour mode that
-  expands: an indexed document stores one channel and the palette lookup turns
-  it into three, so the estimate was 3x short. Flattened indexed documents are
-  what Photoshop ordinarily writes, and such a document takes ``composite()``'s
-  zero-layer early return, leaving this the only guard on the path -- so the
-  undercount was reachable through both entry points. It is now given the wider
-  of the header count and the resolved width, matching the fix applied to
-  ``composite()``'s own guard above. This can reject a document that a very
-  tight budget previously admitted; only indexed documents are affected, that
-  being the only mode whose stored count is below its allocated width (#732).
+  count, which is below what it goes on to allocate for an indexed document:
+  the palette is applied to the whole buffer, so each stored channel becomes
+  three and the estimate was threefold short. Flattened indexed documents are
+  what Photoshop ordinarily writes, and such a document takes the zero-layer
+  early return in :py:func:`psd_tools.composite.composite`, which leaves this
+  the only estimate on that path. The count is now multiplied by the palette
+  expansion, so it matches the allocation exactly for every colour mode, depth
+  and channel count. This can reject a document that a very tight budget
+  previously admitted, and only an 8-bit indexed one (#732).
+
+  Note that the header's channel count is not cross-checked against the colour
+  mode, so the expansion scales with it: a header declaring eight channels
+  allocates twenty-four planes. The guard is sized for that, since it exists to
+  bound hostile headers rather than well-formed ones.
+
+  The estimate bounds the array that is returned, which is what
+  ``check_pixel_size()`` has always measured. Peak usage during parsing is a
+  small multiple of it for every colour mode, and 1-bit documents are
+  under-counted eightfold because the estimate carries no depth term; both
+  predate this entry and are unchanged by it.
 - [fix] Composite duotone documents at their stored width.
   ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
   pixel data is a single grayscale channel, the one to four ink curves living

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -66,7 +66,7 @@ def _image_data_planes(psdimage: "PSDProtocol") -> int:
     colour mode. Nor does it carry a depth term, so a 1-bit document still
     under-counts -- rows unpack to eight times the byte count the estimate
     assumes. Both are pre-existing properties of this estimate rather than
-    anything a colour mode causes; the second is tracked separately.
+    anything a colour mode causes; the second is tracked in #737.
     """
     planes = psdimage.channels
     if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -34,11 +34,21 @@ def get_array(
     )
 
 
-def _image_data_planes(psdimage: "PSDProtocol") -> int:
+def _image_data_planes(psdimage: "PSDProtocol", flat: bool = False) -> int:
     """Planes :func:`get_image_data` will allocate, for its allocation guard.
 
-    The header's channel count is what the merged image data *stores*, and for
-    every colour mode but one it is also what gets allocated. Indexed at depth 8
+    ``flat`` marks the paths that return a synthesised ``(h, w, 1)`` array
+    without reading the image data at all -- a mask, or a shape on a document
+    with no transparency. Those allocate one plane whatever the colour mode, so
+    estimating them at the stored width rejects requests that comfortably fit:
+    ``numpy("mask")`` on a CMYK document allocates a quarter of what the header
+    implies. That over-estimate predates the palette fix below for every
+    multi-channel mode; it is corrected here rather than left to grow a third
+    case.
+
+    Otherwise the header's channel count is what the merged image data *stores*,
+    and for every colour mode but one it is also what gets allocated. Indexed at
+    depth 8
     is the exception: :func:`_parse_array` applies the palette to the whole
     buffer rather than to one plane, so ``(channels * h * w,)`` becomes
     ``(channels * h * w, 3)`` and the reshape below yields
@@ -68,6 +78,8 @@ def _image_data_planes(psdimage: "PSDProtocol") -> int:
     assumes. Both are pre-existing properties of this estimate rather than
     anything a colour mode causes; the second is tracked in #737.
     """
+    if flat:
+        return 1
     planes = psdimage.channels
     if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:
         planes *= EXPECTED_CHANNELS[ColorMode.INDEXED]
@@ -75,6 +87,12 @@ def _image_data_planes(psdimage: "PSDProtocol") -> int:
 
 
 def get_image_data(psdimage: "PSDProtocol", channel: str | None) -> np.ndarray:
+    # Decided before the guard runs rather than after, so the estimate can match
+    # whichever branch is taken. The dimension checks inside check_pixel_size()
+    # apply to both, so neither path escapes it.
+    flat = (channel == "mask") or (
+        channel == "shape" and not has_transparency(psdimage)
+    )
     # The guard is here to reject a file before it allocates, so its estimate
     # must not fall below the array that follows. See _image_data_planes() for
     # why the header's own count is not that bound for an indexed document --
@@ -82,11 +100,11 @@ def get_image_data(psdimage: "PSDProtocol", channel: str | None) -> np.ndarray:
     check_pixel_size(
         psdimage.width,
         psdimage.height,
-        _image_data_planes(psdimage),
+        _image_data_planes(psdimage, flat),
         max_alloc_bytes=psdimage._max_alloc_bytes,
     )
 
-    if (channel == "mask") or (channel == "shape" and not has_transparency(psdimage)):
+    if flat:
         return np.ones((psdimage.height, psdimage.width, 1), dtype=np.float32)
 
     lut = None

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 from psd_tools.api.utils import (
     EXPECTED_CHANNELS,
     check_pixel_size,
+    get_color_channels,
     get_transparency_index,
     has_transparency,
 )
@@ -35,10 +36,21 @@ def get_array(
 
 
 def get_image_data(psdimage: "PSDProtocol", channel: str | None) -> np.ndarray:
+    # The header's channel count is what this function *reads*, but not always
+    # what it allocates: an indexed document stores one channel and the palette
+    # lookup below turns it into three, so the header on its own under-counted
+    # the array by 3x. The guard is here to reject a file before it allocates,
+    # so its estimate must never fall below what follows it -- and a flattened
+    # indexed document is what Photoshop ordinarily writes, not a corner case.
+    #
+    # `max()`, not a swap: grayscale-with-alpha stores two planes and resolves
+    # to one, so the resolved count alone would under-count in the other
+    # direction. Only the modes that expand are tightened by taking the wider
+    # of the pair; every other mode keeps the header's own estimate.
     check_pixel_size(
         psdimage.width,
         psdimage.height,
-        psdimage.channels,
+        max(psdimage.channels, get_color_channels(psdimage)),
         max_alloc_bytes=psdimage._max_alloc_bytes,
     )
 

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 from psd_tools.api.utils import (
     EXPECTED_CHANNELS,
     check_pixel_size,
-    get_color_channels,
     get_transparency_index,
     has_transparency,
 )
@@ -35,22 +34,55 @@ def get_array(
     )
 
 
+def _image_data_planes(psdimage: "PSDProtocol") -> int:
+    """Planes :func:`get_image_data` will allocate, for its allocation guard.
+
+    The header's channel count is what the merged image data *stores*, and for
+    every colour mode but one it is also what gets allocated. Indexed at depth 8
+    is the exception: :func:`_parse_array` applies the palette to the whole
+    buffer rather than to one plane, so ``(channels * h * w,)`` becomes
+    ``(channels * h * w, 3)`` and the reshape below yields
+    ``(h, w, 3 * channels)``. The header alone under-counted that threefold.
+
+    Deliberately *not* ``max(channels, get_color_channels(psdimage))``, the
+    shape #728 gave the compositor's guard. That one bounds a canvas built at
+    the resolved width, so the wider of the pair is right there. This one bounds
+    the stored array, whose width the header fixes -- and taking the wider of
+    the pair here would over-estimate any file whose header declares fewer
+    channels than its mode implies. Those parse fine and produce a narrow array:
+    a one-channel RGB document returns ``(h, w, 1)`` and would have been
+    rejected at four times its real size, which for a guard whose whole job is
+    admitting sound files is a false positive rather than a safety margin.
+
+    The palette is applied only in :func:`_parse_array`'s depth-8 branch, so a
+    16- or 32-bit indexed document -- malformed, indexed being an 8-bit mode --
+    keeps its stored width and must not be tripled either.
+
+    This bounds the array that is returned, which is what
+    :func:`~psd_tools.api.utils.check_pixel_size` estimates by construction. It
+    does not model the transient peak: :func:`_parse_array` holds the raw bytes
+    and two float32 arrays at once, and :func:`_remove_background` adds several
+    more, so the true high-water mark is a small multiple of this for every
+    colour mode. Nor does it carry a depth term, so a 1-bit document still
+    under-counts -- rows unpack to eight times the byte count the estimate
+    assumes. Both are pre-existing properties of this estimate rather than
+    anything a colour mode causes; the second is tracked separately.
+    """
+    planes = psdimage.channels
+    if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:
+        planes *= EXPECTED_CHANNELS[ColorMode.INDEXED]
+    return planes
+
+
 def get_image_data(psdimage: "PSDProtocol", channel: str | None) -> np.ndarray:
-    # The header's channel count is what this function *reads*, but not always
-    # what it allocates: an indexed document stores one channel and the palette
-    # lookup below turns it into three, so the header on its own under-counted
-    # the array by 3x. The guard is here to reject a file before it allocates,
-    # so its estimate must never fall below what follows it -- and a flattened
-    # indexed document is what Photoshop ordinarily writes, not a corner case.
-    #
-    # `max()`, not a swap: grayscale-with-alpha stores two planes and resolves
-    # to one, so the resolved count alone would under-count in the other
-    # direction. Only the modes that expand are tightened by taking the wider
-    # of the pair; every other mode keeps the header's own estimate.
+    # The guard is here to reject a file before it allocates, so its estimate
+    # must not fall below the array that follows. See _image_data_planes() for
+    # why the header's own count is not that bound for an indexed document --
+    # and why the wider-of-the-pair shape used in composite() is not either.
     check_pixel_size(
         psdimage.width,
         psdimage.height,
-        max(psdimage.channels, get_color_channels(psdimage)),
+        _image_data_planes(psdimage),
         max_alloc_bytes=psdimage._max_alloc_bytes,
     )
 

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -558,6 +558,27 @@ def test_composite_guard_estimate_takes_the_header_when_it_is_wider() -> None:
         composite(psd)
 
 
+def test_composite_flattened_indexed_is_bounded_by_the_numpy_guard() -> None:
+    """The zero-layer early return is guarded too, by ``get_image_data()`` (#732).
+
+    The complement of ``..._covers_a_mode_that_expands`` above: that one had to
+    retag a layered document precisely because the shipped indexed fixture is
+    flattened and returns early, before ``composite()``'s own estimate. So on
+    the shape Photoshop actually writes, the guard inside ``numpy()`` is the
+    only one on the path -- and it under-counted the palette expansion by 3x
+    until this was fixed, which is how the undercount stayed reachable through
+    ``composite()``.
+    """
+    name = "colormodes/4x4_8bit_index_color.psd"
+    assert len(PSDImage.open(full_name(name))) == 0  # flattened: early return
+    allocated = PSDImage.open(full_name(name)).numpy().nbytes
+    assert allocated == 4 * 4 * 3 * 4  # one stored channel, three allocated
+
+    composite(PSDImage.open(full_name(name), max_alloc_bytes=allocated))
+    with pytest.raises(ValueError, match="4x4x3"):
+        composite(PSDImage.open(full_name(name), max_alloc_bytes=allocated - 1))
+
+
 def test_composite_duotone_is_one_channel_wide() -> None:
     """Duotone composites at its stored width, not its ink count (#733).
 

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -566,8 +566,12 @@ def test_composite_flattened_indexed_is_bounded_by_the_numpy_guard() -> None:
     flattened and returns early, before ``composite()``'s own estimate. So on
     the shape Photoshop actually writes, the guard inside ``numpy()`` is the
     only one on the path -- and it under-counted the palette expansion by 3x
-    until this was fixed, which is how the undercount stayed reachable through
-    ``composite()``.
+    until this was fixed.
+
+    Scope: this is the low-level :py:func:`psd_tools.composite.composite`. The
+    :py:meth:`PSDImage.composite` *method* does not reach either estimate on
+    this document -- it short-circuits to ``topil()`` when an unmodified
+    document has a preview, which is guarded separately in ``pil_io``.
     """
     name = "colormodes/4x4_8bit_index_color.psd"
     assert len(PSDImage.open(full_name(name))) == 0  # flattened: early return

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -23,6 +23,8 @@ from psd_tools.api.utils import (
     WARN_PIXELS,
 )
 
+from .utils import full_name
+
 
 def _build_psd(width: int, height: int, channels: int = 3) -> io.BytesIO:
     """Return a BytesIO containing a minimal structurally valid PSD.
@@ -239,3 +241,79 @@ def test_explicit_kwarg_overrides_env_default(monkeypatch: pytest.MonkeyPatch) -
     psd = PSDImage.open(_build_psd(_NORMAL_W, _NORMAL_H), max_alloc_bytes=1024)
     with pytest.raises(ValueError, match="1,024 bytes"):
         psd.numpy()
+
+
+# ---------------------------------------------------------------------------
+# The estimate must not fall below the allocation it guards (#732)
+# ---------------------------------------------------------------------------
+#
+# `get_image_data()` reads the header's channel count but does not always
+# allocate that many planes, so these pin the estimate against the array that
+# is actually produced rather than against a hard-coded byte count. A budget
+# equal to the real allocation must admit the document and one byte less must
+# reject it: that brackets the estimate from both sides at once, which a test
+# asserting only "raises" would not.
+
+_COLORMODE_FIXTURES = [
+    "4x4_8bit_index_color.psd",
+    "4x4_8bit_rgba.psd",
+    "4x4_8bit_rgb.psd",
+    "4x4_8bit_grayscale.psd",
+    "4x4_8bit_duotone.psd",
+    "4x4_8bit_cmyk.psd",
+    "4x4_8bit_lab.psd",
+    "4x4_16bit_multichannel.psd",
+    "4x4_1bit_bitmap.psd",
+]
+
+
+def _colormode(filename: str, **kwargs: object) -> PSDImage:
+    return PSDImage.open(full_name("colormodes/" + filename), **kwargs)  # type: ignore[arg-type]
+
+
+def test_numpy_guard_estimate_covers_indexed_expansion() -> None:
+    """Indexed stores one channel and the palette turns it into three.
+
+    The header's count alone under-counted the array by 3x, and indexed is the
+    mode Photoshop writes for a flattened document, so this was the common
+    shape rather than a corner.
+    """
+    allocated = _colormode("4x4_8bit_index_color.psd").numpy().nbytes
+    assert _colormode("4x4_8bit_index_color.psd").channels == 1  # header says 1...
+    assert allocated == 4 * 4 * 3 * 4  # ...the array is 3 planes wide
+
+    _colormode("4x4_8bit_index_color.psd", max_alloc_bytes=allocated).numpy()
+    with pytest.raises(ValueError, match="configured budget"):
+        _colormode("4x4_8bit_index_color.psd", max_alloc_bytes=allocated - 1).numpy()
+
+
+def test_numpy_guard_estimate_takes_the_header_when_it_is_wider() -> None:
+    """The other side of the same max(): RGBA stores four planes, resolves to three.
+
+    Swapping the header's count for the resolved one instead of taking the
+    wider of the pair would under-count here by a channel, so both directions
+    are pinned. The guard is a security control; an estimate below the
+    allocation defeats it, while one needlessly above it rejects sound files.
+    """
+    allocated = _colormode("4x4_8bit_rgba.psd").numpy().nbytes
+    assert _colormode("4x4_8bit_rgba.psd").channels == 4  # header is the wider one
+    assert allocated == 4 * 4 * 4 * 4
+
+    _colormode("4x4_8bit_rgba.psd", max_alloc_bytes=allocated).numpy()
+    with pytest.raises(ValueError, match="configured budget"):
+        _colormode("4x4_8bit_rgba.psd", max_alloc_bytes=allocated - 1).numpy()
+
+
+@pytest.mark.parametrize("filename", _COLORMODE_FIXTURES)
+def test_numpy_guard_estimate_never_exceeds_the_allocation(filename: str) -> None:
+    """No colour mode may be rejected at a budget it actually fits inside.
+
+    The companion invariant to the two above, swept over every colour mode: an
+    estimate above the real allocation turns the budget into a false positive.
+    (Bitmap has slack in the other direction -- 1-bit rows are padded to a byte
+    boundary before unpacking, so its array is wider than any channel count
+    predicts. That is a separate gap in this estimate, not something this
+    assertion is claiming is absent.)
+    """
+    allocated = _colormode(filename).numpy().nbytes
+    _colormode(filename, max_alloc_bytes=allocated).numpy()

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -417,8 +417,8 @@ def test_numpy_guard_estimate_never_exceeds_the_allocation(filename: str) -> Non
     The same invariant as above swept over the real corpus, covering every
     colour mode and all four depths. (Bitmap has slack in the other direction:
     a 1-bit document unpacks to more values than the byte count this estimate
-    assumes, which has no depth term. That is a separate gap, not something this
-    assertion claims is absent.)
+    assumes, which has no depth term -- #737. That is a separate gap, not
+    something this assertion claims is absent.)
     """
     allocated = _colormode(filename).numpy().nbytes
     _colormode(filename, allocated).numpy()

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -13,9 +13,12 @@ import warnings
 
 import pytest
 
+from typing import Any
+
 from psd_tools import PSDImage, PSDLargeImageWarning
 from psd_tools import compression as _compression
 from psd_tools.api import utils as _utils
+from psd_tools.constants import ColorMode
 from psd_tools.api.utils import (
     MAX_DIMENSION_PSD,
     MAX_PIXELS_PSD,
@@ -244,7 +247,7 @@ def test_explicit_kwarg_overrides_env_default(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
-# The estimate must not fall below the allocation it guards (#732)
+# The estimate must match the allocation it guards (#732)
 # ---------------------------------------------------------------------------
 #
 # `get_image_data()` reads the header's channel count but does not always
@@ -253,6 +256,16 @@ def test_explicit_kwarg_overrides_env_default(monkeypatch: pytest.MonkeyPatch) -
 # equal to the real allocation must admit the document and one byte less must
 # reject it: that brackets the estimate from both sides at once, which a test
 # asserting only "raises" would not.
+#
+# Both directions matter. The guard is a security control, so an estimate below
+# the allocation defeats it -- but one above it rejects a file that would have
+# been fine, and a guard that refuses sound documents is its own bug. The
+# estimate is exact for every colour mode, depth and channel count below.
+#
+# Note the scope: it bounds the array that is *returned*, which is what
+# `check_pixel_size()` estimates by construction. The transient peak is a small
+# multiple of it for every mode -- `_parse_array()` holds the raw bytes and two
+# float32 arrays at once -- and that is pre-existing, not colour-mode-specific.
 
 _COLORMODE_FIXTURES = [
     "4x4_8bit_index_color.psd",
@@ -263,57 +276,149 @@ _COLORMODE_FIXTURES = [
     "4x4_8bit_cmyk.psd",
     "4x4_8bit_lab.psd",
     "4x4_16bit_multichannel.psd",
+    "4x4_16bit_cmyk.psd",
+    "4x4_16bit_lab.psd",
+    "4x4_32bit_rgb.psd",
+    "4x4_32bit_grayscale.psd",
     "4x4_1bit_bitmap.psd",
 ]
 
 
-def _colormode(filename: str, **kwargs: object) -> PSDImage:
-    return PSDImage.open(full_name("colormodes/" + filename), **kwargs)  # type: ignore[arg-type]
+def _colormode(filename: str, max_alloc_bytes: int | None = None) -> PSDImage:
+    return PSDImage.open(
+        full_name("colormodes/" + filename), max_alloc_bytes=max_alloc_bytes
+    )
 
 
-def test_numpy_guard_estimate_covers_indexed_expansion() -> None:
-    """Indexed stores one channel and the palette turns it into three.
+def _forge(
+    width: int,
+    height: int,
+    channels: int,
+    depth: int,
+    color_mode: int,
+    max_alloc_bytes: int | None = None,
+) -> PSDImage:
+    """A structurally valid PSD with an arbitrary header/mode combination.
 
-    The header's count alone under-counted the array by 3x, and indexed is the
-    mode Photoshop writes for a flattened document, so this was the common
-    shape rather than a corner.
+    `_build_psd()` above is RGB-only and empty-bodied. These tests need headers
+    that no fixture provides -- an indexed document with more than one stored
+    channel, an indexed document at a depth where the palette is not applied --
+    and need the image data to actually parse, so the estimate can be compared
+    against a real array.
     """
-    allocated = _colormode("4x4_8bit_index_color.psd").numpy().nbytes
+    buf = io.BytesIO()
+    buf.write(
+        struct.pack(
+            ">4sH6xHIIHH", b"8BPS", 1, channels, height, width, depth, color_mode
+        )
+    )
+    buf.write(struct.pack(">I", 768))  # colour mode data: a 256x3 palette
+    buf.write(bytes(768))
+    buf.write(struct.pack(">I", 0))  # image resources
+    buf.write(struct.pack(">I", 0))  # layer and mask info
+    buf.write(struct.pack(">H", 0))  # image data: raw, uncompressed
+    buf.write(bytes(width * height * channels * max(1, depth // 8)))
+    buf.seek(0)
+    return PSDImage.open(buf, max_alloc_bytes=max_alloc_bytes)
+
+
+def _assert_estimate_is_exact(open_doc: Any) -> int:
+    """A budget equal to the allocation admits; one byte less rejects.
+
+    Returns the allocation, so a caller can additionally pin its width.
+    """
+    allocated = open_doc().numpy().nbytes
+    open_doc(allocated).numpy()
+    with pytest.raises(ValueError, match="configured budget"):
+        open_doc(allocated - 1).numpy()
+    return allocated
+
+
+def test_numpy_guard_estimate_covers_the_palette_expansion() -> None:
+    """Indexed at depth 8 allocates three planes per stored channel.
+
+    ``_parse_array()`` applies the palette to the whole buffer rather than to a
+    single plane, so the array comes back ``3 * channels`` wide and the header's
+    own count under-counted it threefold. Indexed is also the mode Photoshop
+    writes for a flattened document, so this was the common shape rather than a
+    corner.
+    """
+    allocated = _assert_estimate_is_exact(
+        lambda budget=None: _colormode("4x4_8bit_index_color.psd", budget)
+    )
     assert _colormode("4x4_8bit_index_color.psd").channels == 1  # header says 1...
     assert allocated == 4 * 4 * 3 * 4  # ...the array is 3 planes wide
 
-    _colormode("4x4_8bit_index_color.psd", max_alloc_bytes=allocated).numpy()
-    with pytest.raises(ValueError, match="configured budget"):
-        _colormode("4x4_8bit_index_color.psd", max_alloc_bytes=allocated - 1).numpy()
 
+@pytest.mark.parametrize("channels", [1, 2, 4, 8])
+def test_numpy_guard_estimate_scales_the_palette_expansion(channels: int) -> None:
+    """The expansion is ``3 * channels``, not a flat 3.
 
-def test_numpy_guard_estimate_takes_the_header_when_it_is_wider() -> None:
-    """The other side of the same max(): RGBA stores four planes, resolves to three.
-
-    Swapping the header's count for the resolved one instead of taking the
-    wider of the pair would under-count here by a channel, so both directions
-    are pinned. The guard is a security control; an estimate below the
-    allocation defeats it, while one needlessly above it rejects sound files.
+    ``FileHeader.channels`` is an attacker-controlled uint16 with no cross-check
+    against the colour mode, and this guard exists for hostile headers
+    (GHSA-8q6g-vjhf-jp8m) -- so "Photoshop never writes multi-channel indexed"
+    is the threat model rather than a defence. Taking the *wider* of the header
+    count and 3, instead of their product, left the estimate a flat third of the
+    array for any header declaring three channels or more.
     """
-    allocated = _colormode("4x4_8bit_rgba.psd").numpy().nbytes
-    assert _colormode("4x4_8bit_rgba.psd").channels == 4  # header is the wider one
-    assert allocated == 4 * 4 * 4 * 4
+    allocated = _assert_estimate_is_exact(
+        lambda budget=None: _forge(4, 4, channels, 8, ColorMode.INDEXED, budget)
+    )
+    assert allocated == 4 * 4 * (3 * channels) * 4
 
-    _colormode("4x4_8bit_rgba.psd", max_alloc_bytes=allocated).numpy()
-    with pytest.raises(ValueError, match="configured budget"):
-        _colormode("4x4_8bit_rgba.psd", max_alloc_bytes=allocated - 1).numpy()
+
+@pytest.mark.parametrize("depth", [16, 32])
+def test_numpy_guard_estimate_does_not_expand_indexed_at_other_depths(
+    depth: int,
+) -> None:
+    """The palette is applied only in ``_parse_array()``'s depth-8 branch.
+
+    Indexed is an 8-bit mode, so such a document is malformed -- but it parses,
+    and it keeps its stored width. Tripling it would reject a file three times
+    smaller than the estimate claimed, which is the false-positive direction.
+    """
+    allocated = _assert_estimate_is_exact(
+        lambda budget=None: _forge(4, 4, 1, depth, ColorMode.INDEXED, budget)
+    )
+    assert allocated == 4 * 4 * 1 * 4  # not tripled
+
+
+@pytest.mark.parametrize(
+    ("color_mode", "channels"),
+    [
+        (ColorMode.RGB, 1),
+        (ColorMode.RGB, 2),
+        (ColorMode.RGB, 4),  # RGBA: the header is wider than the mode
+        (ColorMode.CMYK, 1),
+        (ColorMode.LAB, 2),
+        (ColorMode.GRAYSCALE, 2),  # grayscale + alpha
+    ],
+)
+def test_numpy_guard_estimate_follows_the_header_for_every_other_mode(
+    color_mode: int, channels: int
+) -> None:
+    """Outside the palette expansion, the stored count *is* the allocation.
+
+    Including where the header disagrees with its colour mode. Such files parse
+    fine and produce a narrow array -- a one-channel RGB document returns
+    ``(h, w, 1)`` -- so resolving the width from the colour mode instead would
+    reject them at up to four times their real size.
+    """
+    allocated = _assert_estimate_is_exact(
+        lambda budget=None: _forge(4, 4, channels, 8, color_mode, budget)
+    )
+    assert allocated == 4 * 4 * channels * 4
 
 
 @pytest.mark.parametrize("filename", _COLORMODE_FIXTURES)
 def test_numpy_guard_estimate_never_exceeds_the_allocation(filename: str) -> None:
-    """No colour mode may be rejected at a budget it actually fits inside.
+    """No shipped fixture may be rejected at a budget it actually fits inside.
 
-    The companion invariant to the two above, swept over every colour mode: an
-    estimate above the real allocation turns the budget into a false positive.
-    (Bitmap has slack in the other direction -- 1-bit rows are padded to a byte
-    boundary before unpacking, so its array is wider than any channel count
-    predicts. That is a separate gap in this estimate, not something this
-    assertion is claiming is absent.)
+    The same invariant as above swept over the real corpus, covering every
+    colour mode and all four depths. (Bitmap has slack in the other direction:
+    a 1-bit document unpacks to more values than the byte count this estimate
+    assumes, which has no depth term. That is a separate gap, not something this
+    assertion claims is absent.)
     """
     allocated = _colormode(filename).numpy().nbytes
-    _colormode(filename, max_alloc_bytes=allocated).numpy()
+    _colormode(filename, allocated).numpy()

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -13,11 +13,13 @@ import warnings
 
 import pytest
 
-from typing import Any
+from typing import Any, Literal, Optional
 
 from psd_tools import PSDImage, PSDLargeImageWarning
 from psd_tools import compression as _compression
 from psd_tools.api import utils as _utils
+from psd_tools.api.numpy_io import _image_data_planes
+from psd_tools.api.utils import has_transparency
 from psd_tools.constants import ColorMode
 from psd_tools.api.utils import (
     MAX_DIMENSION_PSD,
@@ -27,6 +29,8 @@ from psd_tools.api.utils import (
 )
 
 from .utils import full_name
+
+_Channel = Literal["color", "shape", "alpha", "mask"]
 
 
 def _build_psd(width: int, height: int, channels: int = 3) -> io.BytesIO:
@@ -410,8 +414,11 @@ def test_numpy_guard_estimate_follows_the_header_for_every_other_mode(
     assert allocated == 4 * 4 * channels * 4
 
 
+@pytest.mark.parametrize("channel", [None, "color", "shape", "alpha", "mask"])
 @pytest.mark.parametrize("filename", _COLORMODE_FIXTURES)
-def test_numpy_guard_estimate_never_exceeds_the_allocation(filename: str) -> None:
+def test_numpy_guard_estimate_never_exceeds_the_allocation(
+    filename: str, channel: Optional[_Channel]
+) -> None:
     """No shipped fixture may be rejected at a budget it actually fits inside.
 
     The same invariant as above swept over the real corpus, covering every
@@ -419,6 +426,42 @@ def test_numpy_guard_estimate_never_exceeds_the_allocation(filename: str) -> Non
     a 1-bit document unpacks to more values than the byte count this estimate
     assumes, which has no depth term -- #737. That is a separate gap, not
     something this assertion claims is absent.)
+
+    Swept over ``channel`` as well, because the estimate has to match whichever
+    branch the argument selects -- see the synthesised paths below, which this
+    parametrisation is what catches.
+
+    Note what "the allocation" means for a channel argument. ``numpy("color")``
+    and ``numpy("shape")`` return *views* into the full array -- on
+    ``4x4_8bit_rgba.psd``, ``numpy("color")`` hands back 192 bytes of a 256-byte
+    buffer -- so the returned array's ``nbytes`` is not what was allocated. The
+    guard has to bound the buffer, so that is what is compared against.
     """
-    allocated = _colormode(filename).numpy().nbytes
-    _colormode(filename, allocated).numpy()
+    psd = _colormode(filename)
+    flat = channel == "mask" or (channel == "shape" and not has_transparency(psd))
+    allocated = 4 * 4 * 1 * 4 if flat else psd.numpy(None).nbytes
+    _colormode(filename, allocated).numpy(channel)
+
+
+@pytest.mark.parametrize("channel", ["mask", "shape"])
+@pytest.mark.parametrize(
+    "filename", ["4x4_8bit_index_color.psd", "4x4_8bit_cmyk.psd", "4x4_8bit_rgb.psd"]
+)
+def test_numpy_guard_estimate_matches_the_synthesised_paths(
+    filename: str, channel: _Channel
+) -> None:
+    """A mask, and a shape on a document with no transparency, allocate one plane.
+
+    Both are returned as synthesised ``(h, w, 1)`` arrays without the image data
+    being read at all, so estimating them at the stored width rejects a request
+    that fits several times over -- a quarter of the header's implication on
+    CMYK, a third on indexed once the palette expansion is counted.
+
+    Raised by review on this PR. The over-estimate predates it for every
+    multi-channel mode; sizing indexed by its expanded width would have added a
+    third case rather than introducing the problem.
+    """
+    one_plane = 4 * 4 * 1 * 4
+    assert _colormode(filename).numpy(channel).nbytes == one_plane
+    assert _image_data_planes(_colormode(filename)) > 1  # the stored width differs
+    _colormode(filename, one_plane).numpy(channel)


### PR DESCRIPTION
Closes #732.

## The change

`get_image_data()`'s allocation guard is sized by the palette expansion instead
of the header's channel count alone:

```python
planes = psdimage.channels
if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:
    planes *= EXPECTED_CHANNELS[ColorMode.INDEXED]
```

The estimate is now **exact — 1.00x — for every colour mode, depth and channel
count**, rather than merely no longer short.

## Why the header count was wrong

The header says how many channels the file *stores*, which is not always how
many `get_image_data()` allocates. `_parse_array()` applies the palette to the
whole buffer, so `(channels * h * w,)` becomes `(channels * h * w, 3)` and the
reshape yields `(h, w, 3 * channels)`. The guard exists to reject a file
*before* it allocates (GHSA-8q6g-vjhf-jp8m), so an estimate under the
allocation is the one thing it must not be.

## Not the `max()` shape #728 used — that was wrong here, both ways

I first wrote this as `max(psdimage.channels, get_color_channels(psdimage))`,
mirroring #728. Review caught that it fails in **both** directions, and the
second commit replaces it. Recording why, since the two call sites look alike:

**It still under-counted by 3x.** The expansion is `3 * channels`, not a flat 3,
so `max()` collapses to the header as soon as it declares three channels or
more:

| header channels | `max(hdr, 3)` | actual array | |
| --- | --- | --- | --- |
| 1 | 3 | `(h, w, 3)` | exact |
| 2 | 3 | `(h, w, 6)` | **2x short** |
| 4 | 4 | `(h, w, 12)` | **3x short** |
| 8 | 8 | `(h, w, 24)` | **3x short** |

`FileHeader.channels` is an unvalidated uint16 in [1, 56] with no cross-check
against `color_mode` (`psd/header.py:68`), and hostile headers are precisely
this guard's threat model — "Photoshop never writes multi-channel indexed" is
not a defence here.

**And it over-counted, rejecting sound files.** The resolved width is not the
allocation for any other mode:

| forged document | `max()` est. | actual array | |
| --- | --- | --- | --- |
| RGB, header says 1 | 3 | `(h, w, 1)` | **3x too high** |
| CMYK, header says 1 | 4 | `(h, w, 1)` | **4x too high** |
| LAB, header says 2 | 3 | `(h, w, 2)` | 1.5x too high |
| INDEXED depth 16/32 | 3 | `(h, w, 1)` | **3x too high** |

These all parse fine today and produce a narrow array. The last row is because
the palette is applied only in `_parse_array()`'s depth-8 branch, so a 16- or
32-bit indexed document keeps its stored width.

The difference from #728: that guard bounds a *canvas* built at the resolved
width, so the wider of the pair is right there. This one bounds the *stored
array*, whose width the header fixes. Same-looking question, different
allocation.

## Why it was reachable through `composite()`

A flattened document takes the zero-layer early return in
`psd_tools.composite.composite()`, which never reaches the compositor's own
estimate — verified there is no `check_pixel_size` between function entry and
that return — so `numpy()`'s guard is the only one on that path. And flattened
indexed is what Photoshop writes: `colormodes/4x4_8bit_index_color.psd` has zero
layers. #728's own test docstring records that it had to retag a layered
grayscale document for exactly this reason; this PR covers the path that return
takes.

Scope correction: this is the low-level function. The `PSDImage.composite()`
*method* reaches neither estimate on such a document — it short-circuits to
`topil()`, guarded separately in `pil_io`. The changelog and the test docstring
both say so; an earlier draft of the entry claimed "both entry points", which
was wrong.

## Scope of the behaviour change

A document that a very tight `max_alloc_bytes` previously admitted can now be
rejected, and only an 8-bit indexed one. Every other mode keeps the estimate it
had, exactly. The branch is also inert unless a budget is set
(`max_alloc_bytes=None` skips it), so no default behaviour moves.

## Tests

Nine parametrized cases in `test_pixel_size.py`, alongside the other
GHSA-8q6g-vjhf-jp8m regressions. Each asserts the estimate is *exact* — a budget
equal to the real allocation must admit the document and one byte less must
reject it — which brackets it from both sides rather than only checking that it
raises:

- `..._covers_the_palette_expansion` — the shipped fixture.
- `..._scales_the_palette_expansion[1,2,4,8]` — that the expansion is
  `3 * channels`. Catches the `max()` defect.
- `..._does_not_expand_indexed_at_other_depths[16,32]` — the depth-8-only branch.
- `..._follows_the_header_for_every_other_mode[...]` — six malformed-but-parseable
  headers, pinning the no-false-positive direction.
- `..._never_exceeds_the_allocation` — the same invariant swept over thirteen
  shipped fixtures x five channel arguments, covering all four depths.
- `..._matches_the_synthesised_paths` — see the review fix below.

And in `test_composite.py`, after #728's two guard tests,
`test_composite_flattened_indexed_is_bounded_by_the_numpy_guard` for the
zero-layer return.

A helper (`_forge`) builds headers no fixture provides — indexed with more than
one stored channel, indexed at a depth where the palette is not applied — with
image data that actually parses, so the estimate is compared against a real
array rather than an assumed one.

**Every historical wrong answer is caught**, verified by swapping the function
body for each:

| variant | new tests failing |
| --- | --- |
| pre-fix (bare header count) | 5 |
| first attempt (`max(header, resolved)`) | 9 |
| without the flat-path handling | 24 |
| this PR | 0 |

## Review fix: the synthesised paths were over-estimated

Copilot review caught that the guard was sized by the stored width
*unconditionally*, while `numpy("mask")` — and `numpy("shape")` on a document
with no transparency — return a synthesised `(h, w, 1)` array without reading
the image data at all. So a budget those requests fit several times over could
still reject them.

Confirmed, and wider than reported: the over-estimate is **pre-existing for
every multi-channel mode** (RGB 3x, CMYK 4x). Sizing indexed by its expanded
width would have added a third case rather than introducing the problem, so it
is fixed for all of them. The branch is now decided before the guard runs;
`check_pixel_size()`'s dimension checks still apply to both, so neither path
escapes the guard by taking the early return.

The coverage hole was in the tests — the sweep only ever called `numpy()` with
no argument. One trap it surfaced, now recorded in its docstring: `numpy()` with
a channel argument returns a **view**, so `numpy("color")` on
`4x4_8bit_rgba.psd` hands back 192 bytes of a 256-byte buffer. Comparing against
the view's `nbytes` asserts the guard is too tight when it is correct, so the
sweep compares against the buffer actually allocated.

## Verification

- Full suite: 1848 passed, 27 xfailed, 2 xpassed. `ruff check`,
  `ruff format --check`, `mypy` and the pre-commit hooks clean. Sphinx builds
  with only the pre-existing `List` ambiguity warning.
- **All 284 fixtures through `numpy()`, before and after — byte-identical**
  (outcome and SHA-256 of the array). The guard only returns or raises, so this
  was really checking the new `EXPECTED_CHANNELS[...]` subscript against a
  corpus-wide `KeyError`; that is unreachable by construction too, since
  `FileHeader.color_mode` is validated `in_(ColorMode)` and all eight members
  are keys of the table.

## What the estimate still does not bound

Stated in the docstring and the changelog rather than left implied, since the
first draft overclaimed:

- **The transient peak.** `_parse_array()` holds the raw bytes and two float32
  arrays at once, and `_remove_background()` adds several more, so the true
  high-water mark is a small multiple of this for *every* mode. That is the
  pre-existing shape of `check_pixel_size()`'s estimate — it measures the
  returned array by construction — not anything a colour mode causes.
- **Depth.** The estimate carries no depth term, so a 1-bit document
  under-counts eightfold: `decompress()` computes `width * height * max(1,
  depth // 8)`, i.e. `w*h` bytes for depth 1, and `np.unpackbits` turns each
  byte into eight values. Measured 8.0x at widths 4, 64 and 1000, and on
  grayscale and RGB as well as bitmap — so it is a property of *depth*, not of
  `ColorMode.BITMAP`. Filed as #737 rather than folded in: the fix is a depth
  term rather than a channel count, and it wants its own sweep of the depth-1
  paths including `pil_io`.

## Amends two unreleased 1.19.0 entries

Neither has shipped, so both are corrected in place rather than left
contradicting this one:

- #728's entry closed by saying `numpy()`'s check "is still header-based and so
  still under-counts an indexed canvas — tracked separately in #732".
- #734's duotone caveat said the single-channel
  `Hue`/`Saturation`/`Color`/`Luminosity` crash had no issue yet. It does now:
  #735 — the reference gap raised on that PR's review thread, where I said it
  could be added once one was filed.

## Also found, filed, not touched here

- #737 — the depth gap above.
- #738 — `numpy()` raises `ValueError: assignment destination is read-only` on a
  32-bit RGB document with a transparency channel. `_parse_array()` returns a
  read-only `np.frombuffer` view at depth 32 and a copy at every other depth, and
  `_remove_background()` writes into it in place. Depth 8 and 16 escape only
  because `.astype()` copies. Photoshop writes 32-bit RGB with transparency, and
  no fixture combines the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
