### PR TITLE
fix: make composite_pil()'s declared mode and pixel array agree

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,9 +28,11 @@ Changelog
   packed into the array -- it is handed to ``post_process()``, which still
   carries it for CMYK by converting to RGB first. So ``force=True`` on a CMYK
   document now returns the same ``"RGBA"`` that ``force=False`` always did.
-  Bitmap results carry no alpha in either mode, ``post_process()`` applying it
-  only to ``"RGB"`` and ``"L"``. Lab results carry none either, though for an
-  unrelated reason: a Lab document with an ICC profile raises before it gets
+  Bitmap results carry no alpha in either mode: ``post_process()`` applies it
+  only to ``"RGB"`` and ``"L"``, and the ICC conversion that gets CMYK there
+  cannot reach a 1-bit image -- little-cms builds no transform for one, so the
+  profile is skipped and the mode stays ``"1"``. Lab results carry none either,
+  for a third reason: a Lab document with an ICC profile raises before it gets
   that far -- #740.
 
   A bitmap document came back **garbled in both modes**.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,30 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Return a coherent image from ``PSDImage.composite(force=True)`` for
+  every colour mode. ``composite_pil()`` declared the PIL mode and built the
+  array separately, and the two could disagree in two ways (#729):
+
+  A multichannel document came back **garbled**. Its colour array has one plane
+  per spot channel, and the narrowing to the single plane PIL can hold was keyed
+  on the mode and ran *after* alpha had been appended -- by which point the mode
+  was ``"LA"`` and no longer matched, so it never fired. ``Image.fromarray()``
+  does not reject a four-plane array declared as two: it reads two bytes out of
+  every four, and the planes that came back corresponded to nothing in the file.
+  The narrowing now happens before alpha is appended, and the dropped channels
+  are announced with a warning instead of being lost silently. Use
+  :py:func:`psd_tools.composite.composite` to keep every channel.
+
+  Bitmap, CMYK and Lab documents **raised**. ``"A"`` was appended to the mode
+  whether or not PIL has an alpha variant of it, so those asked
+  ``Image.fromarray()`` for ``"1A"``, ``"CMYKA"`` and ``"LABA"`` and got
+  ``ValueError: unrecognized image mode`` or ``TypeError: Cannot handle this
+  data type``. They now come back without alpha rather than not at all. Only
+  ``"L"`` and ``"RGB"`` have alpha variants in PIL, which is the rule
+  ``get_pil_mode(alpha=True)`` already applied.
+
+  Documents composited without ``force`` are unaffected -- every one of the 284
+  fixtures renders bitwise identically.
 - [fix] Correct pass-through group compositing when the group opacity is below
   255. The group's contribution was blended against the backdrop twice, so a
   partially transparent backdrop bled its colour into the result and the output

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,17 +27,22 @@ Changelog
   ``"RGB"`` have an alpha variant, so for the others the alpha is no longer
   packed into the array -- it is handed to ``post_process()``, which still
   carries it for CMYK by converting to RGB first. So ``force=True`` on a CMYK
-  document now returns the same ``"RGBA"`` that ``force=False`` always did;
-  bitmap and Lab results carry no alpha either way.
+  document now returns the same ``"RGBA"`` that ``force=False`` always did.
+  Bitmap results carry no alpha in either mode, ``post_process()`` applying it
+  only to ``"RGB"`` and ``"L"``. Lab results carry none either, though for an
+  unrelated reason: a Lab document with an ICC profile raises before it gets
+  that far -- #740.
 
   A bitmap document came back **garbled in both modes**.
   ``Image.fromarray(uint8, "1")`` does not mean "these bytes, as bilevel": PIL
   reads the raw mode literally at one bit per pixel, consuming one byte per
   eight columns and expanding its bits across the row, so a 4x4 document
   returned the bits of its first four bytes. The plane is now built as ``"L"``,
-  where a byte is a pixel, and reduced afterwards. This also removes the only
-  use in the compositor of the ``mode`` parameter of ``Image.fromarray()``,
-  which Pillow deprecated and removes in Pillow 13.
+  where a byte is a pixel, and reduced afterwards. That was also the
+  compositor's only ``Image.fromarray()`` call whose ``mode`` reinterprets the
+  array's data type -- the use Pillow deprecated and removes in Pillow 13 --
+  so it no longer warns. Passing ``mode`` where it matches the dtype, as the
+  other colour modes do, is unaffected.
 
   Of the 284 fixtures outside ``third-party-psds``, rendered in both modes:
   every ``force=False`` render is bitwise identical except the bitmap one, and

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,9 +4,10 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
-- [fix] Return a coherent image from ``PSDImage.composite(force=True)`` for
-  every colour mode. ``composite_pil()`` declared the PIL mode and built the
-  array separately, and the two could disagree in two ways (#729):
+- [fix] Stop ``composite_pil()`` declaring a PIL mode that its pixel array does
+  not match. The mode and the array were chosen separately, and they could
+  disagree in three ways -- two of which produced pixels that corresponded to
+  nothing in the file, and one of which raised (#729):
 
   A multichannel document came back **garbled**. Its colour array has one plane
   per spot channel, and the narrowing to the single plane PIL can hold was keyed
@@ -18,16 +19,31 @@ Changelog
   are announced with a warning instead of being lost silently. Use
   :py:func:`psd_tools.composite.composite` to keep every channel.
 
-  Bitmap, CMYK and Lab documents **raised**. ``"A"`` was appended to the mode
-  whether or not PIL has an alpha variant of it, so those asked
-  ``Image.fromarray()`` for ``"1A"``, ``"CMYKA"`` and ``"LABA"`` and got
+  Under ``force``, bitmap, CMYK and Lab documents **raised**. ``"A"`` was
+  appended to the mode whether or not an alpha variant of it exists, so those
+  asked ``Image.fromarray()`` for ``"1A"``, ``"CMYKA"`` and ``"LABA"`` and got
   ``ValueError: unrecognized image mode`` or ``TypeError: Cannot handle this
-  data type``. They now come back without alpha rather than not at all. Only
-  ``"L"`` and ``"RGB"`` have alpha variants in PIL, which is the rule
-  ``get_pil_mode(alpha=True)`` already applied.
+  data type``. Of the modes this function can produce, only ``"L"`` and
+  ``"RGB"`` have an alpha variant, so for the others the alpha is no longer
+  packed into the array -- it is handed to ``post_process()``, which still
+  carries it for CMYK by converting to RGB first. So ``force=True`` on a CMYK
+  document now returns the same ``"RGBA"`` that ``force=False`` always did;
+  bitmap and Lab results carry no alpha either way.
 
-  Documents composited without ``force`` are unaffected -- every one of the 284
-  fixtures renders bitwise identically.
+  A bitmap document came back **garbled in both modes**.
+  ``Image.fromarray(uint8, "1")`` does not mean "these bytes, as bilevel": PIL
+  reads the raw mode literally at one bit per pixel, consuming one byte per
+  eight columns and expanding its bits across the row, so a 4x4 document
+  returned the bits of its first four bytes. The plane is now built as ``"L"``,
+  where a byte is a pixel, and reduced afterwards. This also removes the only
+  use in the compositor of the ``mode`` parameter of ``Image.fromarray()``,
+  which Pillow deprecated and removes in Pillow 13.
+
+  Of the 284 fixtures outside ``third-party-psds``, rendered in both modes:
+  every ``force=False`` render is bitwise identical except the bitmap one, and
+  under ``force`` seventeen renders that previously raised now return an image,
+  while exactly one changes from one image to another -- the garbled
+  multichannel document.
 - [fix] Correct pass-through group compositing when the group opacity is below
   255. The group's contribution was blended against the backdrop twice, so a
   partially transparent backdrop bled its colour into the result and the output

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -140,7 +140,10 @@ def composite_pil(
           ``"CMYKA"`` or ``"LABA"`` to return it in. For the rest it is offered
           to :py:func:`psd_tools.api.pil_io.post_process` instead, which
           carries it for CMYK by converting to RGB first when an ICC profile is
-          applied. Bitmap and Lab results carry no alpha either way.
+          applied. Bitmap results carry no alpha either way -- ``post_process()``
+          applies it only to ``"RGB"`` and ``"L"``. Nor do Lab results, but for
+          a separate reason: a Lab document carrying an ICC profile raises
+          inside ``_apply_icc()`` before reaching that point (#740).
     """
     UNSUPPORTED_MODES = {
         ColorMode.DUOTONE,

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -135,10 +135,12 @@ def composite_pil(
           multichannel mode, so only the first spot channel survives -- a
           warning says so when it happens; use
           :py:func:`psd_tools.composite.composite` to keep every channel.
-        - The result carries alpha only in the modes PIL has an alpha variant
-          of, ``"L"`` and ``"RGB"``. Bitmap, CMYK and Lab come back without it
-          even under ``force``, there being no ``"1A"``, ``"CMYKA"`` or
-          ``"LABA"`` to return them in.
+        - Alpha is packed into the array only for the two reachable modes that
+          have an alpha variant, ``"L"`` and ``"RGB"``; there is no ``"1A"``,
+          ``"CMYKA"`` or ``"LABA"`` to return it in. For the rest it is offered
+          to :py:func:`psd_tools.api.pil_io.post_process` instead, which
+          carries it for CMYK by converting to RGB first when an ICC profile is
+          applied. Bitmap and Lab results carry no alpha either way.
     """
     UNSUPPORTED_MODES = {
         ColorMode.DUOTONE,
@@ -189,13 +191,15 @@ def composite_pil(
     uniform_alpha = _uniform_alpha(backdrop_alpha)
     has_opaque_backdrop = uniform_alpha is not None and uniform_alpha >= 1.0
     skip_alpha = not force and (delay_alpha_application or has_opaque_backdrop)
-    # PIL only has alpha variants of "L" and "RGB" -- the same rule
-    # get_pil_mode(alpha=True) applies. Appending it regardless built modes PIL
-    # has never heard of, so `force=True` raised outright on a bitmap ("1A"),
-    # CMYK ("CMYKA") or Lab ("LABA") document. Dropping the alpha instead
-    # returns the colour that was asked for rather than nothing at all.
+    # Of the modes reachable here -- "1", "L", "RGB", "CMYK" and "LAB" -- only
+    # "L" and "RGB" have an alpha variant. Appending "A" regardless built modes
+    # PIL has never heard of, so `force=True` raised outright on a bitmap
+    # ("1A"), CMYK ("CMYKA") or Lab ("LABA") document. Leaving it off the array
+    # returns the colour that was asked for rather than nothing at all, and for
+    # the modes `post_process()` can convert it still arrives, via `putalpha`
+    # below.
     if not skip_alpha and mode not in ("L", "RGB"):
-        logger.debug("PIL has no alpha variant of %r; returning it without.", mode)
+        logger.debug("PIL has no alpha variant of %r; not packing it inline.", mode)
         skip_alpha = True
     logger.debug("Skipping alpha: %s", skip_alpha)
     if not skip_alpha:
@@ -206,9 +210,23 @@ def composite_pil(
         color = color[:, :, 0]
     if color.shape[0] == 0 or color.shape[1] == 0:
         return None
-    image = Image.fromarray((255 * color).astype(np.uint8), mode)
+    pixels = (255 * color).astype(np.uint8)
+    if mode == "1":
+        # `fromarray(uint8, "1")` does not mean "these bytes, as bilevel". PIL
+        # takes the raw mode literally at one bit per pixel, so it consumes one
+        # byte per eight columns and expands its bits across the row -- a 4x4
+        # document came back as the bits of its first four bytes. Build the
+        # plane in "L", where a byte is a pixel, and reduce it afterwards.
+        image = Image.fromarray(pixels, "L").convert("1", dither=Image.Dither.NONE)
+    else:
+        image = Image.fromarray(pixels, mode)
     alpha_as_image = None
-    if not force and delay_alpha_application:
+    # Whenever the alpha did not go into the array, offer it to post_process()
+    # instead -- it converts CMYK to RGB before applying it, so `force=True` on
+    # a CMYK document keeps the alpha that `force=False` has always returned.
+    # Gating this on `not force` dropped it on exactly the paths the branch
+    # above had just diverted here.
+    if skip_alpha and delay_alpha_application:
         alpha_as_image = Image.fromarray(
             (255 * np.squeeze(alpha, axis=2)).astype(np.uint8), "L"
         )

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -132,8 +132,13 @@ def composite_pil(
         - LAB and Duotone color modes have limited blending support
         - Alpha channel handling varies by color mode
         - Multichannel documents come back single-channel. PIL has no
-          multichannel mode, so only the first spot channel survives; use
+          multichannel mode, so only the first spot channel survives -- a
+          warning says so when it happens; use
           :py:func:`psd_tools.composite.composite` to keep every channel.
+        - The result carries alpha only in the modes PIL has an alpha variant
+          of, ``"L"`` and ``"RGB"``. Bitmap, CMYK and Lab come back without it
+          even under ``force``, there being no ``"1A"``, ``"CMYKA"`` or
+          ``"LABA"`` to return them in.
     """
     UNSUPPORTED_MODES = {
         ColorMode.DUOTONE,
@@ -159,12 +164,39 @@ def composite_pil(
     mode = pil_io.get_pil_mode(color_mode)
     if mode == "P":
         mode = "RGB"
+    # Narrow the array to what the mode can hold *before* alpha is appended.
+    # A multichannel document carries one plane per spot channel and PIL has no
+    # mode for that. The narrowing used to happen after the concatenation and
+    # was keyed on `mode`, so once alpha had turned "L" into "LA" it stopped
+    # firing -- and PIL does not reject a four-plane array declared as two, it
+    # reads two bytes out of every four and returns planes that correspond to
+    # nothing.
+    pil_channels = pil_io.get_pil_channels(mode)
+    if color.shape[2] > pil_channels:
+        logger.warning(
+            "%s composited to %d channels; PIL mode %r holds %d. Keeping the "
+            "first and dropping the rest -- use psd_tools.composite.composite() "
+            "to keep every channel.",
+            color_mode,
+            color.shape[2],
+            mode,
+            pil_channels,
+        )
+        color = color[:, :, :pil_channels]
     # Skip alpha when the color mode requires deferred alpha handling, or
     # when the backdrop is fully opaque (the result is guaranteed opaque).
     delay_alpha_application = color_mode not in (ColorMode.GRAYSCALE, ColorMode.RGB)
     uniform_alpha = _uniform_alpha(backdrop_alpha)
     has_opaque_backdrop = uniform_alpha is not None and uniform_alpha >= 1.0
     skip_alpha = not force and (delay_alpha_application or has_opaque_backdrop)
+    # PIL only has alpha variants of "L" and "RGB" -- the same rule
+    # get_pil_mode(alpha=True) applies. Appending it regardless built modes PIL
+    # has never heard of, so `force=True` raised outright on a bitmap ("1A"),
+    # CMYK ("CMYKA") or Lab ("LABA") document. Dropping the alpha instead
+    # returns the colour that was asked for rather than nothing at all.
+    if not skip_alpha and mode not in ("L", "RGB"):
+        logger.debug("PIL has no alpha variant of %r; returning it without.", mode)
+        skip_alpha = True
     logger.debug("Skipping alpha: %s", skip_alpha)
     if not skip_alpha:
         color = np.concatenate((color, alpha), 2)

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -140,10 +140,13 @@ def composite_pil(
           ``"CMYKA"`` or ``"LABA"`` to return it in. For the rest it is offered
           to :py:func:`psd_tools.api.pil_io.post_process` instead, which
           carries it for CMYK by converting to RGB first when an ICC profile is
-          applied. Bitmap results carry no alpha either way -- ``post_process()``
-          applies it only to ``"RGB"`` and ``"L"``. Nor do Lab results, but for
-          a separate reason: a Lab document carrying an ICC profile raises
-          inside ``_apply_icc()`` before reaching that point (#740).
+          applied. Bitmap results carry no alpha either way: ``post_process()``
+          applies it only to ``"RGB"`` and ``"L"``, and the ICC conversion that
+          reaches those for CMYK cannot help here -- little-cms builds no
+          transform for a 1-bit image, so ``_apply_icc()`` logs the failure and
+          returns the image still in ``"1"``. Nor do Lab results, for a third
+          reason: a Lab document carrying an ICC profile raises inside
+          ``_apply_icc()`` before reaching that point (#740).
     """
     UNSUPPORTED_MODES = {
         ColorMode.DUOTONE,

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -683,6 +683,111 @@ def test_composite_pil_layered_multichannel_truncates_like_the_layerless_one() -
     assert _mse(np.asarray(image)[:, :, 0] / 255.0, color[:, :, 0]) <= 1e-4
 
 
+def test_composite_pil_multichannel_force_keeps_the_spot_channel_intact() -> None:
+    """``force=True`` returned planes that corresponded to nothing (#729).
+
+    ``get_pil_mode(MULTICHANNEL)`` is ``"L"`` and multichannel defers its alpha,
+    so ``force=True`` made ``skip_alpha`` false, concatenated alpha onto the
+    *three*-channel colour array and set the mode to ``"LA"``. The narrowing to
+    one channel was keyed on ``mode`` and ran afterwards, so by then ``"LA"`` no
+    longer matched and it never fired. ``Image.fromarray()`` does not reject a
+    four-plane array declared as two -- it reads two bytes out of every four:
+
+        plane 0 was [48, 42, 86, 118] -- spot0[0], spot2[0], spot0[1], spot2[1]
+        plane 1 was [179, 255, 199, 255] -- spot1[0], alpha[0], spot1[1], ...
+
+    Asserted bitwise against the NumPy entry point rather than by shape or MSE,
+    because the failure was interleaved bytes rather than a narrower result: a
+    shape assertion passed throughout, and the old planes are close enough in
+    range that a loose MSE bound could too.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
+    assert psd.channels == 3
+    truth, _, truth_alpha = composite(psd, force=True)
+    assert truth.shape[2] == 3  # every spot channel, on the numpy path
+
+    image = psd.composite(ignore_preview=True, force=True, apply_icc=False)
+    assert isinstance(image, Image.Image)
+    assert image.mode == "LA"
+    planes = np.asarray(image)
+    expected_color = (255 * truth[:, :, 0]).astype(np.uint8)
+    expected_alpha = (255 * truth_alpha[:, :, 0]).astype(np.uint8)
+    assert np.array_equal(planes[:, :, 0], expected_color)
+    assert np.array_equal(planes[:, :, 1], expected_alpha)
+
+
+def test_composite_pil_multichannel_force_agrees_with_no_force() -> None:
+    """The two paths differ in how alpha is applied, not in what the colour is.
+
+    Without ``force`` the alpha is deferred and applied by ``post_process()``;
+    with it, the alpha is concatenated up front. Either way the visible plane is
+    the first spot channel, and before #729 only one of them was.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
+    forced = psd.composite(ignore_preview=True, force=True, apply_icc=False)
+    lazy = psd.composite(ignore_preview=True, force=False, apply_icc=False)
+    assert isinstance(forced, Image.Image) and isinstance(lazy, Image.Image)
+    assert forced.mode == lazy.mode == "LA"
+    assert np.array_equal(np.asarray(forced), np.asarray(lazy))
+
+
+def test_composite_pil_warns_when_it_drops_channels(caplog: Any) -> None:
+    """The truncation is announced rather than silent (#729).
+
+    ``UNSUPPORTED_MODES`` already warns for Duotone and Lab, whose *blending* is
+    approximate. This is a different loss -- the blend is fine, PIL simply has
+    no mode wide enough to carry the result -- so it is warned about where it
+    happens and says what was dropped, rather than being folded into a message
+    about blending colour spaces.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
+    with caplog.at_level(logging.WARNING, logger="psd_tools.composite.composite"):
+        psd.composite(ignore_preview=True, apply_icc=False)
+    assert any(
+        "composited to 3 channels" in record.message and "holds 1" in record.message
+        for record in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+@pytest.mark.parametrize(
+    ("colormode", "depth", "mode"),
+    [
+        ("bitmap", 1, "1"),  # PIL has no "1A"
+        ("cmyk", 8, "CMYK"),  # nor "CMYKA"
+        ("lab", 8, "LAB"),  # nor "LABA"
+        ("duotone", 8, "LA"),
+        ("grayscale", 8, "LA"),
+        ("index_color", 8, "RGBA"),
+        ("rgb", 8, "RGBA"),
+        ("rgba", 8, "RGBA"),
+        ("multichannel", 16, "LA"),
+    ],
+)
+def test_composite_pil_force_covers_every_colour_mode(
+    colormode: str, depth: int, mode: str
+) -> None:
+    """``force=True`` at the PIL exit, which nothing covered before (#729).
+
+    ``test_composite_pil`` sweeps the colour modes but never passes ``force``,
+    which is why three of these raised on the shipped fixtures without anyone
+    noticing: the mode had ``"A"`` appended whether or not PIL has an alpha
+    variant of it, so a bitmap document asked for ``"1A"``, CMYK for ``"CMYKA"``
+    and Lab for ``"LABA"``::
+
+        ValueError: unrecognized image mode
+        TypeError: Cannot handle this data type: (1, 1, 5), |u1
+
+    Those three now come back without alpha rather than not at all, which is the
+    same trade the rest of this module makes -- a degraded result beats an
+    exception the caller has to special-case.
+    """
+    filename = "colormodes/4x4_%gbit_%s.psd" % (depth, colormode)
+    psd = PSDImage.open(full_name(filename))
+    image = psd.composite(ignore_preview=True, force=True, apply_icc=False)
+    assert isinstance(image, Image.Image)
+    assert image.mode == mode
+
+
 def test_composite_layer_filter() -> None:
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgba.psd"))
     # Check layer_filter.

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -788,6 +788,64 @@ def test_composite_pil_force_covers_every_colour_mode(
     assert image.mode == mode
 
 
+@pytest.mark.parametrize("colormode", ["bitmap", "lab", "cmyk"])
+def test_composite_pil_force_pixels_match_the_numpy_path(colormode: str) -> None:
+    """The three modes that carry no alpha, compared bitwise rather than by mode.
+
+    Review of this change caught that asserting only ``image.mode`` was not
+    enough -- twice over. It is what let #729 survive for multichannel, and the
+    first version of the fix above turned bitmap's *raise* into silently wrong
+    pixels, which the mode assertion happily accepted:
+    ``Image.fromarray(uint8, "1")`` does not mean "these bytes, as bilevel". PIL
+    reads the raw mode literally at one bit per pixel, so a 4x4 document came
+    back as the bits of its first four bytes::
+
+        composited [[1,1,0,0],[0,0,0,0],[1,1,1,1],[0,0,0,0]]
+        returned   [[1,1,1,1],[1,1,1,1],[0,0,0,0],[0,0,0,0]]
+
+    Since these three modes get no alpha packed in, the returned planes are
+    directly comparable to the NumPy entry point's colour.
+    """
+    depth = 1 if colormode == "bitmap" else 8
+    psd = PSDImage.open(full_name("colormodes/4x4_%gbit_%s.psd" % (depth, colormode)))
+    image = psd.composite(ignore_preview=True, force=True, apply_icc=False)
+    assert isinstance(image, Image.Image)
+    color, _, _ = composite(psd, force=True)
+
+    expected = (255 * color).astype(np.uint8)
+    if colormode == "bitmap":
+        expected = (expected > 127).astype(np.uint8)  # PIL reports "1" as 0/1
+    if image.mode == "CMYK":
+        # post_process() inverts CMYK on the way out; compare on that footing.
+        expected = 255 - expected
+    actual = np.asarray(image)
+    if actual.ndim == 2:
+        actual = actual[:, :, None]
+    assert np.array_equal(actual, expected)
+
+
+def test_composite_pil_force_keeps_cmyk_alpha_reachable() -> None:
+    """``force=True`` must not drop alpha that ``force=False`` returns.
+
+    PIL has no ``"CMYKA"``, so the alpha cannot be packed into the array -- but
+    ``post_process()`` converts CMYK to RGB when an ICC profile is applied and
+    then calls ``putalpha``, which is how ``force=False`` has always returned
+    ``"RGBA"`` here. The first version of this fix diverted ``force=True`` away
+    from packing the alpha inline while that hand-off was still gated on ``not
+    force``, so the plane was dropped on exactly the paths it had just been
+    diverted from. Raised by review.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
+    viewport = (0, 0, 8, 8)  # wider than the document, so some pixels are bare
+    lazy = psd.composite(ignore_preview=True, viewport=viewport, force=False)
+    forced = psd.composite(ignore_preview=True, viewport=viewport, force=True)
+    assert isinstance(lazy, Image.Image) and isinstance(forced, Image.Image)
+    assert lazy.mode == forced.mode == "RGBA"
+    lazy_alpha = np.asarray(lazy)[:, :, 3]
+    assert set(np.unique(lazy_alpha).tolist()) == {0, 255}  # bare px are bare
+    assert np.array_equal(np.asarray(forced)[:, :, 3], lazy_alpha)
+
+
 def test_composite_layer_filter() -> None:
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgba.psd"))
     # Check layer_filter.


### PR DESCRIPTION
Closes #729.

## The change

`composite_pil()` chose the PIL mode and built the pixel array separately, and
the two could disagree. Three ways, as it turned out — the issue reported one:

| | symptom | modes |
| --- | --- | --- |
| 1 | wrong pixels, silently | multichannel under `force=True` |
| 2 | raises | bitmap, CMYK, Lab under `force=True` |
| 3 | wrong pixels, silently | bitmap, **both** modes |

All three are now fixed, and the mode is derived from what the array actually
contains.

## 1. Multichannel came back garbled — the reported bug

Its colour array carries one plane per spot channel. The narrowing to the single
plane PIL can hold was keyed on `mode` and ran *after* the alpha concatenation,
so once that had turned `"L"` into `"LA"` it no longer matched and never fired.
`Image.fromarray()` does not reject a four-plane array declared as two — it
reads two bytes out of every four:

```
spot0 row0 = [48, 86, 138, 198]     plane 0 was [48,  42, 86, 118]
spot1 row0 = [179, 199, 207, 162]   plane 1 was [179, 255, 199, 255]
spot2 row0 = [42, 118, 197, 218]
alpha row0 = [255, 255, 255, 255]
```

Plane 0 is spot0[0], spot2[0], spot0[1], spot2[1] — interleaved bytes, matching
nothing in the file. The narrowing now runs *before* alpha is appended, and the
dropped channels get a warning naming how many were lost.

## 2. `force=True` raised on bitmap, CMYK and Lab

`"A"` was appended whether or not an alpha variant of the mode exists, so those
asked `Image.fromarray()` for `"1A"`, `"CMYKA"` and `"LABA"`:

```
ValueError: unrecognized image mode
TypeError: Cannot handle this data type: (1, 1, 5), |u1
```

Nothing caught this because `test_composite_pil` sweeps the colour modes but
never passes `force`. Of the modes this function can produce, only `"L"` and
`"RGB"` have an alpha variant, so for the rest the alpha is no longer packed
into the array — it is handed to `post_process()`, which still carries it for
CMYK by converting to RGB first. `force=True` on a CMYK document therefore
returns the same `"RGBA"` that `force=False` always did.

## 3. Bitmap was garbled in both modes — review catching my own fix

The first commit replaced bitmap's raise with `Image.fromarray(uint8, "1")`,
which produces **wrong pixels** — the same defect class as #1. PIL takes the raw
mode literally at one bit per pixel, consuming one byte per eight columns and
expanding its bits across the row:

```
composited [[1,1,0,0],[0,0,0,0],[1,1,1,1],[0,0,0,0]]
returned   [[1,1,1,1],[1,1,1,1],[0,0,0,0],[0,0,0,0]]
```

My new mode-only assertion accepted it, which is precisely the test weakness
this PR criticises elsewhere. The plane is now built as `"L"`, where a byte is a
pixel, and reduced with `convert("1", dither=NONE)`.

This one is **pre-existing for `force=False` as well**, so bitmap documents have
been rendering wrong all along.

### It also defuses a Pillow 13 break

That was the compositor's only `Image.fromarray()` call whose `mode`
*reinterprets the array's data type* — the narrower thing Pillow deprecates and
**removes in Pillow 13 on 2026-10-15**. Verified on Pillow 12.3.0:
`fromarray(uint8, m)` warns for `m="1"` and not for `"L"`, `"RGB"`, `"CMYK"` or
`"LAB"`, so passing `mode` where it matches the dtype (as the other modes do) is
unaffected. It was the only line in the suite emitting that warning, and
`pyproject.toml` has `Pillow>=10.3.0` with no upper bound, so it would have
become a hard error. `pil_io.py:292` uses `frombytes` with a genuine 1-bit raw
mode and is unaffected.

## Also surfaced, filed not fixed: #740

Copilot review argued a Lab document should be able to come back `"RGBA"`, since
`post_process()` applies alpha after `_apply_icc()` converts to RGB. Chasing
that exposed a separate pre-existing bug: **a Lab document with an ICC profile
raises**.

`_apply_icc()` detects alpha with `"A" not in image.mode` (`pil_io.py:335-338`),
and `"A" in "LAB"` is `True` — so it attempts `image.convert("LB")` and gets
`ValueError: conversion from LAB to RGB not supported`, which the
`except ImageCms.PyCMSError` below does not catch. None of the three Lab
fixtures carries an ICC profile, which is why nothing caught it; grafting one on
reproduces it on `main` too. Filed as #740 — different module, different root
cause, and fixing it would change what a Lab result returns.

So the docstring's claim that a Lab result carries no alpha is true, but by
accident rather than design, and now says so.

## Scope, measured

284 fixtures (everything outside `third-party-psds`) × both force modes,
hashing `np.asarray(img)`:

- **`force=False`: bitwise identical on 283 of 284.** The exception is the
  bitmap fixture, per #3 above.
- **`force=True`: 18 of 284 change.** 17 are a raise becoming an image — so the
  crashing half is by far the more common one in this corpus — and exactly one
  is image-to-image: the garbled multichannel document, now matching the NumPy
  path bitwise.

## Tests

Ten new items, **all verified to fail against pre-#729 `main`**:

- `..._multichannel_force_keeps_the_spot_channel_intact` — asserted **bitwise**
  against `composite()`, not by shape or MSE. Deliberately: a shape assertion
  passed throughout the bug's lifetime, and the corrupt planes sit close enough
  in range that a loose MSE bound could too.
- `..._multichannel_force_agrees_with_no_force`
- `..._warns_when_it_drops_channels`
- `..._force_covers_every_colour_mode[9 modes]` — the sweep `test_composite_pil`
  never did with `force`.
- `..._force_pixels_match_the_numpy_path[bitmap, lab, cmyk]` — added after
  review, because the sweep's mode-only assertion had accepted garbage. Handles
  `post_process()`'s CMYK inversion.
- `..._force_keeps_cmyk_alpha_reachable` — added after review; see below.

## What review caught in the first commit

Recording it, since both were real and one was serious:

1. **The bitmap garbling above** — I replaced a crash with wrong pixels and
   pinned it as correct.
2. **`force=True` silently dropped CMYK alpha that `force=False` returns.**
   Diverting `force=True` away from packing alpha inline left `alpha_as_image`
   gated on `not force`, so the plane was dropped on exactly the paths just
   diverted there. The gate is now `skip_alpha and delay_alpha_application` —
   provably equivalent for `force=False` (there `skip_alpha` is true whenever
   `delay_alpha_application` is), and symmetric under `force`.

Three claims I had written were also wrong and are corrected: "Only `L` and
`RGB` have alpha variants in PIL" (`PA`, `La` and `RGBa` all exist — it is true
only of the modes reachable here); the appeal to `get_pil_mode(alpha=True)` as
"the same rule" (it applies pre-remap, so it disagrees for indexed); and the
fixture count (284 excludes `third-party-psds`, 285 includes it).

## Two deliberate deviations

**Not added to `UNSUPPORTED_MODES`,** which the issue suggested. That warning
says "Unsupported blending color space", and multichannel's *blending* is fine —
the loss is that PIL has no mode wide enough for the result. So it is warned
about where it happens, naming what was dropped. Happy to change if you'd rather
keep it uniform with Duotone and Lab.

**Not fixed: an array *narrower* than its PIL mode** still reaches
`Image.fromarray` mismatched and raises — a forged 1-channel RGB header gives
`ValueError: buffer is not large enough`. Pre-existing and unchanged here. What
to widen it *with* is exactly the open question in #722 (single-channel widening
replicates instead of converting), so it belongs there. The commit message and
changelog are scoped so neither claims "every colour mode".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
