### PR TITLE
fix: size colors from the document rather than from a per-mode table (#730, #731)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,29 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Let a per-channel colour be set on a multichannel document.
+  :py:attr:`~psd_tools.api.psd_image.PSDImage.background_color` validated the
+  sequence against a table whose multichannel entry is 64 -- the format's
+  maximum number of channels, not any file's own count -- so every sequence was
+  rejected and only a scalar could be set. Since ``background_color`` is the
+  backdrop ``save()`` composites the merged preview against, a multichannel
+  document had no way to be given a per-channel one.
+  ``PSDImage.new("MULTICHANNEL", ...)`` was unsatisfiable for the same reason:
+  it builds a one-channel document while the validator demanded 64
+  (#731, #742).
+
+- [fix] Size a fill from the document rather than from its descriptor. A solid
+  colour, gradient or stroke takes its colour from a descriptor whose colour
+  class is independent of the document's colour mode, and the width that came
+  back was the descriptor's. Where that was neither one channel nor the
+  document's own count the compositor's width assertion fired, which is what an
+  RGB, CMYK or Lab descriptor did on a bitmap, duotone or multichannel
+  document, a CMYK one on an indexed or Lab document, and a Lab one on a
+  grayscale or CMYK document. An HSB descriptor was worse -- it raised
+  ``ValueError`` on every mode but RGB and CMYK. Every descriptor class now
+  converts to the document's width. No colour that already rendered changed
+  value (#730, #742).
+
 - [fix] Stop ``composite_pil()`` declaring a PIL mode that its pixel array does
   not match. The mode and the array were chosen separately, and they could
   disagree in three ways -- two of which produced pixels that corresponded to

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -65,9 +65,10 @@ from PIL import Image
 from psd_tools.api import adjustments, layers, numpy_io, pil_io
 from psd_tools.api.protocols import PSDProtocol
 from psd_tools.api.utils import (
-    EXPECTED_CHANNELS,
     ColorInput,
+    color_channels,
     denormalize_color,
+    get_color_channels,
     normalize_color,
 )
 from psd_tools.constants import (
@@ -156,11 +157,16 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         # Strip alpha channel(s) from color for background_color since
         # composite() only expects color channels (alpha is separate).
         bg_input: ColorInput = color
-        if isinstance(color, Sequence):
-            expected = EXPECTED_CHANNELS.get(header.color_mode)
-            if expected is not None and len(color) > expected:
-                bg_input = tuple(color[:expected])
-        bg_color = normalize_color(bg_input, depth, header.color_mode)
+        # Read from the header rather than from EXPECTED_CHANNELS: that table
+        # reports 64 for a multichannel document -- the format's maximum, not
+        # this file's count -- so the strip below could never fire for one and
+        # the validator then rejected the unstripped sequence outright.
+        expected_channels = color_channels(header.color_mode, header.channels)
+        if isinstance(color, Sequence) and len(color) > expected_channels:
+            bg_input = tuple(color[:expected_channels])
+        bg_color = normalize_color(
+            bg_input, depth, header.color_mode, expected_channels
+        )
         fill_color = denormalize_color(color, depth)
         image_data = ImageData.new(header, color=fill_color, **kwargs)
         # TODO: Add default metadata.
@@ -653,7 +659,12 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         value: ColorInput | None,
     ) -> None:
         if value is not None:
-            value = normalize_color(value, self._record.header.depth, self.color_mode)
+            value = normalize_color(
+                value,
+                self._record.header.depth,
+                self.color_mode,
+                get_color_channels(self),
+            )
         if self._background_color != value:
             self._mark_updated()
         self._background_color = value

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -166,15 +166,16 @@ def get_color_channels(psdimage: "PSDProtocol") -> int:
     :func:`has_transparency` and :func:`get_transparency_index` can never fire,
     because ``FileHeader.channels`` is validated to at most 56, and
     :func:`~psd_tools.api.numpy_io.get_image_data` special-cases multichannel
-    before it reaches the table at all. And one is simply wrong:
-    ``_validate_color_input()`` requires a sequence of exactly 64 components, so
-    assigning a sequence to :py:attr:`PSDImage.background_color` on a
-    multichannel document raises. That is a separate bug, filed rather than
-    fixed here -- it takes a bare ``ColorMode`` where this takes a document, and
-    so cannot reach the header at all.
+    before it reaches the table at all. The one that was simply wrong was
+    ``_validate_color_input()``, which required a sequence of exactly 64
+    components and so rejected every per-channel
+    :py:attr:`PSDImage.background_color` on a multichannel document; #731 fixed
+    that by giving it an explicit channel count, supplied by this function or
+    by :func:`color_channels`, rather than by letting it read the table.
 
     So this is for the callers the constant cannot serve: the ones that must
-    *allocate* a canvas as wide as the document's own arrays.
+    *allocate* a canvas as wide as the document's own arrays, or validate a
+    color against one.
 
     Args:
         psdimage: The PSD image protocol object
@@ -186,9 +187,26 @@ def get_color_channels(psdimage: "PSDProtocol") -> int:
         this in a malformed file -- deliberately, so that the compositor's width
         assertion still sees the mismatch.
     """
-    if psdimage.color_mode == ColorMode.MULTICHANNEL:
-        return psdimage.channels
-    return EXPECTED_CHANNELS[psdimage.color_mode]
+    return color_channels(psdimage.color_mode, psdimage.channels)
+
+
+def color_channels(color_mode: ColorMode, channels: int) -> int:
+    """The same rule as :func:`get_color_channels`, for a bare header.
+
+    :py:meth:`PSDImage.new` has to answer this question before a document
+    exists -- it holds only the :py:class:`~psd_tools.psd.header.FileHeader` it
+    has just built -- so the rule lives here rather than inside the
+    document-taking form.
+
+    Args:
+        color_mode: The document's color mode.
+        channels: The header's channel count, alpha included.
+    Returns:
+        The width of the document's color array.
+    """
+    if color_mode == ColorMode.MULTICHANNEL:
+        return channels
+    return EXPECTED_CHANNELS[color_mode]
 
 
 def has_transparency(psdimage: "PSDProtocol") -> bool:
@@ -257,13 +275,24 @@ def get_transparency_index(psdimage: "PSDProtocol") -> int:
 
 
 def _validate_color_input(
-    color: ColorInput, depth: int, color_mode: ColorMode | None = None
+    color: ColorInput,
+    depth: int,
+    color_mode: ColorMode | None = None,
+    channels: int | None = None,
 ) -> int:
     """Validate common preconditions and return max pixel value for *depth*.
 
     Raises :class:`TypeError` for ``bool``, ``str``, or other unsupported
     types.  Raises :class:`ValueError` for unsupported *depth*, empty
     sequences, or wrong number of channels for *color_mode*.
+
+    *channels* overrides the per-mode count :data:`EXPECTED_CHANNELS` would
+    supply. Multichannel is why it exists: that entry is 64, the format's
+    maximum rather than any document's own count, so validating a sequence
+    against it rejects every sequence a caller could sensibly pass. A caller
+    that knows the real width -- from a document via
+    :func:`get_color_channels`, or from a header via :func:`color_channels` --
+    passes it here.
     """
     if isinstance(color, bool):
         raise TypeError(f"Bool color {color!r} is not supported. Use int or float.")
@@ -278,13 +307,17 @@ def _validate_color_input(
     if isinstance(color, Sequence):
         if len(color) == 0:
             raise ValueError("Color sequence must not be empty.")
-        if color_mode is not None:
+        expected: int | None = None
+        if channels is not None:
+            expected = channels
+        elif color_mode is not None:
             expected = EXPECTED_CHANNELS.get(color_mode)
-            if expected is not None and len(color) != expected:
-                raise ValueError(
-                    f"Expected {expected} color channel(s) for {color_mode.name}, "
-                    f"got {len(color)}."
-                )
+        if expected is not None and len(color) != expected:
+            mode_name = color_mode.name if color_mode is not None else "the document"
+            raise ValueError(
+                f"Expected {expected} color channel(s) for {mode_name}, "
+                f"got {len(color)}."
+            )
     return max_val
 
 
@@ -352,6 +385,7 @@ def normalize_color(
     color: ColorInput,
     depth: int,
     color_mode: ColorMode | None = None,
+    channels: int | None = None,
 ) -> float | tuple[float, ...]:
     """Convert *color* to normalized ``[0.0, 1.0]`` float(s).
 
@@ -364,7 +398,7 @@ def normalize_color(
     ``list``, or any :class:`~collections.abc.Sequence`) returns a
     ``tuple[float, ...]``.  Mixed int/float sequences are supported.
     """
-    max_val = _validate_color_input(color, depth, color_mode)
+    max_val = _validate_color_input(color, depth, color_mode, channels)
     if isinstance(color, (int, float)):
         return _normalize_scalar(color, max_val)
     return tuple(_normalize_scalar(c, max_val, i) for i, c in enumerate(color))
@@ -374,6 +408,7 @@ def denormalize_color(
     color: ColorInput,
     depth: int,
     color_mode: ColorMode | None = None,
+    channels: int | None = None,
 ) -> int | tuple[int, ...]:
     """Convert *color* to raw pixel integer(s).
 
@@ -386,7 +421,7 @@ def denormalize_color(
     ``list``, or any :class:`~collections.abc.Sequence`) returns a
     ``tuple[int, ...]``.  Mixed int/float sequences are supported.
     """
-    max_val = _validate_color_input(color, depth, color_mode)
+    max_val = _validate_color_input(color, depth, color_mode, channels)
     if isinstance(color, (int, float)):
         return _denormalize_scalar(color, max_val)
     return tuple(_denormalize_scalar(c, max_val, i) for i, c in enumerate(color))

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -26,6 +26,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# The modes whose color array is a single channel, so a descriptor color has to
+# be reduced to one component to be a legal source for them. Grayscale, bitmap
+# and duotone genuinely are one grayscale channel -- duotone's inks live in the
+# color mode data section and were never a channel count (#733). Multichannel
+# is here for a different reason: its channels are spot inks with no colorimetric relation to RGB, so
+# there is no conversion to N of them -- one channel is the honest answer, and
+# what a single channel means once widened to N is #722's question, not this
+# function's.
+_SINGLE_CHANNEL_MODES = (
+    ColorMode.BITMAP,
+    ColorMode.GRAYSCALE,
+    ColorMode.DUOTONE,
+    ColorMode.MULTICHANNEL,
+)
+
+
+def _from_rgb(color_mode: ColorMode, rgb: tuple[float, ...]) -> tuple[float, ...]:
+    """Convert a canonical RGB triple to *color_mode*'s color array width.
+
+    Every descriptor color class reaches the document through here, so the
+    result is as wide as the document's own arrays rather than as wide as the
+    descriptor happened to be. A fill that is neither one channel nor exactly
+    the document's width trips ``Compositor._assert_source_fits()``, which is
+    what a solid color, gradient or stroke did on a bitmap, duotone,
+    multichannel and (for some classes) indexed, grayscale or Lab document.
+
+    Indexed is deliberately three: its single stored channel expands through
+    the palette, so three is the width its pixel arrays carry.
+    """
+    if color_mode == ColorMode.CMYK:
+        return rgb_to_cmyk(*rgb)
+    if color_mode in _SINGLE_CHANNEL_MODES:
+        return (rgb_to_grayscale(*rgb),)
+    return rgb
+
+
 def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
     """Return color tuple from descriptor.
 
@@ -67,22 +103,16 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
                 float(color_desc[key])
                 for key in (Key.RedFloat, Key.GreenFloat, Key.BlueFloat)
             )
-        if color_mode == ColorMode.CMYK:
-            return rgb_to_cmyk(*rgb)
-        if color_mode == ColorMode.GRAYSCALE:
-            return (rgb_to_grayscale(*rgb),)
-        return rgb
+        return _from_rgb(color_mode, rgb)
 
     def _get_hsb(color_mode: ColorMode, color_desc: Descriptor) -> tuple[float, ...]:
         hue = float(color_desc[Key.Hue]) / 300.0
         saturation = float(color_desc[Key.Saturation]) / 100.0
         brightness = float(color_desc[Key.Brightness]) / 100.0
-        rgb_components = hsb_to_rgb(hue, saturation, brightness)
-        if color_mode == ColorMode.RGB:
-            return rgb_components
-        if color_mode == ColorMode.CMYK:
-            return rgb_to_cmyk(rgb_components[0], rgb_components[1], rgb_components[2])
-        raise ValueError("Unexpected color mode for HSB color %s" % (color_mode))
+        # Every mode but RGB and CMYK used to raise here, which made an HSB
+        # solid color or gradient unrenderable on a grayscale, Lab, indexed,
+        # bitmap, duotone or multichannel document.
+        return _from_rgb(color_mode, hsb_to_rgb(hue, saturation, brightness))
 
     def _get_gray(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
         (gray,) = _get_invert_color(x, (Key.Gray,))
@@ -96,16 +126,20 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         c, m, y, k = _get_invert_color(
             x, (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black)
         )
-        if color_mode in (ColorMode.RGB, ColorMode.GRAYSCALE):
-            r, g, b = cmyk_to_rgb(c, m, y, k)
-        if color_mode == ColorMode.RGB:
-            return (r, g, b)
-        if color_mode == ColorMode.GRAYSCALE:
-            return (rgb_to_grayscale(r, g, b),)
-        return (c, m, y, k)
+        if color_mode == ColorMode.CMYK:
+            return (c, m, y, k)
+        return _from_rgb(color_mode, cmyk_to_rgb(c, m, y, k))
 
     def _get_lab(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
-        return _get_int_color(x, (Key.Luminance, Key.A, Key.B))
+        # This triple is not RGB, and dividing L/a/b by 255 is not a correct
+        # normalization of any of them -- L is 0..100 and a/b are signed. That
+        # is a value bug independent of this one and is left as it stands for
+        # the modes that already reached the compositor, so the reduction below
+        # only decides the *width* for the modes that could not.
+        lab = _get_int_color(x, (Key.Luminance, Key.A, Key.B))
+        if color_mode in (ColorMode.LAB, ColorMode.RGB, ColorMode.INDEXED):
+            return lab
+        return _from_rgb(color_mode, lab)
 
     _COLOR_FUNC = {
         Klass.RGBColor: _get_rgb,
@@ -230,6 +264,12 @@ def draw_pattern_fill(
         int(np.ceil(float(width) / panel.shape[1])),
         1,
     )
+    # Keyed on the *pattern's* mode, not the document's, so this is the one
+    # place a document-derived count would be wrong. It is still broken for a
+    # multichannel-mode pattern, whose entry is 64 and so never splits the
+    # alpha: the real colour count is not recoverable from the parsed pattern
+    # (the stored channel count is a fixed 24 slots), so that needs a sample
+    # rather than a table fix. See #741.
     channels = EXPECTED_CHANNELS.get(pattern.image_mode)
     pixels = np.tile(panel, reps)[:height, :width, :]
     if channels is not None and pixels.shape[2] > channels:

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -131,15 +131,24 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         return _from_rgb(color_mode, cmyk_to_rgb(c, m, y, k))
 
     def _get_lab(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
-        # This triple is not RGB, and dividing L/a/b by 255 is not a correct
-        # normalization of any of them -- L is 0..100 and a/b are signed. That
-        # is a value bug independent of this one and is left as it stands for
-        # the modes that already reached the compositor, so the reduction below
-        # only decides the *width* for the modes that could not.
+        # Dividing L/a/b by 255 is not a correct normalization of any of the
+        # three -- L is 0..100 and a/b are signed. That is a value bug
+        # independent of this one, so it is left exactly as it stands for the
+        # three modes below, which are the ones that already reached the
+        # compositor.
         lab = _get_int_color(x, (Key.Luminance, Key.A, Key.B))
         if color_mode in (ColorMode.LAB, ColorMode.RGB, ColorMode.INDEXED):
             return lab
-        return _from_rgb(color_mode, lab)
+        # The remaining modes could not be reached at all before, so there is
+        # no established behavior to preserve -- only a width to choose. This
+        # deliberately does not go through _from_rgb(): only L carries
+        # lightness, and feeding signed a/b in as if they were G and B yields
+        # components that are arbitrary and can be negative. Reducing from L
+        # alone keeps them in range and monotonic in lightness.
+        lightness = lab[0]
+        if color_mode == ColorMode.CMYK:
+            return gray_to_cmyk(lightness)
+        return (lightness,)
 
     _COLOR_FUNC = {
         Klass.RGBColor: _get_rgb,

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -617,3 +617,43 @@ def test_composite_preview_rgb_with_positive_layer_count(tmp_path: Path) -> None
     loaded = PSDImage.open(output)
     result = loaded.composite()
     assert result.mode == "RGB"
+
+
+def test_background_color_accepts_a_sequence_on_multichannel() -> None:
+    """A per-channel background is expressible on a multichannel document.
+
+    The setter validated against ``EXPECTED_CHANNELS``, whose multichannel entry
+    is 64 -- the format's maximum rather than this file's three -- so every
+    sequence was rejected and only a scalar could be set (#731). Since
+    ``background_color`` is what ``save()`` composites the merged preview
+    against, there was no way to give a multichannel document a per-channel one.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_16bit_multichannel.psd"))
+    assert psd.channels == 3
+
+    psd.background_color = (0.1, 0.2, 0.3)
+    assert psd.background_color == (0.1, 0.2, 0.3)
+
+    # A scalar kept working throughout, and still does.
+    psd.background_color = 0.5
+    assert psd.background_color == 0.5
+
+    # A wrong width is still rejected, now against the document's own count.
+    with pytest.raises(ValueError, match="Expected 3 color channel"):
+        psd.background_color = (0.1, 0.2)
+
+
+def test_new_multichannel_accepts_a_sequence() -> None:
+    """``new()`` and the validator agree on a multichannel document's width.
+
+    ``_make_header()`` builds a one-channel multichannel file while the
+    validator demanded 64, so no sequence satisfied both -- the same shape of
+    bug that #734 fixed for duotone by correcting the table, which multichannel
+    cannot be fixed by because its count is per-file (#731).
+    """
+    psd = PSDImage.new("MULTICHANNEL", (4, 4), color=(0.5,))
+    assert psd.channels == 1
+    assert psd.background_color == (0.5,)
+
+    # A scalar keeps working.
+    assert PSDImage.new("MULTICHANNEL", (4, 4), color=0.5).background_color == 0.5

--- a/tests/psd_tools/api/test_utils.py
+++ b/tests/psd_tools/api/test_utils.py
@@ -1,7 +1,12 @@
 import pytest
 
 from psd_tools.api.psd_image import PSDImage
-from psd_tools.api.utils import EXPECTED_CHANNELS, get_color_channels
+from psd_tools.api.utils import (
+    EXPECTED_CHANNELS,
+    _validate_color_input,
+    color_channels,
+    get_color_channels,
+)
 from psd_tools.constants import ColorMode
 
 from ..utils import full_name
@@ -57,3 +62,59 @@ def test_get_color_channels_reads_the_header_only_for_multichannel() -> None:
     # A retagged document follows its header rather than the table.
     psd._record.header.channels = 5
     assert get_color_channels(psd) == 5
+
+
+def test_color_channels_matches_the_document_form() -> None:
+    """The header-taking form answers the same question as the document one.
+
+    ``PSDImage.new()`` has to validate a color before a document exists, so the
+    rule is reachable from a bare header too (#731).
+    """
+    for filename in (
+        "colormodes/4x4_1bit_bitmap.psd",
+        "colormodes/4x4_8bit_rgb.psd",
+        "colormodes/4x4_8bit_rgba.psd",
+        "colormodes/4x4_8bit_cmyk.psd",
+        "colormodes/4x4_8bit_index_color.psd",
+        "colormodes/4x4_16bit_multichannel.psd",
+    ):
+        psd = PSDImage.open(full_name(filename))
+        header = psd._record.header
+        assert color_channels(header.color_mode, header.channels) == get_color_channels(
+            psd
+        ), filename
+
+
+def test_color_channels_tracks_the_header_only_for_multichannel() -> None:
+    """A different header count moves the answer for multichannel alone."""
+    assert color_channels(ColorMode.MULTICHANNEL, 3) == 3
+    assert color_channels(ColorMode.MULTICHANNEL, 7) == 7
+    # Every other mode's count is the mode's own, whatever the header says.
+    assert color_channels(ColorMode.RGB, 3) == color_channels(ColorMode.RGB, 4) == 3
+    assert color_channels(ColorMode.DUOTONE, 1) == 1
+
+
+def test_validate_color_input_channels_overrides_the_table() -> None:
+    """The override is what makes a multichannel sequence expressible.
+
+    Without it the count comes from ``EXPECTED_CHANNELS``, whose multichannel
+    entry is 64 -- the format's maximum, not any document's count -- so no
+    sequence could satisfy it (#731).
+    """
+    # The unfixable case the table produces on its own.
+    with pytest.raises(ValueError, match="Expected 64 color channel"):
+        _validate_color_input((0.1, 0.2, 0.3), 8, ColorMode.MULTICHANNEL)
+    # With the real width supplied, the same sequence validates.
+    _validate_color_input((0.1, 0.2, 0.3), 8, ColorMode.MULTICHANNEL, 3)
+    # And a genuinely wrong width still raises, naming the count it was given.
+    with pytest.raises(ValueError, match="Expected 3 color channel"):
+        _validate_color_input((0.1, 0.2), 8, ColorMode.MULTICHANNEL, 3)
+
+
+def test_validate_color_input_leaves_other_modes_alone() -> None:
+    """Passing the override changes nothing for a mode the table gets right."""
+    _validate_color_input((1.0, 0.5, 0.0), 8, ColorMode.RGB, 3)
+    with pytest.raises(ValueError, match="Expected 3 color channel"):
+        _validate_color_input((1.0, 0.5), 8, ColorMode.RGB, 3)
+    with pytest.raises(ValueError, match="Expected 3 color channel"):
+        _validate_color_input((1.0, 0.5), 8, ColorMode.RGB)

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -145,3 +145,67 @@ def test_previously_working_pairs_are_unchanged(
 def test_multichannel_entry_is_not_a_channel_count() -> None:
     """Why multichannel is the mode that cannot be sized from the table."""
     assert EXPECTED_CHANNELS[ColorMode.MULTICHANNEL] == 64
+
+
+@pytest.mark.parametrize(
+    "lab",
+    [
+        (50.0, 10.0, 20.0),
+        (0.0, -128.0, -128.0),
+        (100.0, 127.0, 127.0),
+        (20.0, -90.0, 60.0),
+    ],
+)
+@pytest.mark.parametrize(
+    "color_mode",
+    [
+        ColorMode.BITMAP,
+        ColorMode.GRAYSCALE,
+        ColorMode.DUOTONE,
+        ColorMode.MULTICHANNEL,
+        ColorMode.CMYK,
+    ],
+)
+def test_lab_reduces_from_lightness_alone(
+    lab: tuple[float, float, float], color_mode: ColorMode
+) -> None:
+    """A Lab descriptor reduces via L, not by treating a/b as green and blue.
+
+    ``a`` and ``b`` are signed chroma, so folding them into a grayscale or CMYK
+    conversion as if they were RGB components gives an arbitrary result that can
+    fall outside [0, 1] -- a negative fill component. Only ``L`` carries
+    lightness, so the reduction takes it alone, which keeps the result in range
+    and monotonic in lightness.
+    """
+    desc = _color_desc(
+        Klass.LabColor.value,
+        {Key.Luminance: lab[0], Key.A: lab[1], Key.B: lab[2]},
+    )
+    result = _get_color(color_mode, desc)
+    assert all(0.0 <= c <= 1.0 for c in result), result
+    # a and b do not move the result at all.
+    swapped = _color_desc(
+        Klass.LabColor.value,
+        {Key.Luminance: lab[0], Key.A: -lab[1], Key.B: -lab[2]},
+    )
+    assert _get_color(color_mode, swapped) == result
+
+
+def test_lab_reduction_is_monotonic_in_lightness() -> None:
+    """Darker L stays darker after the reduction, in ink terms for CMYK."""
+
+    def lab_desc(lightness: float) -> Descriptor:
+        return _color_desc(
+            Klass.LabColor.value,
+            {Key.Luminance: lightness, Key.A: 0.0, Key.B: 0.0},
+        )
+
+    dark = _get_color(ColorMode.GRAYSCALE, lab_desc(10.0))
+    light = _get_color(ColorMode.GRAYSCALE, lab_desc(90.0))
+    assert dark[0] < light[0]
+
+    # CMYK is K-only, so more lightness means less key ink.
+    dark_cmyk = _get_color(ColorMode.CMYK, lab_desc(10.0))
+    light_cmyk = _get_color(ColorMode.CMYK, lab_desc(90.0))
+    assert dark_cmyk[:3] == light_cmyk[:3] == (0.0, 0.0, 0.0)
+    assert dark_cmyk[3] > light_cmyk[3]

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -1,0 +1,147 @@
+"""Unit tests for descriptor-to-document color conversion in ``paint``.
+
+A fill's color comes from a descriptor, whose color class is independent of the
+document's color mode: a shape authored in an RGB document keeps its ``RGBC``
+descriptor when the document is converted. ``_get_color()`` is what reconciles
+the two, and the width it returns has to be one the compositor accepts --
+either a single channel or exactly the document's own count, per
+``Compositor._assert_source_fits()``.
+
+It did not. Every cell marked below produced a width that is neither, so a
+solid color, gradient or stroke on such a document tripped the width assertion,
+and an HSB descriptor raised outright (#730).
+"""
+
+import numpy as np
+import pytest
+
+from psd_tools.api.utils import EXPECTED_CHANNELS
+from psd_tools.composite.paint import (
+    _get_color,
+    draw_solid_color_fill,
+)
+from psd_tools.constants import ColorMode
+from psd_tools.psd.descriptor import Descriptor, Double
+from psd_tools.terminology import Key, Klass
+
+
+def _color_desc(class_id: bytes, fields: dict) -> Descriptor:
+    """A ``solidColorLayer`` descriptor wrapping one color descriptor."""
+    inner = Descriptor(classID=class_id)
+    for key, value in fields.items():
+        inner[key] = Double(value)
+    outer = Descriptor(classID=b"solidColorLayer")
+    outer[Key.Color] = inner
+    return outer
+
+
+RGB_DESC = _color_desc(
+    Klass.RGBColor.value, {Key.Red: 128.0, Key.Green: 64.0, Key.Blue: 32.0}
+)
+GRAY_DESC = _color_desc(Klass.Grayscale.value, {Key.Gray: 40.0})
+CMYK_DESC = _color_desc(
+    Klass.CMYKColor.value,
+    {Key.Cyan: 10.0, Key.Magenta: 20.0, Key.Yellow: 30.0, Key.Black: 40.0},
+)
+LAB_DESC = _color_desc(
+    Klass.LabColor.value, {Key.Luminance: 50.0, Key.A: 10.0, Key.B: 20.0}
+)
+HSB_DESC = _color_desc(
+    Klass.HSBColor.value, {Key.Hue: 120.0, Key.Saturation: 50.0, Key.Brightness: 80.0}
+)
+
+ALL_DESCS = [
+    ("RGBColor", RGB_DESC),
+    ("Grayscale", GRAY_DESC),
+    ("CMYKColor", CMYK_DESC),
+    ("LabColor", LAB_DESC),
+    ("HSBColor", HSB_DESC),
+]
+
+# The width each mode's color arrays carry. Multichannel is excluded: its count
+# is per-file rather than per-mode, which is why a fill resolves to a single
+# channel for it and lets the compositor widen.
+MODE_CHANNELS = {
+    ColorMode.BITMAP: 1,
+    ColorMode.GRAYSCALE: 1,
+    ColorMode.INDEXED: 3,
+    ColorMode.RGB: 3,
+    ColorMode.CMYK: 4,
+    ColorMode.DUOTONE: 1,
+    ColorMode.LAB: 3,
+}
+
+
+@pytest.mark.parametrize("class_name, desc", ALL_DESCS)
+@pytest.mark.parametrize("color_mode", list(ColorMode))
+def test_get_color_width_is_legal_for_every_mode(
+    class_name: str, desc: Descriptor, color_mode: ColorMode
+) -> None:
+    """Every descriptor class resolves to a width the compositor accepts.
+
+    ``_assert_source_fits()`` allows a single channel or exactly the document's
+    count. Before #730 this failed for 19 of these 40 pairs -- an RGB, CMYK or
+    Lab descriptor on a bitmap, duotone or multichannel document, a CMYK one on
+    an indexed or Lab document, a Lab one on a grayscale or CMYK document, and
+    an HSB one on anything but RGB or CMYK, which raised instead.
+    """
+    width = len(_get_color(color_mode, desc))
+    if color_mode == ColorMode.MULTICHANNEL:
+        # No colorimetric conversion from RGB to N spot inks exists, so one
+        # channel is the honest answer and widening is the compositor's call.
+        assert width == 1
+    else:
+        assert width in (1, MODE_CHANNELS[color_mode])
+
+
+@pytest.mark.parametrize("class_name, desc", ALL_DESCS)
+@pytest.mark.parametrize("color_mode", list(ColorMode))
+def test_solid_color_fill_shape_is_legal_for_every_mode(
+    class_name: str, desc: Descriptor, color_mode: ColorMode
+) -> None:
+    """The same guarantee at the array the compositor is actually handed."""
+    color, shape = draw_solid_color_fill((0, 0, 4, 4), color_mode, desc)
+    assert shape is None
+    assert color.shape[:2] == (4, 4)
+    expected = 1 if color_mode == ColorMode.MULTICHANNEL else MODE_CHANNELS[color_mode]
+    assert color.shape[2] in (1, expected)
+    assert color.dtype == np.float32
+
+
+def test_hsb_no_longer_raises_outside_rgb_and_cmyk() -> None:
+    """An HSB descriptor was unrenderable on six of the eight modes."""
+    for color_mode in ColorMode:
+        _get_color(color_mode, HSB_DESC)  # would have raised ValueError
+
+
+@pytest.mark.parametrize(
+    "color_mode, desc, expected",
+    [
+        # These are the pairs that already reached the compositor, pinned so the
+        # reduction added in #730 cannot quietly move them. Values are the
+        # pre-#730 outputs.
+        (ColorMode.RGB, RGB_DESC, (128 / 255, 64 / 255, 32 / 255)),
+        (ColorMode.GRAYSCALE, RGB_DESC, None),  # single channel, value below
+        (ColorMode.CMYK, CMYK_DESC, (0.9, 0.8, 0.7, 0.6)),
+        (ColorMode.LAB, LAB_DESC, (50 / 255, 10 / 255, 20 / 255)),
+        (ColorMode.INDEXED, RGB_DESC, (128 / 255, 64 / 255, 32 / 255)),
+        (ColorMode.GRAYSCALE, GRAY_DESC, (0.6,)),
+        (ColorMode.BITMAP, GRAY_DESC, (0.6,)),
+    ],
+)
+def test_previously_working_pairs_are_unchanged(
+    color_mode: ColorMode, desc: Descriptor, expected: tuple[float, ...] | None
+) -> None:
+    """No pair that rendered before #730 changed value."""
+    result = _get_color(color_mode, desc)
+    if expected is None:
+        assert len(result) == 1
+        return
+    assert len(result) == len(expected)
+    for got, want in zip(result, expected):
+        assert got == pytest.approx(want, abs=1e-6)
+
+
+def test_multichannel_entry_is_not_a_channel_count() -> None:
+    """Why multichannel is the mode that cannot be sized from the table."""
+    assert EXPECTED_CHANNELS[ColorMode.MULTICHANNEL] == 64


### PR DESCRIPTION
Fixes #731 and the tractable half of #730. Both are the same root cause: a site
that needed the document's colour-channel count asked `EXPECTED_CHANNELS`
instead, whose multichannel entry is 64 — the format's maximum, not any file's
own count. This is the first two steps of the sequence posted on
[#722](https://github.com/psd-tools/psd-tools/issues/722#issuecomment-5435570090).

## #731 — `background_color` rejected every sequence

`_validate_color_input()` compared the sequence length against the table, so:

```python
psd = PSDImage.open("tests/psd_files/colormodes/4x4_16bit_multichannel.psd")
psd.channels                          # 3
psd.background_color = (0.1, 0.2, 0.3)
# before: ValueError: Expected 64 color channel(s) for MULTICHANNEL, got 3.
# after:  (0.1, 0.2, 0.3)
```

Only a scalar could be set, and since `background_color` is the backdrop
`save()` composites the merged preview against, a multichannel document had no
way to be given a per-channel one.

`PSDImage.new("MULTICHANNEL", ...)` was unsatisfiable for the same reason —
`_make_header()` builds a one-channel document while the validator demanded 64,
so no sequence satisfied both. That is the shape of bug #734 fixed for duotone
by correcting the table; multichannel cannot be fixed that way because its
count is per-file.

The validator now takes an explicit count. Callers supply it from whichever
they hold — `get_color_channels()` for a document, or `color_channels()`, added
here, for a bare `FileHeader`, because `PSDImage.new()` validates before a
document exists. Nothing changes for a mode the table gets right.

## #730 — fills were as wide as their descriptor

A fill's colour comes from a descriptor whose colour class is independent of the
document's colour mode: a shape authored in RGB keeps its `RGBC` descriptor
after the document is converted. `_get_color()` returned whatever width that
class carried, and where that was neither one channel nor the document's own
count, `Compositor._assert_source_fits()` fired.

I measured every descriptor class against every colour mode. **19 of the 40
pairs were broken** — considerably more than the issue identified, which was
multichannel only:

| descriptor | BITMAP | GRAY | INDEXED | RGB | CMYK | MULTI | DUOTONE | LAB |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| RGBColor | **3** | 1 | 3 | 3 | 4 | **3** | **3** | 3 |
| Grayscale | 1 | 1 | 1 | 3 | 4 | 1 | 1 | 1 |
| CMYKColor | **4** | 1 | **4** | 3 | 4 | **4** | **4** | **4** |
| LabColor | **3** | **3** | 3 | 3 | **3** | **3** | **3** | 3 |
| HSBColor | *raise* | *raise* | *raise* | 3 | 4 | *raise* | *raise* | *raise* |
| **legal** | 1 | 1 | 3 | 3 | 4 | N | 1 | 3 |

Bold is a width that is neither `1` nor the mode's count. An HSB descriptor was
worse than a bad width — `_get_hsb()` raised `ValueError` outright on six of the
eight modes, so an HSB solid colour or gradient was unrenderable on a
grayscale, Lab, indexed, bitmap, duotone or multichannel document.

Every class now routes through a single `_from_rgb()` reducer that converts to
the document's width. Multichannel resolves to **one** channel deliberately: its
channels are spot inks with no colorimetric relation to RGB, so there is no
conversion to N of them, one channel is legal everywhere, and what a single
value means once widened to N stays #722's question rather than being pre-empted
here.

### The fix is smaller than the issue predicted

#730 expected the document's count to be threaded into `_get_color()` through
nine call sites. It turned out not to be needed: because a single-channel source
is legal for any document, the reduction is decided by the colour *mode* alone,
and threading a count would also have forced multichannel fills to N identical
channels — exactly the replication #722 is about.

## No output movement

Both issues are about widths that crashed, so nothing that rendered should
change, and nothing does:

- **Value-level:** all **71** previously-legal (class, mode, colour) cells are
  identical to `main`, checked against `main`'s `_get_color()` over several
  colours per class — not just widths.
- **Corpus-level:** all **570** renders (285 files in `tests/psd_files` × both
  `force` modes) are bitwise-equal to `main`. The one fixture that errors
  (`blend-modes/group-divider-blend-mode.psd`) errors identically on both.

## Tests

New `tests/psd_tools/composite/test_paint.py` parametrises the whole 40-cell
matrix for legal width, plus a value-pinning test over the pairs that already
worked so the reduction cannot quietly move them. **39 of the new tests fail on
`main`**; all 1959 pass here.

## Split out

#730's other half — pattern fills, keyed on the *pattern's* mode rather than the
document's — is **not** fixed here and is filed as **#741**. It needs a real
boundary between colour and alpha planes, and that count is not recoverable from
the parsed pattern: the stored channel count is a fixed 24 slots (measured:
`len(data.channels)` is 26 for a 3-channel RGB pattern), so `len(channels) - 2`
does not give it, and `is_written` conflates colour with alpha for a mode that
has no constant to compare against. It wants a sample, not a table fix.

## Note for review

`denormalize_color()` gained the same `channels` parameter as
`normalize_color()` although no caller passes it yet — kept for symmetry, since
the two share a validator and a caller round-tripping through both would
otherwise hit the asymmetry.

Also worth flagging, not fixed here: `_get_lab()` ignores the colour mode
entirely and normalises L/a/b by 255, which is not a correct normalisation of
any of the three (L is 0..100, a/b are signed, and neutral a/b is 0.5 in the
arrays rather than 0). That is a *value* bug independent of the width one, now
filed as **#743** — correcting it drops the MSE against Photoshop's own merged
preview on `descriptors/stroke-color-descriptors-lab.psd` from 0.0328 to 0.0013,
a 96% reduction that the existing 0.05 test threshold currently hides. This PR
preserves the behaviour exactly for the modes that already reached the
compositor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

