### PR TITLE
docs: point _get_lab's normalisation note at #743

### DIFF
--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -132,10 +132,10 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
 
     def _get_lab(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
         # Dividing L/a/b by 255 is not a correct normalization of any of the
-        # three -- L is 0..100 and a/b are signed. That is a value bug
-        # independent of this one, so it is left exactly as it stands for the
-        # three modes below, which are the ones that already reached the
-        # compositor.
+        # three -- L is 0..100 and a/b are signed, and neutral a/b is 0.5 in
+        # the arrays, not 0. That is a value bug independent of this one (#743),
+        # so it is left exactly as it stands for the three modes below, which
+        # are the ones that already reached the compositor.
         lab = _get_int_color(x, (Key.Luminance, Key.A, Key.B))
         if color_mode in (ColorMode.LAB, ColorMode.RGB, ColorMode.INDEXED):
             return lab


### PR DESCRIPTION
Comment-only follow-up to #742. That PR's merge commit captured `6e9032d`, one
short of the branch tip, so this four-line comment change never landed on `main`.

`_get_lab()`'s note said the Lab value bug was "independent of this one" without
naming it. #743 now carries the analysis, so the comment points at it, and picks
up the detail that makes the bug concrete: neutral `a`/`b` is **0.5** in the
arrays (as `api/layers.py:1692` already states), not 0 — so the current `/255`
sends a neutral `a` to the extreme of the axis rather than the middle.

No behaviour change and no changelog entry — comment lines only, verified by
diffing with non-comment lines filtered out. `ruff`, `mypy` and the composite
suite (610 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)