### PR TITLE
fix: degrade non-separable blends off RGB/CMYK instead of crashing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Degrade the non-separable blend modes on grayscale, duotone and
+  multichannel documents instead of crashing. ``Hue``, ``Saturation``, ``Color``
+  and ``Luminosity`` raised ``IndexError`` or ``ValueError`` on every
+  single-channel document -- grayscale and duotone -- because they index
+  channels 1 and 2 of an array that has only channel 0, while ``Darker Color``
+  and ``Lighter Color`` did not raise but returned the backdrop unchanged
+  whatever the source was. A document wider than CMYK was broken too, there
+  raising for all six. Photoshop offers none of these six modes on such a
+  document, so there is no result to reproduce and they now fall back to
+  ``Normal`` with a debug log, as ``Dissolve`` already does. RGB and CMYK are
+  unaffected, and Lab is three channels wide so it keeps its existing
+  treatment (#735).
+
 - [fix] Let a per-channel colour be set on a multichannel document.
   :py:attr:`~psd_tools.api.psd_image.PSDImage.background_color` validated the
   sequence against a table whose multichannel entry is 64 -- the format's

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,8 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
-- [fix] Degrade the non-separable blend modes on grayscale, duotone and
-  multichannel documents instead of crashing. ``Hue``, ``Saturation``, ``Color``
+- [fix] Degrade the non-separable blend modes on documents whose colour array
+  is neither three nor four channels wide instead of crashing. ``Hue``, ``Saturation``, ``Color``
   and ``Luminosity`` raised ``IndexError`` or ``ValueError`` on every
   single-channel document -- grayscale and duotone -- because they index
   channels 1 and 2 of an array that has only channel 0, while ``Darker Color``
@@ -15,7 +15,7 @@ Changelog
   document, so there is no result to reproduce and they now fall back to
   ``Normal`` with a debug log, as ``Dissolve`` already does. RGB and CMYK are
   unaffected, and Lab is three channels wide so it keeps its existing
-  treatment (#735).
+  as-if-RGB treatment -- Photoshop does offer all six modes there (#735).
 
 - [fix] Let a per-channel colour be set on a multichannel document.
   :py:attr:`~psd_tools.api.psd_image.PSDImage.background_color` validated the

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -261,15 +261,20 @@ def non_separable(k: str = "s"):
     and a four-channel one round-trips through RGB. Any other width falls back
     to :py:func:`normal` rather than raising or inventing a result.
 
-    The documents that reach the fallback are the grayscale, duotone and
-    multichannel ones, and Photoshop offers none of these six modes on any of
-    them: scripted against Photoshop 2026, a grayscale document rejects every
-    one with *The command "Set" is not currently available*, and they are greyed
-    out in the UI. So there is no result to reproduce, and widening the array to
+    The fallback is keyed on the width rather than on the colour mode, so it
+    covers every mode that is not three or four channels wide: the one-channel
+    ones -- grayscale and duotone, and bitmap and indexed alike -- and
+    multichannel at whatever its spot plates come to. Photoshop offers none of
+    the six on any of them. Scripted against Photoshop 2026, a grayscale
+    document rejects every one with *The command "Set" is not currently
+    available* and they are greyed out in the UI, and bitmap mode does not admit
+    layers at all. So there is no result to reproduce, and widening the array to
     three channels would produce output Photoshop never does (#735).
 
     Lab is three channels wide and so is blended as if it were RGB. That is this
-    module's pre-existing treatment of Lab, not something the fallback decides.
+    module's pre-existing treatment of Lab, not something the fallback decides,
+    and it is the right side to leave Lab on: Photoshop does offer all six modes
+    on a Lab document.
 
     .. note: This implementation is still inaccurate.
     """

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -256,6 +256,21 @@ def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 def non_separable(k: str = "s"):
     """Wrap non-separable blending function for CMYK handling.
 
+    The wrapped functions are RGB-only by construction: the helpers below index
+    channels 0, 1 and 2 by name. A three-channel source reaches them unchanged
+    and a four-channel one round-trips through RGB. Any other width falls back
+    to :py:func:`normal` rather than raising or inventing a result.
+
+    The documents that reach the fallback are the grayscale, duotone and
+    multichannel ones, and Photoshop offers none of these six modes on any of
+    them: scripted against Photoshop 2026, a grayscale document rejects every
+    one with *The command "Set" is not currently available*, and they are greyed
+    out in the UI. So there is no result to reproduce, and widening the array to
+    three channels would produce output Photoshop never does (#735).
+
+    Lab is three channels wide and so is blended as if it were RGB. That is this
+    module's pre-existing treatment of Lab, not something the fallback decides.
+
     .. note: This implementation is still inaccurate.
     """
 
@@ -266,6 +281,17 @@ def non_separable(k: str = "s"):
                 K = Cs[:, :, 3:4] if k == "s" else Cb[:, :, 3:4]
                 Cb, Cs = _cmyk2rgb(Cb), _cmyk2rgb(Cs)
                 return np.concatenate((_rgb2cmy(func(Cb, Cs), K), K), axis=2)
+            if Cs.shape[2] != 3:
+                # Keyed on the source: the compositor allows a one-channel
+                # source against a wider canvas, so this is not always the
+                # document's own width.
+                logger.debug(
+                    "%s blend is not defined for a %d-channel source; "
+                    "falling back to normal",
+                    func.__name__,
+                    Cs.shape[2],
+                )
+                return normal(Cb, Cs)
             return func(Cb, Cs)
 
         return _blend_fn

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -6,7 +7,16 @@ from PIL import Image
 
 from psd_tools import PSDImage
 from psd_tools.api.layers import GroupMixin, PixelLayer
-from psd_tools.composite.blend import BLEND_FUNC, lighter_color, normal
+from psd_tools.composite.blend import (
+    BLEND_FUNC,
+    color,
+    darker_color,
+    hue,
+    lighter_color,
+    luminosity,
+    normal,
+    saturation,
+)
 from psd_tools.constants import BlendMode
 from .test_composite import check_composite_quality
 
@@ -202,3 +212,72 @@ def test_passthrough_group_opacity_equivalence(
     if got[4, 4, 3] == 0 and ref[4, 4, 3] == 0:
         return  # Fully transparent; the color channels are undefined.
     assert tuple(got[4, 4]) == pytest.approx(tuple(ref[4, 4]), abs=2)
+
+
+NON_SEPARABLE = [hue, saturation, color, luminosity, darker_color, lighter_color]
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+@pytest.mark.parametrize("channels", [1, 2, 5])
+def test_non_separable_falls_back_to_normal_off_rgb(
+    func: Callable, channels: int
+) -> None:
+    """Widths other than RGB and CMYK degrade instead of crashing (#735).
+
+    The four component modes raised on any single-channel document -- every
+    grayscale and duotone fixture that has layers::
+
+        hue, saturation:    IndexError: boolean index did not match indexed
+                            array along axis 2
+        color, luminosity:  ValueError: zero-size array to reduction operation
+                            minimum which has no identity
+
+    ``darker_color`` and ``lighter_color`` did not raise, which was worse: the
+    empty mask they built selected nothing, so both returned the backdrop
+    untouched whatever the source was. Two and five channels -- a duotone canvas
+    widened to its inks, a multichannel document with spot plates -- are broken
+    too, differing only in which exception comes out and in that five channels
+    raises for all six rather than silently passing the backdrop through. So
+    the fallback keys on "not RGB" rather than on "single channel".
+
+    ``normal`` is the fallback because Photoshop refuses to set any of these
+    six modes on such a document, so there is no result to reproduce.
+    """
+    Cb = np.full((2, 2, channels), 0.4, dtype=np.float32)
+    Cs = np.full((2, 2, channels), 0.6, dtype=np.float32)
+    result = func(Cb, Cs)
+    assert result.shape == (2, 2, channels)
+    assert np.array_equal(result, normal(Cb, Cs))
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+@pytest.mark.parametrize("channels", [3, 4])
+def test_non_separable_still_blends_rgb_and_cmyk(
+    func: Callable, channels: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The fallback must not swallow the widths that do have ground truth.
+
+    The source is brighter than the backdrop in one pixel and darker in the
+    other. A spatially constant pair would not do: ``darker_color`` and
+    ``lighter_color`` return one whole operand, so on constant input one of the
+    two always coincides with ``normal`` and the comparison could not tell a
+    real blend from the fallback.
+    """
+    Cb = np.full((1, 2, channels), 0.4, dtype=np.float32)
+    Cs = np.full((1, 2, channels), 0.6, dtype=np.float32)
+    Cs[0, 0, 0] = 0.9
+    Cs[0, 1, :] = 0.1
+    with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
+        result = func(Cb.copy(), Cs.copy())
+    assert result.shape == (1, 2, channels)
+    assert not np.array_equal(result, normal(Cb, Cs))
+    assert "falling back to normal" not in caplog.text
+
+
+def test_non_separable_fallback_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """Degrading silently would hide a mode the caller asked for (#735)."""
+    Cb = np.full((2, 2, 1), 0.4, dtype=np.float32)
+    Cs = np.full((2, 2, 1), 0.6, dtype=np.float32)
+    with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
+        luminosity(Cb, Cs)
+    assert "luminosity blend is not defined for a 1-channel source" in caplog.text

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -625,17 +625,106 @@ def test_composite_duotone_with_a_channelwise_blend_mode(blend_mode: BlendMode) 
     in duotone mode, so this was reachable on ordinary documents rather than
     only on hand-built ones.
 
-    ``Hue``, ``Saturation``, ``Color`` and ``Luminosity`` still raise, and are
-    deliberately not listed: they fail identically on
-    ``colormodes/4x4_8bit_grayscale.psd``, so that is a pre-existing
-    single-channel-document bug rather than anything duotone-specific. Duotone
-    now behaves exactly as grayscale does, which is the point.
+    The non-separable modes are covered separately by
+    ``test_composite_single_channel_with_a_non_separable_blend_mode``: they
+    failed on grayscale in the same way, so they were a single-channel-document
+    bug rather than anything duotone-specific (#735). Duotone behaves exactly as
+    grayscale does, which is the point.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_duotone.psd"))
     for layer in psd:
         layer.blend_mode = blend_mode
     color, _, _ = composite(psd)
     assert color.shape == (psd.height, psd.width, 1)
+
+
+@pytest.mark.parametrize(
+    "blend_mode",
+    [
+        BlendMode.HUE,
+        BlendMode.SATURATION,
+        BlendMode.COLOR,
+        BlendMode.LUMINOSITY,
+        BlendMode.DARKER_COLOR,
+        BlendMode.LIGHTER_COLOR,
+    ],
+)
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "colormodes/4x4_8bit_grayscale.psd",
+        "colormodes/4x4_16bit_grayscale.psd",
+        "colormodes/4x4_32bit_grayscale.psd",
+        "colormodes/4x4_8bit_duotone.psd",
+    ],
+)
+def test_composite_single_channel_with_a_non_separable_blend_mode(
+    filename: str, blend_mode: BlendMode
+) -> None:
+    """The non-separable modes degrade to normal instead of crashing (#735).
+
+    ``Hue`` and ``Saturation`` raised ``IndexError`` and ``Color`` and
+    ``Luminosity`` raised ``ValueError`` on every single-channel fixture that
+    has layers; ``Darker Color`` and ``Lighter Color`` returned the backdrop
+    unchanged. All six index channels 1 and 2 of an array that has only
+    channel 0.
+
+    Photoshop 2026 refuses to set any of the six on a grayscale document -- the
+    modes are greyed out in the UI and scripting them answers *The command
+    "Set" is not currently available* -- so there is no result to reproduce and
+    widening the array to three channels would invent one. Falling back to
+    normal is what ``dissolve`` already does, so the composite must match the
+    document rendered with ``Normal`` exactly.
+    """
+    psd = PSDImage.open(full_name(filename))
+    for layer in psd:
+        layer.blend_mode = blend_mode
+    color, _, _ = composite(psd)
+    assert color.shape == (psd.height, psd.width, 1)
+
+    reference = PSDImage.open(full_name(filename))
+    for layer in reference:
+        layer.blend_mode = BlendMode.NORMAL
+    assert np.array_equal(color, composite(reference)[0])
+
+
+@pytest.mark.parametrize(
+    "blend_mode",
+    [
+        BlendMode.HUE,
+        BlendMode.SATURATION,
+        BlendMode.COLOR,
+        BlendMode.LUMINOSITY,
+        BlendMode.DARKER_COLOR,
+        BlendMode.LIGHTER_COLOR,
+    ],
+)
+def test_composite_single_channel_non_separable_over_an_opaque_backdrop(
+    blend_mode: BlendMode,
+) -> None:
+    """The fixtures above cannot pin ``Darker Color`` / ``Lighter Color``.
+
+    Where the layer paints in those files the backdrop alpha is zero, so
+    ``_apply_source``'s ``(1 - alpha_b) * color + alpha_b * blend(...)``
+    collapses to the source and the blend result never reaches the output --
+    returning the backdrop and returning the source composite identically.
+    That is exactly the half of #735 that failed silently, so it needs a
+    backdrop that is opaque underneath the source.
+
+    Here the lower layer is opaque grey 96 and the upper opaque grey 192. Before
+    the fix both modes composited to 96/255, the backdrop, whatever the source
+    said; the fallback makes them the source, 192/255, like every other mode.
+    """
+    psd = PSDImage.new(mode="L", size=(4, 4), color=64)
+    psd.create_pixel_layer(image=Image.new("L", (4, 4), 96), name="lower")
+    psd.create_pixel_layer(image=Image.new("L", (4, 4), 192), name="upper")
+    for layer in psd:
+        layer.blend_mode = blend_mode
+
+    color, alpha, _ = composite(psd)
+    assert (alpha == 1.0).all(), "the backdrop must be opaque for this to bite"
+    assert color.shape == (4, 4, 1)
+    assert np.allclose(color, 192 / 255.0, atol=1 / 255.0)
 
 
 def test_composite_pil_duotone_force_keeps_the_luminance_plane_intact() -> None:


### PR DESCRIPTION
Closes #735.

## The bug

The six non-separable blend modes are RGB-only by construction — the helpers in
`blend.py` index channels 0, 1 and 2 by name — and `non_separable` adapted only
the four-channel CMYK case. Every other width reached them unguarded:

| width | before |
| --- | --- |
| 1 (grayscale, duotone) | `hue`/`saturation` → `IndexError`, `color`/`luminosity` → `ValueError`, `darker_color`/`lighter_color` **silently returned the backdrop** |
| 2 | all six broken; the four raise `ValueError` |
| 3 (RGB) | correct |
| 4 (CMYK) | correct |
| 5+ (multichannel spot plates) | all six raise |

The issue lists the four crashing modes. `darker_color` and `lighter_color` are
in the same decorator with the same root cause and did not crash — the empty
mask they built selected nothing, so both returned the backdrop whatever the
source said. That is the worse failure of the two, so they are fixed here rather
than left behind a guard written directly above them.

## The behaviour

Photoshop offers **none of the six** on such a document. Scripted against
Photoshop 2026 on a grayscale document — this also settles whether the issue's
"no ground truth" argument extends to Darker/Lighter Color, which it had not
tested:

```
doc mode=DocumentMode.GRAYSCALE channels=1
HUE / SATURATION / COLORBLEND / LUMINOSITY / DARKERCOLOR / LIGHTERCOLOR:
    REJECTED: The command "Set" is not currently available.
DARKEN / LIGHTEN / DISSOLVE: ACCEPTED
```

So there is no result to reproduce, and widening the array to three channels
would produce output Photoshop never does. They fall back to `normal` with a
`logger.debug`, which is what the issue recommends and what `dissolve` already
does.

The guard is keyed on *not three channels* rather than on *single channel*, so
the two- and five-channel widths are covered by the same condition instead of
leaving an identical crash live one branch away. RGB and CMYK are untouched.
Lab is three channels wide and keeps its existing as-if-RGB treatment — the
guard neither changes nor endorses that.

## Tests

- `test_blend.py`: all six functions at widths 1, 2 and 5 return exactly
  `normal`; at 3 and 4 they still differ from `normal` and do not log the
  fallback; the fallback is logged.
- `test_composite.py`: the six modes over the 8/16/32-bit grayscale and duotone
  fixtures, pinned against the same document rendered with `Normal`.
- `test_composite.py`: a second end-to-end case over an **opaque** backdrop.
  Where the layer paints in the `colormodes` fixtures the backdrop alpha is
  zero, so `_apply_source`'s `(1 - alpha_b) * color + alpha_b * blend(...)`
  collapses to the source — returning the backdrop and returning the source
  composite identically, and the fixture parametrization alone pins nothing for
  `Darker Color` / `Lighter Color`, which is exactly the half of this bug that
  failed silently. With the guard removed, all six of these cases fail.

Also updates the stale paragraph in
`test_composite_duotone_with_a_channelwise_blend_mode`, which recorded these
four as deliberately excluded (#733 / #734).

Full suite: 2041 passed, 27 xfailed, 2 xpassed. No reference-image churn.

## Adjacent, not fixed here

`Cs.shape[2] == 4` still claims a four-plate MULTICHANNEL document as CMYK and
treats its fourth spot plate as K. That predates this change and is unaffected
by it — the new guard sits after the `== 4` test. Worth its own issue; the
result is that multichannel documents with 2, 3 or 5+ plates now degrade
cleanly while the 4-plate one still mis-blends silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
