### PR TITLE
fix: invert cross-mode CMYK fills into the canvas convention

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Stop cross-mode fills writing ink-space CMYK into an inverted canvas.
+  The compositor's CMYK arrays store what is *left* -- 1.0 is no ink, which
+  ``topil()`` inverts back on the way out -- but the three conversions into CMYK
+  in ``composite/paint.py`` handed them ``color_convert``'s ink-space output
+  unchanged, where white is ``(0, 0, 0, 0)``. A white solid-colour, gradient or
+  stroke fill on a CMYK document therefore composited to solid black, and a
+  black one to a muddy CMY; the artboard background constants were inverted the
+  same way. Fills authored from an RGB, grayscale, HSB or Lab descriptor are
+  affected; a CMYK descriptor on a CMYK document always read correctly.
+  ``psd_tools.color_convert`` is unchanged -- it is public API with a documented
+  ink-space contract -- and the ``background_color`` docstring, which repeated
+  the wrong spelling, is corrected (#747).
+
 - [fix] Degrade the non-separable blend modes on documents whose colour array
   is neither three nor four channels wide instead of crashing. ``Hue``, ``Saturation``, ``Color``
   and ``Luminosity`` raised ``IndexError`` or ``ValueError`` on every

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -1693,8 +1693,11 @@ class Artboard(Group):
                 # LAB: L in [0,1]; a and b channels are neutral at 0.5
                 return (1.0 if white else 0.0, 0.5, 0.5), 1.0
             elif color_mode == ColorMode.CMYK:
-                # CMYK: white = no ink (0,0,0,0); black = full K (0,0,0,1)
-                return ((0.0, 0.0, 0.0, 0.0) if white else (0.0, 0.0, 0.0, 1.0)), 1.0
+                # CMYK arrays store what is left rather than what is laid down,
+                # so 1.0 is no ink: white is (1,1,1,1) and black is full key,
+                # (1,1,1,0). Writing the ink-space spelling here put a white
+                # artboard background on a CMYK document at solid black (#747).
+                return ((1.0, 1.0, 1.0, 1.0) if white else (1.0, 1.0, 1.0, 0.0)), 1.0
             else:
                 logger.debug(
                     "Artboard background color not applied: unsupported color mode %s",

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -636,7 +636,10 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         :py:meth:`~PSDImage.composite` ``color`` parameter:
 
         - **RGB / Grayscale**: ``1.0`` = white, ``0.0`` = black
-        - **CMYK**: ``(0.0, 0.0, 0.0, 0.0)`` = white (no ink)
+        - **CMYK**: ``(1.0, 1.0, 1.0, 1.0)`` = white, ``(1.0, 1.0, 1.0, 0.0)``
+          = black. These arrays count what is *left*, not what is laid down,
+          so 1.0 is no ink -- the same convention as the ``color`` parameter
+          and as :py:meth:`~PSDImage.numpy` (#747).
 
         Use a scalar for uniform color or a tuple for per-channel values.
         Set to ``None`` for transparent backdrop (legacy behavior).

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -42,6 +42,23 @@ _SINGLE_CHANNEL_MODES = (
 )
 
 
+def _ink_to_canvas(ink: tuple[float, ...]) -> tuple[float, ...]:
+    """Invert an ink-space CMYK tuple into the compositor's canvas convention.
+
+    ``color_convert``'s CMYK helpers are public API with a documented ink-space
+    contract -- white is ``(0, 0, 0, 0)``, no ink laid down at all. The
+    compositor's arrays are the other way round: they store what is *left*, so
+    1.0 is no ink, and ``pil_io.post_process()`` inverts them back on the way
+    out. Handing ink space straight to the canvas made a white fill composite
+    black (#747).
+
+    Only the conversions *into* CMYK need this. ``_get_cmyk()`` already reads a
+    CMYK descriptor through ``_get_invert_color()``, which lands in canvas space
+    directly.
+    """
+    return tuple(1.0 - v for v in ink)
+
+
 def _from_rgb(color_mode: ColorMode, rgb: tuple[float, ...]) -> tuple[float, ...]:
     """Convert a canonical RGB triple to *color_mode*'s color array width.
 
@@ -56,7 +73,7 @@ def _from_rgb(color_mode: ColorMode, rgb: tuple[float, ...]) -> tuple[float, ...
     the palette, so three is the width its pixel arrays carry.
     """
     if color_mode == ColorMode.CMYK:
-        return rgb_to_cmyk(*rgb)
+        return _ink_to_canvas(rgb_to_cmyk(*rgb))
     if color_mode in _SINGLE_CHANNEL_MODES:
         return (rgb_to_grayscale(*rgb),)
     return rgb
@@ -119,7 +136,7 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         if color_mode == ColorMode.RGB:
             return gray_to_rgb(gray)
         if color_mode == ColorMode.CMYK:
-            return gray_to_cmyk(gray)
+            return _ink_to_canvas(gray_to_cmyk(gray))
         return (gray,)
 
     def _get_cmyk(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
@@ -147,7 +164,7 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         # alone keeps them in range and monotonic in lightness.
         lightness = lab[0]
         if color_mode == ColorMode.CMYK:
-            return gray_to_cmyk(lightness)
+            return _ink_to_canvas(gray_to_cmyk(lightness))
         return (lightness,)
 
     _COLOR_FUNC = {

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Optional, Tuple
 
+import numpy as np
 import pytest
 from PIL import Image
 
@@ -13,16 +14,19 @@ from psd_tools.api.layers import (
     SmartObjectLayer,
     TypeLayer,
 )
-from psd_tools.api.pil_io import get_pil_channels, get_pil_depth
+from psd_tools.api.pil_io import get_pil_channels, get_pil_depth, post_process
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.constants import (
     BlendMode,
+    ColorMode,
     CompatibilityMode,
     ProtectedFlags,
     SectionDivider,
     SheetColorType,
     Tag,
 )
+
+from psd_tools.psd.descriptor import Integer
 
 from ..utils import full_name
 
@@ -943,3 +947,46 @@ def test_group_move_between_psdimages() -> None:
     assert len(psdimage2) == 1
     assert len(group) == 1
     assert layer.parent is group
+
+
+@pytest.mark.parametrize(
+    ("bg_type", "expected"),
+    [(2, (1.0, 1.0, 1.0, 1.0)), (3, (1.0, 1.0, 1.0, 0.0))],
+)
+def test_artboard_background_is_canvas_space_on_a_cmyk_document(
+    bg_type: int, expected: tuple[float, ...]
+) -> None:
+    """A white artboard background composited black on a CMYK document (#747).
+
+    The branch spelled white as ``(0, 0, 0, 0)`` -- no ink -- into arrays that
+    count what is *left*, where that is every ink at full strength. The RGB,
+    grayscale and Lab branches beside it were already canvas-space, so CMYK was
+    the odd one out.
+
+    ``artboard-bgcolor.psd`` is an RGB document whose artboards both use the
+    custom-colour type, so neither the colour mode nor the background type
+    under test can be reached from a shipped fixture; both are forged here.
+    """
+    psd = PSDImage.open(full_name("artboard-bgcolor.psd"))
+    artboard = psd[0]
+    assert isinstance(artboard, Artboard)
+
+    for key in (Tag.ARTBOARD_DATA1, Tag.ARTBOARD_DATA2, Tag.ARTBOARD_DATA3):
+        if key in artboard.tagged_blocks:
+            artboard.tagged_blocks.get_data(key)[b"artboardBackgroundType"] = Integer(
+                bg_type
+            )
+    psd._record.header.color_mode = ColorMode.CMYK
+    assert psd.color_mode == ColorMode.CMYK
+
+    color, alpha = artboard._artboard_background_defaults()
+    assert alpha == 1.0
+    assert color == expected
+
+    # The polarity is only meaningful against what the PIL exit does with it.
+    image = Image.fromarray(
+        np.full((2, 2, 4), 255 * np.array(color, dtype=np.float32), dtype=np.uint8),
+        "CMYK",
+    )
+    rendered = post_process(image, None, None).convert("RGB").getpixel((0, 0))
+    assert rendered == ((255, 255, 255) if bg_type == 2 else (0, 0, 0))

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -14,7 +14,9 @@ and an HSB descriptor raised outright (#730).
 
 import numpy as np
 import pytest
+from PIL import Image
 
+from psd_tools.api.pil_io import post_process
 from psd_tools.api.utils import EXPECTED_CHANNELS
 from psd_tools.composite.paint import (
     _get_color,
@@ -192,7 +194,15 @@ def test_lab_reduces_from_lightness_alone(
 
 
 def test_lab_reduction_is_monotonic_in_lightness() -> None:
-    """Darker L stays darker after the reduction, in ink terms for CMYK."""
+    """Darker L stays darker after the reduction.
+
+    The CMYK direction reversed with #747. These arrays count what is *left*
+    rather than what is laid down -- 1.0 is no ink -- so a darker colour has the
+    *smaller* K entry, and the CMY entries of a K-only build are 1.0 rather than
+    0.0. Before #747 the ink-space spelling went into the canvas unchanged, so
+    the assertions below read the other way round and a white fill composited
+    black.
+    """
 
     def lab_desc(lightness: float) -> Descriptor:
         return _color_desc(
@@ -204,8 +214,72 @@ def test_lab_reduction_is_monotonic_in_lightness() -> None:
     light = _get_color(ColorMode.GRAYSCALE, lab_desc(90.0))
     assert dark[0] < light[0]
 
-    # CMYK is K-only, so more lightness means less key ink.
+    # CMYK is K-only, so more lightness means less key ink -- a larger entry.
     dark_cmyk = _get_color(ColorMode.CMYK, lab_desc(10.0))
     light_cmyk = _get_color(ColorMode.CMYK, lab_desc(90.0))
-    assert dark_cmyk[:3] == light_cmyk[:3] == (0.0, 0.0, 0.0)
-    assert dark_cmyk[3] > light_cmyk[3]
+    assert dark_cmyk[:3] == light_cmyk[:3] == (1.0, 1.0, 1.0)
+    assert dark_cmyk[3] < light_cmyk[3]
+
+
+@pytest.mark.parametrize(
+    ("klass", "fields", "label"),
+    [
+        (Klass.Grayscale.value, {Key.Gray: 0.0}, "gray white"),
+        (
+            Klass.RGBColor.value,
+            {Key.Red: 255, Key.Green: 255, Key.Blue: 255},
+            "rgb white",
+        ),
+        (
+            Klass.HSBColor.value,
+            {Key.Hue: 0.0, Key.Saturation: 0.0, Key.Brightness: 100.0},
+            "hsb white",
+        ),
+        (
+            Klass.LabColor.value,
+            {Key.Luminance: 255.0, Key.A: 0.0, Key.B: 0.0},
+            "lab white",
+        ),
+    ],
+)
+def test_white_fill_is_white_on_a_cmyk_document(
+    klass: bytes, fields: dict, label: str
+) -> None:
+    """A white fill composited black on every CMYK document (#747).
+
+    ``color_convert``'s CMYK helpers are ink-space by contract -- white is
+    ``(0, 0, 0, 0)``, no ink -- and the three conversions into CMYK handed that
+    to a canvas that means the opposite by it. Rendered, the fill came out
+    ``(0, 0, 0)``: solid black where Photoshop shows white.
+
+    Pinned through the real PIL exit rather than on the tuple, because the
+    inversion is only wrong relative to what ``post_process()`` does with it.
+    """
+    fill, _ = draw_solid_color_fill(
+        (0, 0, 4, 4), ColorMode.CMYK, _color_desc(klass, fields)
+    )
+    assert fill is not None
+    image = Image.fromarray((255 * fill).astype(np.uint8), "CMYK")
+    rendered = post_process(image, None, None).convert("RGB")
+    assert rendered.getpixel((0, 0)) == (255, 255, 255)
+
+
+def test_cmyk_fill_lightness_survives_the_round_trip() -> None:
+    """The canvas and the PIL exit must agree on which way the axis runs.
+
+    A monotonic check on its own would pass with the polarity reversed -- it
+    did, before #747 -- so this pins the rendered greys themselves.
+    """
+    seen = []
+    for gray in (0.0, 50.0, 100.0):
+        fill, _ = draw_solid_color_fill(
+            (0, 0, 4, 4),
+            ColorMode.CMYK,
+            _color_desc(Klass.Grayscale.value, {Key.Gray: gray}),
+        )
+        image = Image.fromarray((255 * fill).astype(np.uint8), "CMYK")
+        pixel = post_process(image, None, None).convert("RGB").getpixel((0, 0))
+        assert isinstance(pixel, tuple)
+        seen.append(pixel[0])
+    assert seen[0] == 255 and seen[2] == 0
+    assert seen[0] > seen[1] > seen[2]


### PR DESCRIPTION
Closes #747. Found while working on #722 — measuring what a CMYK canvas value
means, in order to widen a grey into one correctly.

## The bug

The compositor's CMYK arrays store what is **left**, not what is laid down —
`1.0` is no ink, which `pil_io.post_process()` inverts back on the way out:

```python
>>> psd = PSDImage.open("tests/psd_files/colormodes/4x4_8bit_cmyk.psd")
>>> psd.numpy()[0, 0]
array([0.        , 0.05882353, 0.96862745, 1.        ], dtype=float32)
>>> psd.topil(apply_icc=False).getpixel((0, 0))
(255, 240, 8, 0)                      # ink = 255 * (1 - v)
```

Three conversions into CMYK handed those arrays `color_convert`'s **ink-space**
output unchanged, where white is `(0, 0, 0, 0)`:

- `composite/paint.py:59` — `_from_rgb()`, `rgb_to_cmyk(*rgb)`
- `composite/paint.py:122` — `_get_gray()`, `gray_to_cmyk(gray)`
- `composite/paint.py:150` — `_get_lab()`, `gray_to_cmyk(lightness)`

so a white fill composited to solid black:

| descriptor | RGB document | CMYK document, before | after |
| --- | --- | --- | --- |
| white | `(1, 1, 1)` | `(0, 0, 0, 0)` → renders **black** | `(1, 1, 1, 1)` → white |
| black | `(0, 0, 0)` | `(0, 0, 0, 1)` → renders muddy CMY | `(1, 1, 1, 0)` → black |

Through the real PIL exit, before and after:

```
white  canvas [0. 0. 0. 0.] -> RGB (0, 0, 0)        white  canvas [1. 1. 1. 1.] -> RGB (255, 255, 255)
mid    canvas [0.  0.  0.  0.5] -> RGB (127,127,127)  mid  canvas [1.  1.  1.  0.5] -> RGB (127, 127, 127)
black  canvas [0. 0. 0. 1.] -> RGB (114, 96, 87)    black  canvas [1. 1. 1. 0.] -> RGB (0, 0, 0)
```

`api/layers.py:1697` had the same inversion for artboard backgrounds — its
comment described ink space correctly while the values went into the canvas —
and the `background_color` docstring (`api/psd_image.py:639`) repeated the wrong
spelling, though the code behind it was already canvas-space.

## Scope

`psd_tools.color_convert` is **not** changed. It is public API whose ink-space
contract is documented and doctested (`color_convert.py:53-55`, `:156-159`), so
the inversion belongs at the consumer; changing it would be a silent breaking
change for direct callers.

`_get_cmyk()` was already correct — it reads through `_get_invert_color()` and
lands in canvas space directly. That is why a CMYK descriptor on a CMYK document
always rendered right, and why the suite stayed green: only cross-mode fills
(RGB, grayscale, HSB, Lab descriptors) were affected.

This fixes the **encoding**, not the **colorimetry**. `rgb_to_cmyk` remains a
naive conversion rather than Photoshop's ICC one — that is #722, and it is
measurably different (Photoshop puts a 50% grey at `C.516 M.432 Y.432 K.075`,
not at K-only). Doing #747 first means #722's widening arm has a settled
convention to be written against.

## Tests

- `test_white_fill_is_white_on_a_cmyk_document` — all four descriptor classes
  that convert into CMYK, pinned **through the PIL exit** rather than on the
  tuple, since the polarity is only wrong relative to what `post_process()` does
  with it.
- `test_cmyk_fill_lightness_survives_the_round_trip` — pins the rendered greys.
  A monotonicity check alone passes with the polarity reversed; it did, before.
- `test_artboard_background_is_canvas_space_on_a_cmyk_document` — forges the
  colour mode and background type, because `artboard-bgcolor.psd` is an RGB
  document whose artboards both use the custom-colour type, so neither is
  reachable from a shipped fixture.
- `test_lab_reduction_is_monotonic_in_lightness` changes direction: darker now
  means the *smaller* K entry. Its intent is unchanged; the docstring records
  why it flipped.

With the source reverted and the tests kept, 8 of them fail. Full suite:
2048 passed, 27 xfailed, 2 xpassed.

## Not covered by a fixture

No shipped CMYK fixture has a solid-colour or gradient fill layer, which is why
this went unnoticed. Authoring one would be the honest way to pin it end-to-end;
noted in #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
