### PR TITLE
fix: convert Lab fills across colour modes in both directions (#743, #752)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,33 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Convert a Lab fill colour across colour modes instead of passing the
+  numbers through. Two mirror-image gaps, both closed here because they share
+  the conversion: a Lab descriptor on a **non**-Lab document was read with a
+  ``/255`` divisor that suited none of its three components, and any other
+  descriptor class on a **Lab** document was written into the Lab arrays
+  uninterpreted. Red on a Lab document arrived as ``(1.0, 0.0, 0.0)`` -- white
+  at the extreme green-blue corner -- where the answer is
+  ``(0.543, 0.819, 0.776)``.
+
+  ``psd_tools.color_convert`` gains :py:func:`~psd_tools.color_convert.lab_to_rgb`
+  and :py:func:`~psd_tools.color_convert.rgb_to_lab`, D50 with Bradford-adapted
+  sRGB matrices, matching Photoshop's own colour engine to 0.05 Lab units
+  converting in and a mean of 0.35/255 converting out. Lab values there are in
+  native CIE units -- ``L`` 0..100 and signed ``a``/``b`` -- which is the one
+  exception to the module's normalized-float rule, and the module now has a
+  reference page.
+
+  Backwards-incompatible in what it renders, for two cases that no Photoshop
+  file can contain -- Photoshop rewrites a fill descriptor into the document's
+  own colour class on save, so both need a third-party writer. Beyond the
+  conversion itself, the **reduction curve moves** for a Lab fill on a
+  grayscale, bitmap, duotone or multichannel document: it was ``L/255`` and is
+  now the BT.601 luminance of the converted colour, so even a neutral changes
+  (``Lab(50, 0, 0)`` goes from 0.196 to 0.466). A grey fill on a Lab document
+  changes too, from the raw grey to its ``L*``; the single-channel *widening*
+  path deliberately still does not convert, and says why (#743, #752).
+
 - [fix] Read a Lab fill colour with the right divisor for each of its three
   components. ``L``, ``a`` and ``b`` were all divided by 255, which suits none
   of them: ``L`` runs 0..100, and ``a``/``b`` are signed and stored offset by
@@ -20,13 +47,8 @@ Changelog
   0.5, half a code value below the byte Photoshop writes: the artboard
   background default and the single-channel widening added in #722.
 
-  Lab descriptors on a *non*-Lab document are otherwise unchanged: RGB and
-  indexed targets still take the ``/255`` triple, and the narrower modes still
-  reduce from ``L`` alone. A real Lab conversion for them is the remaining half
-  of #743. They do gain the clamp, which matters more there than on the fixed
-  path -- dividing signed chroma as if it were unsigned made every negative
-  ``a`` or ``b``, so every green and every blue, wrap to an unrelated byte
-  (#743).
+  Lab descriptors on a *non*-Lab document were left to the entry above, which
+  replaces the ``/255`` reading for them with a real conversion (#743).
 
 - [fix] Convert rather than replicate when a single-channel canvas is widened
   to a CMYK or Lab document's channel count. A grey ``g`` became ``(g, g, g, g)``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,6 +97,7 @@ Not supported:
     reference/psd_tools.api.mask
     reference/psd_tools.api.shape
     reference/psd_tools.api.smart_object
+    reference/psd_tools.color_convert
     reference/psd_tools.composite
     reference/psd_tools.compression
     reference/psd_tools.constants

--- a/docs/reference/psd_tools.color_convert.rst
+++ b/docs/reference/psd_tools.color_convert.rst
@@ -1,0 +1,6 @@
+psd\_tools\.color\_convert
+==========================
+
+.. automodule:: psd_tools.color_convert
+    :members:
+    :undoc-members:

--- a/src/psd_tools/color_convert.py
+++ b/src/psd_tools/color_convert.py
@@ -3,11 +3,18 @@
 Units: RGB, CMYK, HSB and grayscale values are normalized floats in
 ``[0.0, 1.0]``. **CIE L*a*b* is the exception and is in native units** --
 ``L`` in ``0..100`` and ``a``/``b`` signed, nominally ``-128..127``. That is
-what the PSD descriptors carry, what Photoshop's scripting bridge reports and
-what every published reference table is printed in; normalizing it would mean
-choosing an encoding, and the only sensible choice (``L/100``,
-``(a + 128)/255``) is a *canvas* encoding rather than a colorimetric one. It
-belongs with the compositor, in ``psd_tools.composite.paint``.
+what the PSD descriptors carry and what published reference tables are printed
+in; normalizing it would mean choosing an encoding, and the only sensible
+choice (``L/100``, ``(a + 128)/255``) is a *canvas* encoding rather than a
+colorimetric one. It belongs with the compositor, in
+``psd_tools.composite.paint``.
+
+Comparing against Photoshop's scripting bridge needs care: ``SolidColor.lab``
+does *not* report native units. It reports ``a`` and ``b`` through the signed
+8-bit encoding Photoshop stores them in, ``a * (255 / 256) - 0.5``, which is
+why a neutral colour comes back from it as ``a = b = -0.5`` rather than 0.
+``L`` is native. See ``tests/psd_tools/test_color_convert.py``, which undoes
+the encoding before comparing.
 
 There are intentionally no numpy or internal ``psd_tools`` imports so this
 module can be imported freely from both ``psd_tools.api`` and

--- a/src/psd_tools/color_convert.py
+++ b/src/psd_tools/color_convert.py
@@ -1,6 +1,14 @@
 """Pure scalar color space conversion utilities.
 
-All functions operate on normalized float values in ``[0.0, 1.0]``.
+Units: RGB, CMYK, HSB and grayscale values are normalized floats in
+``[0.0, 1.0]``. **CIE L*a*b* is the exception and is in native units** --
+``L`` in ``0..100`` and ``a``/``b`` signed, nominally ``-128..127``. That is
+what the PSD descriptors carry, what Photoshop's scripting bridge reports and
+what every published reference table is printed in; normalizing it would mean
+choosing an encoding, and the only sensible choice (``L/100``,
+``(a + 128)/255``) is a *canvas* encoding rather than a colorimetric one. It
+belongs with the compositor, in ``psd_tools.composite.paint``.
+
 There are intentionally no numpy or internal ``psd_tools`` imports so this
 module can be imported freely from both ``psd_tools.api`` and
 ``psd_tools.composite`` without introducing circular dependencies.
@@ -9,9 +17,17 @@ References:
     - ITU-R BT.601 for the luminance coefficients used in
       :func:`rgb_to_grayscale`.
     - Adobe Photoshop Color Model documentation for the CMYK ↔ RGB formulas.
+    - CIE 15:2004 for the L*a*b* transfer function, and Lindbloom's
+      Bradford-adapted sRGB/D50 matrices for :func:`lab_to_rgb` and
+      :func:`rgb_to_lab`.
 """
 
-#: The normalized value of a neutral ``a``/``b`` axis in a Lab color array.
+#: The normalized value of a neutral ``a``/``b`` axis in a Lab color *array*.
+#:
+#: An encoding constant rather than a conversion result -- the one value in this
+#: module that is not in the native units the docstring above describes. It is
+#: here because :func:`rgb_to_lab` returns exactly ``a = b = 0.0`` for a neutral,
+#: and this is what that becomes once the compositor encodes it.
 #:
 #: Lab's two chroma axes are signed and are stored offset by 128 -- byte 128 is
 #: ``a = 0``, byte 0 is ``a = -128`` -- so a normalized neutral is ``128 / 255``
@@ -35,8 +51,8 @@ def rgb_to_grayscale(r: float, g: float, b: float) -> float:
         ``0.299·R + 0.587·G + 0.114·B``.
 
     Examples:
-        >>> rgb_to_grayscale(1.0, 1.0, 1.0)
-        1.0
+        >>> rgb_to_grayscale(1.0, 0.0, 0.0)
+        0.299
         >>> rgb_to_grayscale(0.0, 0.0, 0.0)
         0.0
     """
@@ -169,3 +185,143 @@ def gray_to_cmyk(gray: float) -> tuple[float, float, float, float]:
         (0.0, 0.0, 0.0, 1.0)
     """
     return (0.0, 0.0, 0.0, 1.0 - gray)
+
+
+# CIE 15:2004's transfer-function constants, in the exact-rational form that
+# makes kappa * eps == 8.0 and the two branches meet without a step.
+_LAB_EPS = 216.0 / 24389.0
+_LAB_KAPPA = 24389.0 / 27.0
+
+#: D50 white point, as the tristimulus the matrices below actually sum to.
+#:
+#: Deliberately Lindbloom's ``(0.96422, 1.0, 0.82521)`` and not the ICC PCS
+#: triple ``(0.9642, 1.0, 0.8249)``. Pairing the ICC triple with these matrices
+#: leaves the transform without an exact fixed point: white comes back as
+#: ``(1.0, 1.0, 0.99981)`` and a neutral grey as ``b = -0.025``, which the
+#: compositor's truncating cast turns into byte 127 where Photoshop -- and
+#: :py:data:`LAB_NEUTRAL_CHROMA` -- write 128.
+_LAB_D50 = (0.96422, 1.0, 0.82521)
+
+# Bradford-adapted, so they carry the D50 adaptation rather than needing a
+# separate chromatic-adaptation step.
+_XYZ_D50_TO_SRGB = (
+    (3.1338561, -1.6168667, -0.4906146),
+    (-0.9787684, 1.9161415, 0.0334540),
+    (0.0719453, -0.2289914, 1.4052427),
+)
+_SRGB_TO_XYZ_D50 = (
+    (0.4360747, 0.3850649, 0.1430804),
+    (0.2225045, 0.7168786, 0.0606169),
+    (0.0139322, 0.0971045, 0.7141733),
+)
+
+
+def _srgb_gamma(c: float) -> float:
+    return 12.92 * c if c <= 0.0031308 else 1.055 * (c ** (1.0 / 2.4)) - 0.055
+
+
+def _srgb_ungamma(c: float) -> float:
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    """Clamp, mapping NaN to *low*.
+
+    ``max(low, nan)`` returns ``low`` because ``nan > low`` is false, and
+    ``min`` then leaves it alone. That is the behaviour wanted here -- a NaN
+    from a malformed descriptor degrades to the end of the axis rather than
+    poisoning the canvas -- but it is a property of the argument order, so do
+    not reverse it.
+    """
+    return min(high, max(low, value))
+
+
+def lab_to_rgb(lightness: float, a: float, b: float) -> tuple[float, float, float]:
+    """Convert CIE L*a*b* to normalized sRGB.
+
+    The white point is D50, which is what Photoshop's Lab is; a D65 conversion
+    is wrong here by a mean of 11.6/255 and a maximum of 92.7/255 against
+    Photoshop's own numbers, against 0.35/255 and 4.5/255 for this one.
+
+    Out-of-gamut colors are clipped per channel. Every caller writes to a canvas
+    that cannot represent them, so the alternative is not a better color but an
+    array the compositor cannot use. The result is therefore always inside
+    ``[0, 1]`` and never reports that clipping happened.
+
+    Total: any float, including infinities and NaN, returns a usable triple
+    rather than raising. Descriptor values are unvalidated file data.
+
+    Args:
+        lightness: ``L*``, 0..100. Outside that the result saturates.
+        a: green-red chroma, nominally -128..127. Outside that it saturates.
+        b: blue-yellow chroma, nominally -128..127. Outside that it saturates.
+
+    Returns:
+        3-tuple ``(R, G, B)`` with each component in [0.0, 1.0].
+
+    Examples:
+        >>> tuple(round(v, 4) for v in lab_to_rgb(100.0, 0.0, 0.0))
+        (1.0, 1.0, 1.0)
+        >>> tuple(round(v, 4) for v in lab_to_rgb(0.0, 0.0, 0.0))
+        (0.0, 0.0, 0.0)
+        >>> tuple(round(v, 4) for v in lab_to_rgb(54.291, 80.812, 69.885))
+        (1.0, 0.0, 0.0)
+    """
+    fy = (lightness + 16.0) / 116.0
+    fxyz = (fy + a / 500.0, fy, fy - b / 200.0)
+    xyz = []
+    for f, white in zip(fxyz, _LAB_D50):
+        # ``f * f * f`` rather than ``f ** 3`` on purpose. A descriptor carries
+        # unvalidated file data, and on a large float the power operator raises
+        # OverflowError where the multiplication saturates to inf -- which the
+        # clamps below then degrade to the end of the axis. Keep the
+        # multiplication, or a malformed fill becomes an exception.
+        cube = f * f * f
+        xyz.append(
+            (cube if cube > _LAB_EPS else (116.0 * f - 16.0) / _LAB_KAPPA) * white
+        )
+
+    rgb = []
+    for row in _XYZ_D50_TO_SRGB:
+        linear = row[0] * xyz[0] + row[1] * xyz[1] + row[2] * xyz[2]
+        # One clamp, after the transfer function rather than either side of
+        # it. A negative linear value takes _srgb_gamma's linear branch, so it
+        # never reaches the fractional power that would make it complex, and
+        # infinities and NaN pass straight through to be clamped here.
+        rgb.append(_clamp(_srgb_gamma(linear), 0.0, 1.0))
+    return (rgb[0], rgb[1], rgb[2])
+
+
+def rgb_to_lab(r: float, g: float, b: float) -> tuple[float, float, float]:
+    """Convert normalized sRGB to CIE L*a*b*.
+
+    The exact inverse of :func:`lab_to_rgb` for any in-gamut color: round
+    tripping every sRGB value on a 6x6x6 grid returns it to within
+    0.0003/255. A neutral grey returns ``a = b = 0.0`` exactly, which is what
+    :py:data:`LAB_NEUTRAL_CHROMA` encodes.
+
+    Args:
+        r: Red channel in [0.0, 1.0]. Values outside are clamped.
+        g: Green channel in [0.0, 1.0]. Values outside are clamped.
+        b: Blue channel in [0.0, 1.0]. Values outside are clamped.
+
+    Returns:
+        3-tuple ``(L*, a, b)`` in native units -- ``L*`` in 0..100, ``a`` and
+        ``b`` signed.
+
+    Examples:
+        >>> tuple(round(v, 4) for v in rgb_to_lab(1.0, 1.0, 1.0))
+        (100.0, 0.0, 0.0)
+        >>> tuple(round(v, 4) for v in rgb_to_lab(0.5, 0.5, 0.5))
+        (53.389, 0.0, 0.0)
+    """
+    linear = [_srgb_ungamma(_clamp(v, 0.0, 1.0)) for v in (r, g, b)]
+    f = []
+    for row, white in zip(_SRGB_TO_XYZ_D50, _LAB_D50):
+        ratio = (row[0] * linear[0] + row[1] * linear[1] + row[2] * linear[2]) / white
+        f.append(
+            ratio ** (1.0 / 3.0)
+            if ratio > _LAB_EPS
+            else (_LAB_KAPPA * ratio + 16.0) / 116.0
+        )
+    return (116.0 * f[1] - 16.0, 500.0 * (f[0] - f[1]), 200.0 * (f[1] - f[2]))

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -12,8 +12,10 @@ from psd_tools.color_convert import (
     gray_to_cmyk,
     gray_to_rgb,
     hsb_to_rgb,
+    lab_to_rgb,
     rgb_to_cmyk,
     rgb_to_grayscale,
+    rgb_to_lab,
 )
 from psd_tools.composite._compat import require_scipy, require_skimage
 from psd_tools.constants import ColorMode, Tag
@@ -45,23 +47,40 @@ _SINGLE_CHANNEL_MODES = (
 def _clamp01(value: float) -> float:
     """Hold *value* inside the range a color array is allowed to carry.
 
-    Only the Lab readings need this. Lab is the one color class whose stored
-    range is signed, so it is the one whose normalization can leave [0, 1] --
+    Only the Lab encoding needs this. Lab's range is a convention the
+    descriptor does not enforce, so a writer emitting ``a = 200`` yields 1.29 --
     and :py:func:`psd_tools.composite.composite_pil` casts with
-    ``(255 * color).astype(np.uint8)``, which *wraps* rather than saturates. A
-    component of 1.29 lands on byte 71 and one of -0.16 on byte 216: not a
-    clipped chroma but a colour unrelated to the one asked for. Clamping
-    degrades to the end of the axis instead.
+    ``(255 * color).astype(np.uint8)``, which *wraps* rather than saturates,
+    landing that on byte 71: not a clipped chroma but a colour unrelated to the
+    one asked for. Clamping degrades to the end of the axis instead.
 
-    Both branches of ``_get_lab()`` need it, for opposite reasons. The Lab
-    target only leaves the range for input outside Photoshop's own -128..127,
-    which takes a third-party writer. The RGB and INDEXED targets leave it for
-    input squarely *inside* that range: they still divide signed chroma by 255,
-    so every negative ``a`` or ``b`` -- every green, every blue -- wraps. That
-    reading is wrong for more than its sign and is replaced wholesale by the
-    second half of #743; until then it should at least not wrap.
+    :py:func:`psd_tools.color_convert.lab_to_rgb` clamps its own inputs and
+    output, so the values reaching here through ``_from_rgb()`` are already in
+    range; this guards the direct Lab-to-Lab path, which does no conversion.
     """
     return min(1.0, max(0.0, value))
+
+
+def _lab_to_canvas(lightness: float, a: float, b: float) -> tuple[float, ...]:
+    """Encode native CIE L*a*b* into the compositor's Lab color array.
+
+    The arrays leave through PIL mode "LAB", whose bytes are ``L * 255/100``
+    with the two chroma axes offset by 128 -- byte 128 is ``a = 0``, byte 0 is
+    ``a = -128``, at slope exactly 1. So this is a relabelling into the
+    destination's own encoding rather than a conversion, and Photoshop's own
+    render of a Lab fill agrees with it to within 1/255 across the full a/b
+    range (#743).
+
+    Shared by the two ways a Lab value arrives: a Lab descriptor on a Lab
+    document, which lands here unconverted, and any other color class on a Lab
+    document, which reaches here through
+    :py:func:`psd_tools.color_convert.rgb_to_lab` (#752).
+    """
+    return (
+        _clamp01(lightness / 100.0),
+        _clamp01((a + 128.0) / 255.0),
+        _clamp01((b + 128.0) / 255.0),
+    )
 
 
 def _ink_to_canvas(ink: tuple[float, ...]) -> tuple[float, ...]:
@@ -93,9 +112,17 @@ def _from_rgb(color_mode: ColorMode, rgb: tuple[float, ...]) -> tuple[float, ...
 
     Indexed is deliberately three: its single stored channel expands through
     the palette, so three is the width its pixel arrays carry.
+
+    Lab is a real conversion rather than a width choice. It used to fall through
+    to ``return rgb``, which is three wide and so passed the width assertion
+    while meaning nothing: red arrived as ``(1.0, 0.0, 0.0)``, which a Lab array
+    reads as white at the extreme green-blue corner rather than as
+    ``(0.543, 0.819, 0.776)`` (#752).
     """
     if color_mode == ColorMode.CMYK:
         return _ink_to_canvas(rgb_to_cmyk(*rgb))
+    if color_mode == ColorMode.LAB:
+        return _lab_to_canvas(*rgb_to_lab(*rgb))
     if color_mode in _SINGLE_CHANNEL_MODES:
         return (rgb_to_grayscale(*rgb),)
     return rgb
@@ -159,6 +186,13 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
             return gray_to_rgb(gray)
         if color_mode == ColorMode.CMYK:
             return _ink_to_canvas(gray_to_cmyk(gray))
+        if color_mode == ColorMode.LAB:
+            # Not left to widen(): one channel is a legal width, so a grey fill
+            # was reaching a Lab canvas as a bare lightness and being widened
+            # with a neutral a/b. That put it on the right axis but at the wrong
+            # height -- the grey itself rather than its L* -- and disagreed with
+            # the same grey written as an RGB descriptor (#752).
+            return _from_rgb(color_mode, gray_to_rgb(gray))
         return (gray,)
 
     def _get_cmyk(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
@@ -170,42 +204,19 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         return _from_rgb(color_mode, cmyk_to_rgb(c, m, y, k))
 
     def _get_lab(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
+        lightness = float(x[Key.Luminance])
+        a = float(x[Key.A])
+        b = float(x[Key.B])
         if color_mode == ColorMode.LAB:
-            # 255 was the right divisor for none of the three (#743). L runs
-            # 0..100 and a/b are signed, which is why psd/color.py reads Lab as
-            # "4h" where every other space is "4H".
-            #
-            # These arrays leave through PIL mode "LAB", whose bytes are
-            # L * 255/100 with the two chroma axes offset by 128 -- byte 128 is
-            # a = 0, byte 0 is a = -128, at slope exactly 1. So this is not a
-            # conversion at all, only a relabelling into the destination's own
-            # encoding, and Photoshop's merged preview of a Lab fill agrees with
-            # it to within 1/255 across the full a/b range including both ends.
-            # (Photoshop's own slope is 254/255: it puts a = 127 on byte 254.
-            # Copying that would gain under half a code value against the
-            # preview and lose the same against any ImageCms decode.)
-            return (
-                _clamp01(float(x[Key.Luminance]) / 100.0),
-                _clamp01((float(x[Key.A]) + 128.0) / 255.0),
-                _clamp01((float(x[Key.B]) + 128.0) / 255.0),
-            )
-        # Every other target still takes the /255 reading: RGB and INDEXED get
-        # the triple, and the modes that would otherwise be the wrong width
-        # reduce from L alone. Neither is a conversion. The reduction drops a/b
-        # rather than carrying them, so two colours differing only in chroma
-        # collapse to one value; the triple keeps them but reads signed chroma
-        # as if it were unsigned. Routing both through a real Lab -> RGB and on
-        # through _from_rgb() is the second half of #743, and it moves rendered
-        # output for RGB and INDEXED documents, so it is left to its own change.
-        lab = tuple(
-            _clamp01(v) for v in _get_int_color(x, (Key.Luminance, Key.A, Key.B))
-        )
-        if color_mode in (ColorMode.RGB, ColorMode.INDEXED):
-            return lab
-        lightness = lab[0]
-        if color_mode == ColorMode.CMYK:
-            return _ink_to_canvas(gray_to_cmyk(lightness))
-        return (lightness,)
+            # Straight into the array's own encoding, with no trip through RGB
+            # to lose anything on (#743).
+            return _lab_to_canvas(lightness, a, b)
+        # Everything else is a real conversion now. It used to divide all three
+        # by 255 and hand RGB and INDEXED the raw triple -- reading signed
+        # chroma as unsigned, and putting L = 100 at 0.39 -- while the narrower
+        # modes reduced from L alone, dropping a/b so that two colours differing
+        # only in chroma collapsed to one value (the second half of #743).
+        return _from_rgb(color_mode, lab_to_rgb(lightness, a, b))
 
     _COLOR_FUNC = {
         Klass.RGBColor: _get_rgb,

--- a/src/psd_tools/composite/widen.py
+++ b/src/psd_tools/composite/widen.py
@@ -150,6 +150,16 @@ def _lab(color: np.ndarray) -> np.ndarray:
     the artboard defaults beside it. Lab has no exit ICC transform to anchor a
     transfer function against, so converting here would bake an sRGB gamma
     assumption into a mode the compositor already lists as unsupported.
+
+    Since #752 that makes this deliberately disagree with the *fill* path, which
+    does convert: a grey fill descriptor now reaches a Lab canvas at its L*, so
+    grey 0.6 lands at 0.632 where a widened grey 0.6 canvas channel stays at
+    0.6. The asymmetry is intended. A descriptor carries a colour a person
+    picked in some space, and for every class but Lab that space is sRGB-ish, so
+    interpreting it is sound. An arbitrary single-channel canvas handed to a Lab
+    document carries no such claim -- it may be a mask, a spot plane or a
+    caller's scalar -- and interpreting it would invent a colour space it never
+    had.
     """
     neutral = np.full_like(color, LAB_NEUTRAL_CHROMA)
     return np.concatenate((color, neutral, neutral), axis=2)

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -164,9 +164,9 @@ def test_multichannel_entry_is_not_a_channel_count() -> None:
     "lab",
     [
         (50.0, 10.0, 20.0),
-        (0.0, -128.0, -128.0),
-        (100.0, 127.0, 127.0),
         (20.0, -90.0, 60.0),
+        (65.49, 13.0, 69.0),
+        (45.0, 40.0, -50.0),
     ],
 )
 @pytest.mark.parametrize(
@@ -177,59 +177,77 @@ def test_multichannel_entry_is_not_a_channel_count() -> None:
         ColorMode.DUOTONE,
         ColorMode.MULTICHANNEL,
         ColorMode.CMYK,
+        ColorMode.RGB,
+        ColorMode.INDEXED,
+        ColorMode.LAB,
     ],
 )
-def test_lab_reduces_from_lightness_alone(
+def test_lab_chroma_reaches_every_target(
     lab: tuple[float, float, float], color_mode: ColorMode
 ) -> None:
-    """A Lab descriptor reduces via L, not by treating a/b as green and blue.
+    """``a`` and ``b`` move the result on every document mode.
 
-    ``a`` and ``b`` are signed chroma, so folding them into a grayscale or CMYK
-    conversion as if they were RGB components gives an arbitrary result that can
-    fall outside [0, 1] -- a negative fill component. Only ``L`` carries
-    lightness, so the reduction takes it alone, which keeps the result in range
-    and monotonic in lightness.
+    This is the inverse of the test it replaces. #742 deliberately reduced a Lab
+    colour from ``L`` alone for the narrow modes and read the raw ``/255``
+    triple for the wide ones, and `test_lab_reduces_from_lightness_alone`
+    pinned that by asserting negating a/b changed nothing. It is now a real
+    conversion, so negating the chroma has to move the answer -- otherwise the
+    colour is being thrown away again.
+
+    The parameters are chosen so that negating a/b changes the luminance too;
+    for a narrow mode the two can otherwise coincide by accident, which would
+    make this pass without carrying any chroma.
     """
     desc = _color_desc(
         Klass.LabColor.value,
         {Key.Luminance: lab[0], Key.A: lab[1], Key.B: lab[2]},
     )
-    result = _get_color(color_mode, desc)
-    assert all(0.0 <= c <= 1.0 for c in result), result
-    # a and b do not move the result at all.
-    swapped = _color_desc(
+    flipped = _color_desc(
         Klass.LabColor.value,
         {Key.Luminance: lab[0], Key.A: -lab[1], Key.B: -lab[2]},
     )
-    assert _get_color(color_mode, swapped) == result
+    result = _get_color(color_mode, desc)
+    assert all(0.0 <= c <= 1.0 for c in result), result
+    assert result != _get_color(color_mode, flipped)
 
 
-def test_lab_reduction_is_monotonic_in_lightness() -> None:
-    """Darker L stays darker after the reduction.
+def test_lab_conversion_is_monotonic_in_lightness() -> None:
+    """Darker L stays darker after the conversion.
 
     The CMYK direction reversed with #747. These arrays count what is *left*
     rather than what is laid down -- 1.0 is no ink -- so a darker colour has the
-    *smaller* K entry, and the CMY entries of a K-only build are 1.0 rather than
-    0.0. Before #747 the ink-space spelling went into the canvas unchanged, so
-    the assertions below read the other way round and a white fill composited
-    black.
+    *smaller* K entry. What is gone since #743 is the claim that the build is
+    K-only: a neutral Lab colour converts through sRGB, and ``rgb_to_cmyk``
+    puts a genuine neutral on K alone, but the moment there is any chroma the
+    CMY entries carry it.
     """
 
-    def lab_desc(lightness: float) -> Descriptor:
+    def lab_desc(lightness: float, a: float = 0.0, b: float = 0.0) -> Descriptor:
         return _color_desc(
             Klass.LabColor.value,
-            {Key.Luminance: lightness, Key.A: 0.0, Key.B: 0.0},
+            {Key.Luminance: lightness, Key.A: a, Key.B: b},
         )
 
     dark = _get_color(ColorMode.GRAYSCALE, lab_desc(10.0))
     light = _get_color(ColorMode.GRAYSCALE, lab_desc(90.0))
     assert dark[0] < light[0]
 
-    # CMYK is K-only, so more lightness means less key ink -- a larger entry.
     dark_cmyk = _get_color(ColorMode.CMYK, lab_desc(10.0))
     light_cmyk = _get_color(ColorMode.CMYK, lab_desc(90.0))
-    assert dark_cmyk[:3] == light_cmyk[:3] == (1.0, 1.0, 1.0)
     assert dark_cmyk[3] < light_cmyk[3]
+    # A neutral still builds on K alone. Approximate, not exact: the three rows
+    # of the sRGB matrix do not sum identically, so a neutral comes back out of
+    # lab_to_rgb with ~1e-8 between its channels, and rgb_to_cmyk divides that
+    # by (1 - K) to get the CMY entries. The residue lands around 5e-8 -- a
+    # hundred-thousandth of a code value, and not worth snapping for.
+    assert dark_cmyk[:3] == pytest.approx((1.0, 1.0, 1.0), abs=1e-6)
+    assert light_cmyk[:3] == pytest.approx((1.0, 1.0, 1.0), abs=1e-6)
+    # ...and a chromatic one does not, which is the part #743 changed.
+    assert _get_color(ColorMode.CMYK, lab_desc(50.0, 60.0, -40.0))[:3] != (
+        1.0,
+        1.0,
+        1.0,
+    )
 
 
 @pytest.mark.parametrize(
@@ -406,26 +424,138 @@ def test_lab_out_of_range_clamps_rather_than_wrapping(field: Key, value: float) 
     assert pixels[axes.index(field)] == (255 if value > 0 else 0)
 
 
-@pytest.mark.parametrize("color_mode", [ColorMode.RGB, ColorMode.INDEXED])
-@pytest.mark.parametrize("lab", [(50.0, -128.0, -100.0), (25.0, -40.0, 15.0)])
-def test_lab_negative_chroma_clamps_on_an_rgb_target(
-    color_mode: ColorMode, lab: tuple[float, float, float]
-) -> None:
-    """Here the wrapping input is in range, not out of it.
+# ---------------------------------------------------------------------------
+# Cross-mode Lab conversion (#743 second half, #752)
+#
+# Photoshop rewrites a fill descriptor into the document's own colour class on
+# save, so neither direction below is authorable from Photoshop and no fixture
+# can carry them -- a scan of every file under tests/psd_files finds no LAB
+# document with a non-Lab descriptor and no non-LAB document with a Lab one.
+# The ground truth is therefore Photoshop's own colour engine over the
+# scripting bridge, with the chroma reporting encoding undone; see
+# tests/psd_tools/test_color_convert.py for the model.
+# ---------------------------------------------------------------------------
 
-    RGB and INDEXED still take the ``/255`` reading pending the second half of
-    #743, and that divides *signed* chroma as if it were unsigned. Every
-    negative ``a`` or ``b`` -- so every green and every blue -- came out
-    negative and wrapped on the cast: Lab(25, -40, 15), an ordinary green, put
-    ``a`` on byte 216, near the top of its axis rather than below the middle.
-    The reading stays wrong until it is replaced; it should not also wrap.
+
+def _native(reported: float) -> float:
+    return (reported + 0.5) * 256.0 / 255.0
+
+
+@pytest.mark.parametrize("color_mode", [ColorMode.RGB, ColorMode.INDEXED])
+@pytest.mark.parametrize(
+    ("lab", "photoshop_rgb"),
+    [
+        ((65.49, 13.0, 69.0), (202.690, 148.651, 0.0)),
+        ((75.0, 25.0, -30.0), (211.468, 168.986, 239.887)),
+        ((25.0, -40.0, 15.0), (0.0, 72.513, 33.509)),
+        ((90.0, 5.0, -5.0), (234.175, 223.039, 235.179)),
+        ((50.0, 0.0, 0.0), (120.084, 118.613, 118.084)),
+    ],
+)
+def test_lab_fill_on_an_rgb_document_matches_photoshop(
+    color_mode: ColorMode,
+    lab: tuple[float, float, float],
+    photoshop_rgb: tuple[float, float, float],
+) -> None:
+    """#743's second half: a Lab descriptor on an RGB or indexed document.
+
+    This used to be ``(L/255, a/255, b/255)`` -- signed chroma read as unsigned,
+    and ``L = 100`` arriving at 0.39. A Lab green came out an unrelated colour.
+    Indexed goes the same way: its arrays are three wide, so it fell through the
+    same branch.
     """
     desc = _color_desc(
         Klass.LabColor.value,
-        {Key.Luminance: lab[0], Key.A: lab[1], Key.B: lab[2]},
+        {
+            Key.Luminance: lab[0],
+            Key.A: _native(lab[1]),
+            Key.B: _native(lab[2]),
+        },
     )
-    result = _get_color(color_mode, desc)
-    assert all(0.0 <= c <= 1.0 for c in result), result
-    assert result[1] == 0.0  # negative a, clamped to the end of the axis
-    pixels = (255 * np.array(result, dtype=np.float32)).astype(np.uint8)
-    assert pixels[1] == 0
+    got = [255.0 * v for v in _get_color(color_mode, desc)]
+    assert len(got) == 3
+    for channel, (value, want) in enumerate(zip(got, photoshop_rgb)):
+        assert abs(value - want) <= 1.0, (lab, channel, value, want)
+
+
+@pytest.mark.parametrize(
+    ("rgb", "photoshop_lab"),
+    [
+        ((255, 0, 0), (54.2908, 79.9968, 69.1176)),
+        ((0, 255, 0), (87.8204, -79.4638, 80.1758)),
+        ((202, 149, 1), (65.5060, 12.5582, 68.3083)),
+        ((120, 200, 255), (77.0691, -14.5231, -35.5812)),
+        ((128, 128, 128), (53.5828, -0.5, -0.5)),
+    ],
+)
+def test_rgb_fill_on_a_lab_document_matches_photoshop(
+    rgb: tuple[int, int, int], photoshop_lab: tuple[float, float, float]
+) -> None:
+    """#752: an RGB descriptor on a Lab document.
+
+    ``_from_rgb()`` had no Lab branch, so the triple fell through unconverted.
+    Three channels is a legal width for a Lab document, so nothing complained --
+    red simply arrived as ``(1.0, 0.0, 0.0)``, which those arrays read as white
+    at the extreme green-blue corner.
+
+    Compared in canvas encoding rather than native units, because that is what
+    the compositor consumes; 1/255 here is one code value of the rendered
+    pixel.
+    """
+    desc = _color_desc(
+        Klass.RGBColor.value,
+        {Key.Red: float(rgb[0]), Key.Green: float(rgb[1]), Key.Blue: float(rgb[2])},
+    )
+    got = _get_color(ColorMode.LAB, desc)
+    want = (
+        photoshop_lab[0] / 100.0,
+        (_native(photoshop_lab[1]) + 128.0) / 255.0,
+        (_native(photoshop_lab[2]) + 128.0) / 255.0,
+    )
+    assert len(got) == 3
+    for channel, (value, expected) in enumerate(zip(got, want)):
+        assert abs(value - expected) * 255.0 <= 1.0, (rgb, channel, value, expected)
+
+
+@pytest.mark.parametrize(
+    ("klass", "fields", "expected"),
+    [
+        # A grey, so a and b must land exactly on the neutral axis and L on the
+        # grey's L* rather than on the grey itself. 0.6 -> 0.632 is the number
+        # widen._lab()'s docstring quotes for the divergence it keeps.
+        (
+            Klass.Grayscale.value,
+            {Key.Gray: 40.0},
+            (0.632226, 128 / 255, 128 / 255),
+        ),
+        (
+            Klass.CMYKColor.value,
+            {Key.Cyan: 10.0, Key.Magenta: 20.0, Key.Yellow: 30.0, Key.Black: 40.0},
+            (0.060154, 0.495916, 0.468762),
+        ),
+    ],
+)
+def test_other_classes_on_a_lab_document_go_through_the_conversion(
+    klass: bytes, fields: dict, expected: tuple[float, float, float]
+) -> None:
+    """The grayscale and CMYK classes reach the Lab branch too (#752).
+
+    Pinned as values rather than as agreement with the equivalent RGB
+    descriptor. That equivalence is how the code is built -- both spellings end
+    in ``_from_rgb(LAB, ...)`` -- so asserting it cannot fail, and an earlier
+    draft of this test proved it: deleting either branch left the equivalence
+    assertion passing.
+
+    Not compared against Photoshop's own Lab for these two, either. Its
+    grayscale working space is Dot Gain 20% and its CMYK separation is
+    profile-driven, neither of which is what ``gray_to_rgb`` and ``cmyk_to_rgb``
+    do, so a disagreement would be Photoshop's colour management rather than
+    this conversion. The RGB class carries the Photoshop-anchored assertion,
+    above.
+
+    Grayscale is the one that needed a branch of its own: one channel is a legal
+    width, so a grey fill used to reach the canvas as a bare lightness and get
+    widened with a neutral a/b. Right axis, wrong height.
+    """
+    got = _get_color(ColorMode.LAB, _color_desc(klass, fields))
+    assert got == pytest.approx(expected, abs=1e-6)

--- a/tests/psd_tools/test_color_convert.py
+++ b/tests/psd_tools/test_color_convert.py
@@ -2,13 +2,18 @@
 
 import pytest
 
+import doctest
+
+import psd_tools.color_convert
 from psd_tools.color_convert import (
     cmyk_to_rgb,
     gray_to_cmyk,
     gray_to_rgb,
     hsb_to_rgb,
+    lab_to_rgb,
     rgb_to_cmyk,
     rgb_to_grayscale,
+    rgb_to_lab,
 )
 
 
@@ -130,3 +135,189 @@ class TestGrayToCmyk:
 
     def test_mid_gray(self):
         assert gray_to_cmyk(0.5) == pytest.approx((0.0, 0.0, 0.0, 0.5))
+
+
+# ---------------------------------------------------------------------------
+# CIE L*a*b* (#743, #752)
+#
+# Ground truth is Photoshop 2026's own colour engine, read over the ExtendScript
+# bridge as ``SolidColor.lab = ...; .rgb`` and the reverse. Its RGB working
+# space is sRGB (confirmed from the profile it embeds), so the two are directly
+# comparable.
+#
+# One correction has to be applied first. Photoshop's scripting property does
+# not report ``a``/``b`` in native units -- it reports them through the signed
+# 8-bit encoding it stores them in:
+#
+#     a_reported = a_true * (255 / 256) - 0.5
+#
+# which is why every neutral colour comes back as ``a = b = -0.5`` rather than
+# 0. This is not a fitted correction: both constants come from the encoding, and
+# undoing it takes the disagreement across 33 measured colours from ~0.87 Lab
+# units to 0.014 -- so the tolerances below are chosen from the model, not from
+# whatever this implementation happens to produce.
+# ---------------------------------------------------------------------------
+
+
+def _native(reported: float) -> float:
+    """Undo Photoshop's signed 8-bit reporting encoding for ``a``/``b``."""
+    return (reported + 0.5) * 256.0 / 255.0
+
+
+# Lab (native) -> Photoshop's RGB, 0..255. Chroma is as Photoshop *reported* it.
+_LAB_TO_RGB = [
+    ((0.0, 0.0, 0.0), (1.268, 0.0, 0.031)),
+    ((100.0, 0.0, 0.0), (255.0, 254.658, 254.051)),
+    ((50.0, 0.0, 0.0), (120.084, 118.613, 118.084)),
+    ((45.88, 1.0, 2.0), (112.590, 107.695, 104.504)),
+    ((65.49, 13.0, 69.0), (202.690, 148.651, 0.0)),
+    ((19.07, 52.29, -85.08), (16.957, 0.0, 177.748)),
+    ((54.29, 80.8, 69.89), (255.0, 0.0, 0.0)),
+    ((96.84, -14.39, 92.87), (255.0, 251.755, 0.0)),
+    ((53.24, 80.09, 67.2), (251.498, 0.0, 4.303)),
+    ((87.73, -86.18, 83.18), (0.0, 255.0, 0.0)),
+    ((32.3, 79.19, -107.86), (92.823, 0.0, 255.0)),
+    ((75.0, 25.0, -30.0), (211.468, 168.986, 239.887)),
+    ((25.0, -40.0, 15.0), (0.0, 72.513, 33.509)),
+    ((90.0, 5.0, -5.0), (234.175, 223.039, 235.179)),
+    ((10.0, 60.0, 60.0), (91.804, 0.0, 0.934)),
+]
+
+# Photoshop clips these two somewhere we do not, so they get a named exemption
+# rather than a loosened global tolerance:
+#   Lab(10, 60, 60)  is outside sRGB -- Photoshop desaturates where we clip per
+#                    channel, which is a gamut-mapping policy rather than a
+#                    transform difference.
+#   Lab(0, 0, 0)     comes back as (1.27, 0, 0.03) rather than black, which is
+#                    black point compensation.
+_LAB_TO_RGB_GAMUT_LIMITED = {(10.0, 60.0, 60.0): 5.0, (0.0, 0.0, 0.0): 1.0}
+
+# Photoshop's RGB 0..255 -> the Lab it reports for it.
+_RGB_TO_LAB = [
+    ((0, 0, 0), (0.0, -0.5, -0.5)),
+    ((255, 255, 255), (100.0, -0.5, -0.5)),
+    ((128, 128, 128), (53.5828, -0.5, -0.5)),
+    ((255, 0, 0), (54.2908, 79.9968, 69.1176)),
+    ((0, 255, 0), (87.8204, -79.4638, 80.1758)),
+    ((0, 0, 255), (29.5654, 67.5223, -112.0936)),
+    ((255, 255, 0), (97.6074, -16.1885, 92.5258)),
+    ((0, 255, 255), (90.6677, -50.9662, -15.4025)),
+    ((255, 0, 255), (60.1685, 92.6815, -60.7637)),
+    ((202, 149, 1), (65.5060, 12.5582, 68.3083)),
+    ((64, 32, 192), (27.7649, 48.1452, -78.9813)),
+    ((10, 120, 60), (43.9514, -40.5772, 23.9354)),
+    ((230, 180, 150), (77.3834, 15.1807, 22.0677)),
+    ((35, 35, 40), (13.8702, 0.4650, -3.8307)),
+    ((120, 200, 255), (77.0691, -14.5231, -35.5812)),
+    ((200, 60, 90), (47.8912, 56.5108, 15.6787)),
+    ((90, 90, 10), (37.1552, -7.6049, 40.1998)),
+    ((250, 250, 200), (97.3480, -6.3443, 23.5230)),
+]
+
+
+class TestLabToRgb:
+    @pytest.mark.parametrize(("lab", "expected"), _LAB_TO_RGB)
+    def test_matches_photoshop(self, lab, expected):
+        lightness, a, b = lab
+        got = [v * 255.0 for v in lab_to_rgb(lightness, _native(a), _native(b))]
+        tolerance = _LAB_TO_RGB_GAMUT_LIMITED.get(lab, 0.5)
+        for channel, (g, want) in enumerate(zip(got, expected)):
+            assert abs(g - want) <= tolerance, (lab, channel, g, want)
+
+    def test_white_is_exactly_white(self):
+        """The white point has to be the one the matrices carry.
+
+        Pairing the ICC PCS D50 with Lindbloom's Bradford matrices leaves the
+        transform without a fixed point -- white returns 0.99981 in blue, and a
+        neutral grey picks up a b of -0.025, which the compositor's truncating
+        cast turns into byte 127 where Photoshop writes 128.
+        """
+        assert lab_to_rgb(100.0, 0.0, 0.0) == pytest.approx((1.0, 1.0, 1.0), abs=1e-7)
+        assert lab_to_rgb(0.0, 0.0, 0.0) == (0.0, 0.0, 0.0)
+
+    def test_clamps_out_of_gamut(self):
+        for component in lab_to_rgb(60.0, 120.0, -120.0):
+            assert 0.0 <= component <= 1.0
+
+    @pytest.mark.parametrize(
+        "value",
+        [1e308, -1e308, 1e300, float("inf"), float("-inf"), float("nan")],
+    )
+    @pytest.mark.parametrize("axis", [0, 1, 2])
+    def test_absurd_input_degrades_instead_of_raising(self, value, axis):
+        """A descriptor carries unvalidated file data.
+
+        Cubing the transfer function overflows on a large float, so writing it
+        as ``f ** 3`` turns a malformed fill into an ``OverflowError`` on the
+        path whose whole purpose is tolerating writers other than Photoshop.
+        ``f * f * f`` saturates to infinity instead and the clamps take it from
+        there; NaN degrades through ``_clamp``'s argument order.
+        """
+        lab = [50.0, 0.0, 0.0]
+        lab[axis] = value
+        result = lab_to_rgb(*lab)
+        assert all(0.0 <= c <= 1.0 for c in result), result
+
+    def test_nan_degrades_to_black_not_white(self):
+        """Pins ``_clamp``'s argument order, which nothing else does.
+
+        ``max(low, nan)`` returns ``low`` because the comparison is false;
+        writing the clamp the other way round would send a NaN to *white*
+        instead, and every other assertion here -- membership in [0, 1] --
+        holds equally well either way.
+        """
+        assert lab_to_rgb(float("nan"), 0.0, 0.0) == (0.0, 0.0, 0.0)
+        assert lab_to_rgb(50.0, float("nan"), float("nan")) == (0.0, 0.0, 0.0)
+
+
+class TestRgbToLab:
+    @pytest.mark.parametrize(("rgb", "expected"), _RGB_TO_LAB)
+    def test_matches_photoshop(self, rgb, expected):
+        got = rgb_to_lab(*[v / 255.0 for v in rgb])
+        want = (expected[0], _native(expected[1]), _native(expected[2]))
+        assert got == pytest.approx(want, abs=0.05)
+
+    @pytest.mark.parametrize("grey", [0.0, 0.25, 0.5, 0.75, 1.0])
+    def test_a_grey_is_exactly_neutral(self, grey):
+        """Neutral must be 0.0, not merely near it.
+
+        ``LAB_NEUTRAL_CHROMA`` is ``128/255``, and the compositor truncates on
+        the way out, so a chroma of -0.025 -- which is what the ICC PCS white
+        point gives here -- emits byte 127 instead of 128.
+        """
+        _, a, b = rgb_to_lab(grey, grey, grey)
+        assert (a, b) == pytest.approx((0.0, 0.0), abs=1e-9)
+        # The bound that actually matters: what the compositor's truncating
+        # cast makes of it. The ICC PCS white point gives -0.025 here, which
+        # is small but lands a byte low.
+        for chroma in (a, b):
+            assert int(255.0 * ((chroma + 128.0) / 255.0)) == 128
+
+    def test_round_trips_through_lab_to_rgb(self):
+        """Sanity check only.
+
+        Both directions divide by the same white point, so this cannot detect a
+        wrong one -- a D65 pairing round trips just as cleanly. The white point
+        is pinned by the Photoshop tables and by the two exactness tests above.
+        """
+        worst = 0.0
+        for r in range(0, 256, 51):
+            for g in range(0, 256, 51):
+                for b in range(0, 256, 51):
+                    source = (r / 255.0, g / 255.0, b / 255.0)
+                    back = lab_to_rgb(*rgb_to_lab(*source))
+                    worst = max(worst, max(abs(x - y) for x, y in zip(back, source)))
+        assert worst * 255.0 < 0.01
+
+
+def test_module_doctests_run_and_pass():
+    """The module's doctests are otherwise dead documentation.
+
+    ``addopts`` carries no ``--doctest-modules`` and there is no Sphinx doctest
+    build in CI, so nothing collected these until now -- which is how
+    ``rgb_to_grayscale``'s example came to claim 1.0 for a call that returns
+    0.9999999999999999.
+    """
+    result = doctest.testmod(psd_tools.color_convert, verbose=False)
+    assert result.attempted > 0
+    assert result.failed == 0


### PR DESCRIPTION
Closes #743. Closes #752.

Two mirror-image gaps, in one PR because they are the same conversion read in
opposite directions. Splitting them would mean either stacking branches or
making the white-point decision twice — and per **B1** below, that decision
needed care.

- **#743's second half** — a Lab descriptor on a **non**-Lab document was read
  with a `/255` divisor that suits none of its three components. RGB and indexed
  got the raw triple, so signed chroma was read as unsigned and `L = 100` arrived
  at 0.39; the narrower modes reduced from `L` alone, so two colours differing
  only in chroma collapsed to one value.
- **#752** — `_from_rgb()` had no Lab branch, so any other descriptor class fell
  through `return rgb` into a Lab array. Three channels is a legal width, so
  nothing complained: red simply arrived as `(1.0, 0.0, 0.0)`, which those arrays
  read as white at the extreme green-blue corner, against Photoshop's
  `(0.543, 0.819, 0.776)`.

## The conversion

`psd_tools.color_convert` gains `lab_to_rgb` and `rgb_to_lab` — D50 with
Bradford-adapted sRGB matrices, CIE 15:2004 transfer function. Lab is in native
CIE units there (`L` 0..100, signed a/b), which is the one exception to the
module's normalized-float rule; the module docstring now states the rule
properly, and the module finally has a Sphinx reference page.

## Ground truth, and a correction to how it was read

Photoshop 2026 over the scripting bridge, both directions. One thing had to be
understood first: **Photoshop's `SolidColor` does not report Lab a/b in native
units.** It reports them through the signed 8-bit encoding it stores them in:

```
a_reported = a_true * (255/256) - 0.5
```

which is why every neutral colour comes back as `a = b = -0.5` rather than 0.
Both constants come from the encoding — nothing is fitted. Undoing it:

| | as read | de-encoded |
| --- | --- | --- |
| `rgb_to_lab`, 18 colours | max 0.87 Lab units | **max 0.014** |
| `lab_to_rgb`, 15 colours | max 7.49/255 | **≤0.10/255 on 12 of 15** |

The two exceptions are named in the test with their reasons rather than hidden
under a loose global tolerance: `Lab(10,60,60)` is outside sRGB and Photoshop
desaturates where we clip per channel, and `Lab(0,0,0)` comes back as
(1.27, 0, 0.03) — black point compensation.

This is why the tolerances (0.05 Lab units, 0.5/255) are derived from a stated
model rather than from measuring what this implementation happens to produce.

## The white point is not a free choice

The matrices are Lindbloom's Bradford-adapted pair, whose rows sum to
`(0.96422, 1.0, 0.82521)`. Pairing them with the ICC PCS D50
`(0.9642, 1.0, 0.8249)` — the obvious thing to reach for — leaves the transform
without a fixed point: white returns 0.99981 in blue, and a neutral grey picks up
`b = -0.025`. The compositor truncates on the way out, so that lands on **byte
127** where `LAB_NEUTRAL_CHROMA` and Photoshop both write 128 — exactly the
off-by-one #751 just fixed, re-entering through a new door. Two tests pin it
(`test_white_is_exactly_white`, `test_a_grey_is_exactly_neutral`), and both fail
if the ICC triple is substituted.

D65 instead of D50 is wrong by mean 11.6/255, max 92.7/255.

## Blast radius: zero, and that is the point

A scan of every fixture for (document mode × descriptor colour class) finds **no
LAB document carrying a non-Lab descriptor, and no non-LAB document carrying a
Lab one.** Photoshop rewrites a fill descriptor into the document's own colour
class on save — verified both ways — so neither issue is authorable from
Photoshop and no fixture can hold one. A corpus sweep confirms it: 3778 render
events, **0 changed**. All the evidence here is unit-level against Photoshop's
own colour engine, by necessity.

That does not mean nothing changes for users. Two rendering changes, both
requiring a third-party writer, are called out in the changelog:

- The **reduction curve moves** for a Lab fill on a grayscale, bitmap, duotone or
  multichannel document — `L/255` becomes the BT.601 luminance of the converted
  colour, so even a neutral changes: `Lab(50, 0, 0)` goes from 0.196 to 0.466.
- A **grey fill on a Lab document** changes from the raw grey to its `L*`
  (0.6 → 0.632). `_get_gray` needed a Lab branch of its own: one channel is a
  legal width, so a grey fill was reaching the canvas as a bare lightness and
  being widened with a neutral a/b — right axis, wrong height.

The single-channel *widening* path deliberately still does not convert, and
`widen._lab`'s docstring now says so and why: a descriptor carries a colour
someone picked in a space, an arbitrary canvas channel does not.

## Tests

Every production change is mutation-checked, `__pycache__` cleared between runs:

| reverted | caught by |
| --- | --- |
| `_from_rgb` LAB branch | 2 tests |
| `_get_lab` routing | 3 tests |
| `_get_gray` LAB branch | 1 test |
| ICC PCS white point instead of Lindbloom's | 4 tests |
| D65 white point | 8 tests |
| `f * f * f` → `f ** 3` | 9 tests |

Two of those are worth explaining, because both started as tests that could not
see what they claimed to.

`lab_to_rgb` must be total — descriptor values are unvalidated file data — and
cubing overflows on a large float. `f ** 3` raises `OverflowError`; `f * f * f`
saturates to infinity and the clamp takes it from there. I originally guarded
this with an input clamp instead, then mutation-checking showed **removing that
clamp broke nothing**: it was dead code, because the multiplication had already
made the function total. It is gone, and the test now pins the mechanism that
does the work, across inf, NaN and ±1e308 on each of the three axes.

The NaN direction needed its own assertion. `_clamp` sends NaN to black only
because of its argument order, and reversing it to `max(low, min(high, value))`
sends it to white while still satisfying every "is it inside [0, 1]" check —
so the whole suite passed against the reversed form until this was added.

For the same reason, the grayscale and CMYK fills on a Lab document are pinned
as **values** rather than as agreement with the equivalent RGB descriptor. That
equivalence is how the code is built, so it cannot fail; an earlier draft proved
it by surviving deletion of both branches under test.

Three tests that pinned the deferred behaviour are replaced:
`test_lab_reduces_from_lightness_alone` (which asserted negating a/b changed
nothing) becomes `test_lab_chroma_reaches_every_target`, its exact inverse;
`test_lab_reduction_is_monotonic_in_lightness` keeps the monotonicity and drops
the K-only claim; and `test_lab_negative_chroma_clamps_on_an_rgb_target`, added
last PR to stop the `/255` path wrapping, goes with that path.

The module's doctests are now actually run. They were not — there is no
`--doctest-modules` and no Sphinx doctest build in CI — which is how
`rgb_to_grayscale`'s example came to claim `1.0` for a call that returns
`0.9999999999999999`. Corrected in passing, since it is in the file being
extended and blocked the new test.

## Filed, not fixed here

#754 — `_get_hsb()` divides hue by 300 instead of 360, so every non-zero hue is
rotated and hue 360 renders white instead of red. Found while assembling the
Photoshop tables; unrelated to Lab, and the only HSB fixture uses hue 0, the one
value where the two divisors agree.
