### PR TITLE
fix: merge a Lab composite's planes instead of reinterpreting them (#759)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,26 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Stop ``composite()`` shifting both chroma planes of a Lab document.
+  The result was built with ``Image.fromarray(pixels, "LAB")``, and PIL's
+  ``"LAB"`` unpacker reads the two chroma planes as *signed* and adds 128 --
+  so an array in the encoding the compositor carries, where byte 128 is
+  ``a = 0``, came back 128 off on both axes. Not a rounding gap but a different
+  colour: a flat ``Lab(60, 25, 25)`` converted to RGB as ``(0, 187, 255)``
+  where Photoshop puts it at ``(196, 126, 101)``. Every Lab document was
+  affected, and ``composite()`` disagreed with
+  :py:meth:`~psd_tools.api.psd_image.PSDImage.topil` on the same file --
+  ``topil()`` builds with ``Image.merge()``, which writes the planes verbatim
+  and was right all along. The planes are now merged the same way, and three of
+  the five Lab documents in the test corpus composite bitwise-identically to
+  Photoshop's own preview where before every one of them was 128 out.
+
+  ``numpy()`` and :py:func:`psd_tools.composite.composite` were never affected;
+  the arrays were correct and only the PIL step corrupted them. Note that
+  ``np.asarray()`` on a ``"LAB"`` image reads PIL's internal buffer rather than
+  the values ``getpixel()`` reports, which is why the round trip looked right
+  (#759).
+
 - [fix] Size and interpret a colour-noise gradient from the document rather
   than from its descriptor. A noise gradient carries a colour space of its own
   -- Photoshop offers RGB, HSB and Lab, and keeps whichever was chosen in every

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -234,6 +234,28 @@ def composite_pil(
         # document came back as the bits of its first four bytes. Build the
         # plane in "L", where a byte is a pixel, and reduce it afterwards.
         image = Image.fromarray(pixels, "L").convert("1", dither=Image.Dither.NONE)
+    elif mode == "LAB":
+        # The same trap as "1", in a different raw mode. PIL's "LAB" unpacker
+        # reads the two chroma planes as *signed* and adds 128, so an array in
+        # the encoding the compositor carries -- where byte 128 is ``a = 0``,
+        # the file's own convention -- lands 128 off on both axes. That is not
+        # a slightly wrong colour but an unrelated one: a flat Lab(60, 25, 25)
+        # converted to RGB as (0, 187, 255) where Photoshop puts it at
+        # (196, 126, 101). Merging plane by plane writes them verbatim, which
+        # is what `pil_io._merge_channels()` does for `topil()`; the two
+        # disagreed until #759.
+        #
+        # `np.asarray()` cannot see the difference -- it reads PIL's internal
+        # buffer, which is offset the other way, so a round trip through
+        # `fromarray` is the identity. `getpixel()`, `convert()` and `save()`
+        # all see it.
+        image = Image.merge(
+            mode,
+            [
+                Image.fromarray(np.ascontiguousarray(pixels[:, :, band]), "L")
+                for band in range(pil_channels)
+            ],
+        )
     else:
         image = Image.fromarray(pixels, mode)
     alpha_as_image = None

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -877,6 +877,22 @@ def test_composite_pil_force_covers_every_colour_mode(
     assert image.mode == mode
 
 
+def _pixels_as_seen(image: Image.Image) -> np.ndarray:
+    """The planes a consumer of *image* reads, rather than PIL's own buffer.
+
+    The two differ for exactly one mode reachable here. PIL stores ``"LAB"``
+    with its chroma planes offset from the values ``getpixel()`` reports, and
+    ``np.asarray()`` reads the buffer -- so a round trip out through
+    ``Image.fromarray(..., "LAB")`` and back is the identity no matter what the
+    unpacker does in between. That is why a NumPy-only assertion could not see
+    #759, where the composited image carried both chroma planes 128 off and
+    converted to an unrelated colour. ``getdata()`` goes through the unpacker,
+    which is what ``convert()`` and ``save()`` do too.
+    """
+    planes = np.array(image.getdata(), dtype=np.uint8)
+    return planes.reshape(image.size[1], image.size[0], -1)
+
+
 @pytest.mark.parametrize("colormode", ["bitmap", "lab", "cmyk"])
 def test_composite_pil_force_pixels_match_the_numpy_path(colormode: str) -> None:
     """The three modes that carry no alpha, compared bitwise rather than by mode.
@@ -908,6 +924,10 @@ def test_composite_pil_force_pixels_match_the_numpy_path(colormode: str) -> None
         # post_process() inverts CMYK on the way out; compare on that footing.
         expected = 255 - expected
     actual = np.asarray(image)
+    if colormode == "lab":
+        # `np.asarray()` is not an independent check for "LAB" -- see
+        # `_pixels_as_seen()`. Read the planes the way a consumer does.
+        actual = _pixels_as_seen(image)
     if actual.ndim == 2:
         actual = actual[:, :, None]
     assert np.array_equal(actual, expected)
@@ -1293,3 +1313,56 @@ def test_composite_mixed_colorspace_stroke() -> None:
         if isinstance(layer, GroupMixin):
             for sublayer in layer:
                 sublayer.composite()
+
+
+def test_lab_composite_agrees_with_the_preview_it_reproduces() -> None:
+    """The two entry points onto a Lab document returned different colours.
+
+    ``topil()`` builds its image with ``Image.merge()``, which writes the
+    planes verbatim; ``composite_pil()`` used ``Image.fromarray(..., "LAB")``,
+    whose unpacker reads the chroma as signed and adds 128. On a document whose
+    composite does reproduce its stored preview the two are directly
+    comparable, and they were 128 apart on both chroma axes (#759).
+
+    All three of these composite to their preview *bitwise* now. Every Lab
+    document in the corpus moved towards its preview: the two left out do not
+    reach zero for reasons that predate this and are not about chroma -- the
+    16-bit fixture's own lightness plane is 108 out, and the stroke fixture
+    carries the stroke approximation.
+    """
+    for name in (
+        "colormodes/4x4_8bit_lab.psd",
+        "descriptors/lab-color-swatches.psd",
+        "gradients/noise-gradient-lab.psd",
+    ):
+        psd = PSDImage.open(full_name(name))
+        assert psd.color_mode == ColorMode.LAB
+        preview_image = psd.topil()
+        composited_image = psd.composite(ignore_preview=True)
+        assert isinstance(preview_image, Image.Image)
+        assert isinstance(composited_image, Image.Image)
+        preview = _pixels_as_seen(preview_image)
+        composited = _pixels_as_seen(composited_image)
+        assert np.array_equal(preview, composited), name
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_lab_composite_converts_to_the_colour_it_encodes(force: bool) -> None:
+    """What the planes *mean*, which no byte-level assertion here establishes.
+
+    The band sampled is a flat ``Lab(60, 25, 25)`` -- a noise gradient with
+    ``Mnm `` equal to ``Mxm ``, from the fixture added in #758. Photoshop
+    2026's own colour engine, asked over the scripting bridge, puts it at
+    ``rgb(196, 126, 101)``.
+
+    Before the fix this converted to ``(0, 187, 255)``: not a rounding gap but
+    a different colour, which is the whole of #759. The tolerance is loose
+    enough to survive Pillow's own conversion drifting a code value and still
+    nowhere near admitting that.
+    """
+    psd = PSDImage.open(full_name("gradients/noise-gradient-lab.psd"))
+    image = psd.composite(ignore_preview=True, force=force, apply_icc=False)
+    assert isinstance(image, Image.Image)
+    assert image.mode == "LAB"
+    rendered = np.array(image.convert("RGB").getpixel((4, 20)), dtype=float)
+    assert np.abs(rendered - np.array([196.0, 126.0, 101.0])).max() <= 2.0


### PR DESCRIPTION
Fixes #759.

`composite_pil()` built its result with `Image.fromarray(pixels, mode)`. For every
mode but `"LAB"` that is a relabelling of the bytes. PIL's `"LAB"` unpacker reads the
two chroma planes as **signed** and adds 128, so an array in the encoding the
compositor carries — where byte 128 is `a = 0`, the file's own convention — came back
128 off on both axes.

This is the same trap the `"1"` branch immediately above it already documents, in a
different raw mode.

## The array was never wrong

`psd_tools.composite.composite()` and `numpy()` both return the right planes, and
`topil()` returns the right image — `pil_io._merge_channels()` builds it with
`Image.merge()`, which writes the planes verbatim. Only the one construction site
corrupted them, so the two entry points onto the same file disagreed:

```python
psd = PSDImage.open("tests/psd_files/colormodes/4x4_8bit_lab.psd")
[round(float(v) * 255) for v in psd.numpy()[1, 1]]  # [48, 180, 43]
psd.topil().getpixel((1, 1))                        # (48, 180, 43)
psd.composite(ignore_preview=True).getpixel((1, 1)) # (48,  52, 171)   ← before
```

And it was a different colour, not a near one. On the flat `Lab(60, 25, 25)` band of
the fixture added in #758 — Photoshop 2026's own colour engine, over the scripting
bridge, puts that at `rgb(196, 126, 101)`:

| | `.convert("RGB")` |
| --- | --- |
| before | `(0, 187, 255)` |
| after | `(195, 127, 102)` |

## Result across the corpus

Only Lab documents move — every other file's PIL output is byte-identical, both force
modes. All five Lab documents move *towards* Photoshop's own preview, and three land
on it exactly:

| fixture | max diff vs preview, before → after |
| --- | --- |
| `colormodes/4x4_8bit_lab.psd` | 128 → **0** |
| `descriptors/lab-color-swatches.psd` | 128 → **0** |
| `gradients/noise-gradient-lab.psd` | 128 → **0** |
| `descriptors/stroke-color-descriptors-lab.psd` | 129 → 78 |
| `colormodes/4x4_16bit_lab.psd` | 183 → 114 |

The two that do not reach zero keep residuals that predate this and are not about
chroma — the 16-bit fixture's own *lightness* plane is 108 out, and the stroke fixture
carries the stroke approximation.

## Why the existing test could not see it

`test_composite_pil_force_pixels_match_the_numpy_path[lab]` exists precisely to catch
wrong pixels behind a right-looking mode, and it passed throughout. It compares
through `np.asarray()`, which reads PIL's *internal* buffer — so a round trip out
through `Image.fromarray(..., "LAB")` and back is the identity no matter what the
unpacker does in between. `getpixel()`, `convert()` and `save()` all see the shift;
NumPy does not.

That test now reads the planes through `getdata()`, and I checked it fails on the old
code. Two tests are added alongside it: one pinning that `composite()` and `topil()`
agree on the three fixtures above, and one pinning what the planes *mean*, by
converting to RGB and comparing against Photoshop's own answer.
