### PR TITLE
fix: convert a scalar backdrop rather than broadcasting it (#753)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,24 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Convert a scalar backdrop instead of broadcasting it across every
+  channel. ``composite()`` accepts its backdrop as a scalar, a per-channel
+  sequence or a full array, and the single-channel *array* spelling has gone
+  through the colour mode's conversion since 1.10.8 -- but the scalar was
+  expanded with ``np.full()``, so the same backdrop had two answers depending
+  on how it was written. A scalar now takes the same conversion, and only a
+  genuinely single component is converted: a per-channel sequence is left
+  exactly as given.
+
+  On a **Lab** document this was the default backdrop. ``color=1.0`` put both
+  chroma axes at byte 255 -- the extreme corner of each -- so a document
+  composited against maximum chroma at maximum lightness where white is
+  ``(255, 128, 128)``. On a **CMYK** document the default is unaffected, since
+  ``1.0`` is white either way, but other scalars were the over-inked build that
+  widening exists to avoid: ``color=0.0`` broadcast to ``(0, 0, 0, 0)``, every
+  plate at 100%. RGB, grayscale, indexed and multichannel are unchanged --
+  replication is the conversion there (#753).
+
 - [fix] Stop ``composite()`` shifting both chroma planes of a Lab document.
   The result was built with ``Image.fromarray(pixels, "LAB")``, and PIL's
   ``"LAB"`` unpacker reads the two chroma planes as *signed* and adds 128 --

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,12 +6,15 @@ Changelog
 
 - [fix] Convert a scalar backdrop instead of broadcasting it across every
   channel. ``composite()`` accepts its backdrop as a scalar, a per-channel
-  sequence or a full array, and the single-channel *array* spelling has gone
-  through the colour mode's conversion since 1.10.8 -- but the scalar was
-  expanded with ``np.full()``, so the same backdrop had two answers depending
-  on how it was written. A scalar now takes the same conversion, and only a
-  genuinely single component is converted: a per-channel sequence is left
-  exactly as given.
+  sequence or a full array. #722, in this same release, taught the
+  single-channel *array* spelling to go through the colour mode's conversion,
+  but the scalar path was missed and stayed on ``np.full()`` -- so the same
+  backdrop had two answers depending on how it was written. A scalar now takes
+  the same conversion, and only a genuinely single component is converted: a
+  per-channel sequence is left exactly as given. Both halves land together, so
+  no released version carries the split; what *is* longstanding is the colour
+  below, which every released version got wrong by broadcasting either
+  spelling.
 
   On a **Lab** document this was the default backdrop. ``color=1.0`` put both
   chroma axes at byte 255 -- the extreme corner of each -- so a document

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -604,6 +604,16 @@ def _to_canvas(
         else:
             array = widen(array, shape[2])
         return array
+    if not exact_channels and array.size == 1 and shape[2] > 1:
+        # One color component, which is what the single-channel array above is
+        # too -- so it takes the same conversion rather than being broadcast
+        # across channels that do not share an axis. Spelling the same backdrop
+        # two ways used to give two answers: on a Lab document `color=1.0` --
+        # the public default -- came out (255, 255, 255), maximum chroma at
+        # maximum lightness, where the one-channel array spelling of it already
+        # gave the (255, 128, 128) that is white (#753).
+        single = np.full((shape[0], shape[1], 1), array, dtype=np.float32)
+        return widen(single, shape[2])
     try:
         return np.full(shape, array, dtype=np.float32)
     except ValueError:

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -579,7 +579,13 @@ def _to_canvas(
     ``exact_channels`` rejects any mismatch outright instead, for alpha, which
     is single-channel by definition and would otherwise reach
     ``composite_pil()`` and be concatenated into a color array of the wrong
-    width. Anything else (a scalar, a per-channel sequence) is broadcast.
+    width.
+
+    A scalar is one color component, exactly as that single-channel array is,
+    so it is widened the same way rather than being broadcast across channels
+    that do not share an axis (#753). A per-channel sequence is broadcast as
+    given: its width is the caller's statement of the colour, not something to
+    reinterpret.
     """
     array = np.asarray(value, dtype=np.float32)
     if array.ndim == 3:

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -275,6 +275,55 @@ def test_normalize_backdrop_widens_a_single_channel_canvas() -> None:
     assert result.shape == (2, 2, 1)
 
 
+def test_normalize_backdrop_converts_a_scalar_like_a_single_channel_canvas() -> None:
+    """The two spellings of one color component must resolve the same way.
+
+    A scalar backdrop was broadcast across every channel while the identical
+    value spelled as a one-channel canvas went through the mode's conversion,
+    so the same backdrop had two answers. On a Lab document the scalar one was
+    not a color at all: ``1.0`` put both chroma axes at byte 255, the extreme
+    corner of each, where white is ``(255, 128, 128)`` (#753).
+    """
+
+    def lab_widen(color: np.ndarray, channels: int) -> np.ndarray:
+        """Stands in for ``make_widen()`` on a Lab document."""
+        neutral = np.full_like(color, 128.0 / 255.0)
+        return np.concatenate((color, neutral, neutral), axis=2)
+
+    for value in (0.0, 0.25, 1.0):
+        scalar, _ = _normalize_backdrop(value, 0.0, 2, 2, 3, widen=lab_widen)
+        canvas, _ = _normalize_backdrop(gray(value), 0.0, 2, 2, 3, widen=lab_widen)
+        assert np.array_equal(scalar, canvas), value
+        assert scalar[0, 0, 0] == pytest.approx(value)
+        assert scalar[0, 0, 1] == pytest.approx(128.0 / 255.0)
+        assert scalar[0, 0, 2] == pytest.approx(128.0 / 255.0)
+
+
+def test_normalize_backdrop_leaves_a_per_channel_sequence_alone() -> None:
+    """Only a *single* component is converted; a full tuple is already canvas.
+
+    The rule is the width the caller supplied, not the value: ``(1.0, 1.0,
+    1.0)`` is three components that happen to be equal, and reinterpreting it
+    would overwrite a backdrop the caller spelled out per channel.
+    """
+
+    def explode(color: np.ndarray, channels: int) -> np.ndarray:
+        raise AssertionError("a per-channel sequence must not be widened")
+
+    result, _ = _normalize_backdrop(WHITE, 0.0, 2, 2, 3, widen=explode)
+    assert np.array_equal(result, rgb(WHITE))
+
+
+def test_normalize_backdrop_scalar_needs_no_conversion_at_one_channel() -> None:
+    """A grayscale document has nothing to widen into."""
+
+    def explode(color: np.ndarray, channels: int) -> np.ndarray:
+        raise AssertionError("a one-channel canvas must not be widened")
+
+    result, _ = _normalize_backdrop(0.25, 0.0, 2, 2, 1, widen=explode)
+    assert np.array_equal(result, gray(0.25))
+
+
 def test_normalize_backdrop_infers_channels_when_none_is_given() -> None:
     """The defensive fallback for when no document names a color mode.
 

--- a/tests/psd_tools/composite/test_widen.py
+++ b/tests/psd_tools/composite/test_widen.py
@@ -279,3 +279,49 @@ def test_pattern_overlay_reuses_the_threaded_conversion(monkeypatch) -> None:
         "the document was resolved %d times for %d pattern overlays; it should "
         "be resolved once per composite() and threaded" % (len(resolved), len(drawn))
     )
+
+
+def test_scalar_backdrop_reaches_the_conversion_on_a_lab_document() -> None:
+    """The default backdrop, which is where #753 actually bites.
+
+    ``composite()`` defaults to ``color=1.0``, so this is what a Lab document
+    composites against wherever nothing covers it. Broadcasting that scalar put
+    both chroma axes at 1.0 -- byte 255, the extreme corner of each -- so the
+    default backdrop was maximum chroma at maximum lightness rather than white,
+    which on a Lab canvas is ``(255, 128, 128)``.
+
+    The viewport is wider than the layer so that bare backdrop is exposed;
+    without that the layer covers every pixel and the backdrop never shows.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_lab.psd"))
+    color, _, _ = composite(psd[0], viewport=(0, 0, 8, 8), force=True)
+    bare = color[7, 7]
+    assert bare[0] == pytest.approx(1.0)
+    assert bare[1] == pytest.approx(128 / 255, abs=1e-6)
+    assert bare[2] == pytest.approx(128 / 255, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["colormodes/4x4_8bit_lab.psd", "colormodes/4x4_8bit_cmyk.psd"],
+)
+@pytest.mark.parametrize("value", [0.0, 0.25, 1.0])
+def test_scalar_and_single_channel_backdrops_agree(filename: str, value: float) -> None:
+    """The same backdrop, spelled two ways, end to end.
+
+    This is the defect underneath #753 rather than one mode's symptom: the
+    array spelling went through the conversion #722 added and the scalar did
+    not, so which answer a caller got depended on how they happened to write
+    it. Lab is where that produced a colour off the neutral axis entirely;
+    CMYK is where it produced the over-inked build this module exists to avoid
+    -- ``0.0`` broadcast to ``(0, 0, 0, 0)``, which is every plate at 100%.
+    """
+    psd = PSDImage.open(full_name(filename))
+    canvas = np.full((psd.height, psd.width, 1), value, dtype=np.float32)
+    scalar_color, _, _ = composite(
+        psd, color=value, alpha=1.0, layer_filter=lambda layer: False
+    )
+    canvas_color, _, _ = composite(
+        psd, color=canvas, alpha=1.0, layer_filter=lambda layer: False
+    )
+    assert np.array_equal(scalar_color, canvas_color)


### PR DESCRIPTION
Fixes #753.

`_to_canvas()` expanded a scalar backdrop with `np.full()`, putting the same value in
every channel. The single-channel *array* spelling of the same backdrop has gone
through the colour mode's conversion since #722 — so which answer a caller got
depended only on how they happened to write it:

```python
psd = PSDImage.open("tests/psd_files/colormodes/4x4_8bit_lab.psd")
composite(psd[0], viewport=(0, 0, 8, 8), force=True)[0][7, 7]
# before: [1., 1., 1.]           -> bytes (255, 255, 255)
composite(psd[0], viewport=(0, 0, 8, 8), force=True, color=np.full((8, 8, 1), 1.0))[0][7, 7]
# already: [1., 0.502, 0.502]    -> bytes (255, 128, 128), which is white
```

A scalar is one colour component, which is exactly what that one-channel array is, so
it now takes the same conversion. Only a *genuinely single* component is converted — a
per-channel sequence is left exactly as given, since its width is the caller's
statement rather than something to reinterpret.

## Lab: this was the default backdrop

`composite()` defaults to `color=1.0`, so every Lab document composited against
maximum chroma at maximum lightness wherever nothing covered it — both chroma axes at
byte 255, the extreme corner of each, rather than the 128 that means neutral.

## CMYK moves too, which the issue says it should not

Flagging this because it contradicts the issue's closing paragraph, and @kyamagu
confirmed the wider scope before I landed it.

That paragraph checks the endpoints, and `1.0` genuinely is white either way. But
`0.0` is not:

| CMYK backdrop | before (broadcast) | after (converted) |
| --- | --- | --- |
| `color=1.0` — the default | `(1, 1, 1, 1)` | `(1, 1, 1, 1)` — unchanged |
| `color=0.0` | `(0, 0, 0, 0)` — every plate at 100% | `(0.26, 0.32, 0.33, 0.10)` |
| `color=0.5` | `(0.5, 0.5, 0.5, 0.5)` | `(0.49, 0.56, 0.56, 0.92)` |

Those middle values are the over-inked build `widen.py`'s own module docstring gives
as the reason this conversion exists at all. Fixing only Lab would have closed the
inconsistency in one mode and left it standing in another, for the same reason and
with the same fix available.

RGB, grayscale, indexed and multichannel are unchanged — replication *is* the
conversion there.

## Blast radius

Rendered every fixture at four backdrops with a viewport wider than the canvas, so
bare backdrop is exposed:

- At the **default** backdrop, only the two Lab documents move.
- CMYK fixtures move only for scalars other than `1.0` (14 documents).
- Everything else is byte-identical.

## Tests

Seven added, and I checked all seven fail without the fix:

- the invariant itself — a scalar and a one-channel canvas of the same value resolve
  identically, end to end, on both Lab and CMYK;
- the Lab default backdrop, which is the issue's own repro;
- two negative cases — a per-channel sequence is never widened, and a grayscale
  document has nothing to widen into.

Note that `test_scalar_and_single_channel_backdrops_agree[1.0-…cmyk.psd]` passes
without the fix, which is the CMYK default being genuinely unaffected showing up in
the suite rather than only in the table above.
