### PR TITLE
fix: return a writeable native float32 array at depth 32 (#738)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,25 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Read a 32-bit document with transparency through
+  :py:meth:`~psd_tools.api.psd_image.PSDImage.numpy`, which raised
+  ``ValueError: assignment destination is read-only``. Photoshop writes 32-bit
+  RGB with a transparency channel routinely, so this was an ordinary file
+  shape rather than a malformed one, and
+  :py:func:`psd_tools.composite.composite` failed with it for the same reason.
+  ``topil()`` was unaffected, and ``PSDImage.composite()`` only appeared to be
+  because it short-circuits to the stored preview.
+
+  ``_parse_array()`` rescales at depths 1, 8 and 16, and the conversion that
+  needs hands back a fresh, writeable, native-endian array. Depth 32 needs no
+  rescaling, so it returned ``np.frombuffer()``'s view of the file's bytes --
+  read-only, and still big-endian where every other depth returns
+  ``np.float32``. Un-premultiplying the preview writes in place, and it runs
+  only for RGB with transparency, which is why just that one combination
+  raised. All four depths now return the same kind of array. The cost is one
+  more array the size of the merged image data on 32-bit documents, which is
+  what the other three depths already allocate (#738).
+
 - [fix] Convert a scalar backdrop instead of broadcasting it across every
   channel. ``composite()`` accepts its backdrop as a scalar, a per-channel
   sequence or a full array. #722, in this same release, taught the

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -220,7 +220,15 @@ def _parse_array(
     elif depth == 16:
         return np.frombuffer(data, ">u2").astype(np.float32) / 65535.0
     elif depth == 32:
-        return np.frombuffer(data, ">f4")
+        # The conversion the other three branches get for free from their own
+        # rescaling, spelled out here because 32-bit data needs no rescaling.
+        # Without it this branch alone returned an array that was neither
+        # writeable -- `np.frombuffer` over immutable `bytes` is read-only, and
+        # `_remove_background()` writes in place, so a 32-bit RGB document with
+        # transparency raised `assignment destination is read-only` -- nor
+        # `np.float32`, since it kept the file's big-endian byte order where
+        # every other depth returns the native dtype (#738).
+        return np.frombuffer(data, ">f4").astype(np.float32)
     elif depth == 1:
         return np.unpackbits(np.frombuffer(data, np.uint8)).astype(np.float32)
     else:

--- a/tests/psd_tools/api/test_numpy_io.py
+++ b/tests/psd_tools/api/test_numpy_io.py
@@ -6,6 +6,7 @@ import pytest
 
 from psd_tools.api import numpy_io
 from psd_tools.api.psd_image import PSDImage
+from psd_tools.constants import ColorMode
 from psd_tools.psd.patterns import Pattern
 
 from ..utils import TEST_ROOT, full_name
@@ -34,11 +35,78 @@ def test_get_pattern(filename: str) -> None:
         ("rgba", 8),
         ("lab", 8),
         ("multichannel", 16),
+        # Depth 32 was missing from this sweep, which is part of why #738 stood:
+        # it is the one branch of `_parse_array` that does no rescaling, so it
+        # is the one that returned the raw buffer's dtype and mutability.
+        ("grayscale", 32),
+        ("rgb", 32),
     ],
 )
 def test_numpy_colormodes(colormode: str, depth: int) -> None:
     filename = "colormodes/4x4_%gbit_%s.psd" % (depth, colormode)
     psd = PSDImage.open(full_name(filename))
-    assert isinstance(psd.numpy(), np.ndarray)
+    array = psd.numpy()
+    assert isinstance(array, np.ndarray)
+    _assert_array_contract(array)
     for layer in psd:
-        assert isinstance(layer.numpy(), (np.ndarray, type(None)))
+        layer_array = layer.numpy()
+        assert isinstance(layer_array, (np.ndarray, type(None)))
+        if layer_array is not None:
+            _assert_array_contract(layer_array)
+
+
+def _assert_array_contract(array: np.ndarray) -> None:
+    """What every depth returns, which depth 32 alone did not (#738).
+
+    Native ``float32`` and writeable. The other three branches get both for
+    free from the ``.astype()`` their rescaling needs; 32-bit data needs no
+    rescaling, so it was handed back as ``np.frombuffer`` produced it -- a
+    read-only view carrying the file's big-endian dtype.
+    """
+    assert array.dtype == np.float32, array.dtype
+    assert array.dtype.byteorder in ("=", "|"), array.dtype.byteorder
+    assert array.flags.writeable
+
+
+@pytest.mark.parametrize("filename", ["transparentbg.psd", "transparentbg.psb"])
+def test_numpy_reads_a_32bit_document_with_transparency(filename: str) -> None:
+    """``numpy()`` raised on an ordinary Photoshop file shape (#738).
+
+    ``_remove_background()`` un-premultiplies the merged preview in place, and
+    it is reached only for RGB with a transparency channel -- so depth 32's
+    read-only array raised ``assignment destination is read-only`` there and
+    nowhere else. These two fixtures have shipped all along and reproduce it;
+    the issue was filed believing none did.
+    """
+    psd = PSDImage.open(full_name(filename))
+    assert (psd.depth, psd.color_mode, psd.channels) == (32, ColorMode.RGB, 4)
+
+    array = psd.numpy()  # would raise ValueError
+    _assert_array_contract(array)
+    assert array.shape == (psd.height, psd.width, 4)
+    assert psd.numpy("color").shape == (psd.height, psd.width, 3)
+    assert psd.numpy("shape").shape == (psd.height, psd.width, 1)
+
+    # Not merely non-raising: where the preview is opaque there is nothing to
+    # un-premultiply, so the colour has to agree with `topil()` -- which took
+    # the `Image.frombytes` path and worked throughout.
+    preview = np.asarray(psd.topil()).astype(np.float32) / 255.0
+    opaque = array[:, :, 3] > 0.999
+    assert opaque.any()
+    assert np.abs(array[:, :, :3][opaque] - preview[:, :, :3][opaque]).max() == 0.0
+
+
+def test_parse_array_does_not_alias_its_input() -> None:
+    """The mutability half, at the unit rather than the document level.
+
+    Writing into what ``_parse_array`` returns must not reach back into the
+    caller's buffer. A ``bytearray`` is used because the read-only-ness of the
+    ``bytes`` the real callers pass is what masked this: over a mutable buffer
+    ``np.frombuffer`` yields a *writeable* view, so the alias would be silent
+    corruption rather than a raise.
+    """
+    source = bytearray(np.arange(4, dtype=">f4").tobytes())
+    parsed = numpy_io._parse_array(source, 32)
+    assert np.array_equal(parsed, np.arange(4, dtype=np.float32))
+    parsed[0] = 99.0
+    assert bytearray(np.arange(4, dtype=">f4").tobytes()) == source


### PR DESCRIPTION
Fixes #738.

`_parse_array()` rescales at depths 1, 8 and 16, and the `.astype()` that needs hands
back a fresh, writeable, native-endian array as a side effect. Depth 32 needs no
rescaling, so it returned `np.frombuffer()`'s view of the file's bytes — read-only,
because the callers pass immutable `bytes`.

`_remove_background()` un-premultiplies the merged preview **in place**, and it is
reached only for RGB with a transparency channel. That is why exactly one combination
raised while a three-channel 32-bit document read fine:

```python
PSDImage.open("tests/psd_files/transparentbg.psd").numpy()
# ValueError: assignment destination is read-only
```

Photoshop writes 32-bit RGB with transparency routinely, so this is an ordinary file
shape.

## A second deviation, not in the issue

The same branch also kept the file's **big-endian** dtype, where every other depth
returns `np.float32`:

| depth | dtype | writeable |
| --- | --- | --- |
| 8 | `float32` | yes |
| 16 | `float32` | yes |
| **32** | **`>f4`** | **no** |

Both come from the same missing conversion, and both are fixed by it. The byte order
was wrong for every 32-bit caller regardless of mutability — visible even within one
file, since a *layer* array came back native `float32` (its `np.stack` copies) while
the document array did not.

## Why at the source

The issue offers making `_remove_background()` build a new array instead. Fixing
`_parse_array()` is the option it leans towards and I agree: the read-only view is a
trap for whoever touches it next, `_remove_background` is merely the first to trip it,
and only this end fixes the dtype. It costs one array the size of the merged image
data on 32-bit documents — which is what the other three depths already allocate.

## The fixture already existed

The issue says no shipped fixture combines depth 32 with a transparency channel. Two
do: **`transparentbg.psd` and `transparentbg.psb`**, both 32-bit RGB with 4 channels,
and both reproduce it. So no fixture authoring was needed.

I checked the recovered array is not merely non-raising. Where the preview is opaque
there is nothing to un-premultiply, so the colour must agree with `topil()` — which
took a different path and worked throughout — and it agrees **exactly**, 0.0 max
difference.

## Blast radius

Swept every fixture through `numpy()`, `numpy("color")`, `numpy("shape")` and
`numpy("mask")`. The only differences are the six calls that used to raise and now
return an array. Everything else is byte-identical.

## Tests

Five failing-before / passing-after:

- the regression on both `transparentbg` fixtures, including the `topil()` agreement;
- `test_numpy_colormodes` extended to depth 32, which it **skipped entirely** — part
  of why this stood — now asserting the dtype and mutability contract at every depth;
- a unit test that `_parse_array` does not alias its input, written over a `bytearray`
  on purpose: `np.frombuffer` yields a *writeable* view of a mutable buffer, so an
  alias there would be silent corruption rather than a raise.
