### PR TITLE
fix: saturate out-of-range descriptor colour components (#757)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,16 +5,24 @@ Changelog
 -------------------
 
 - [fix] Clamp a fill descriptor's colour components so an out-of-range value
-  saturates instead of wrapping to an unrelated colour (#757). Nothing in the
-  format constrains a component to the range its colour class normalizes by, and
-  :py:func:`psd_tools.composite.composite_pil` casts with
-  ``(255 * color).astype(np.uint8)``, which wraps: an ``HSBC`` at ``S = 120,
-  B = 150`` rendered grey-teal instead of red, an ``RGBC`` at ``Rd = 300``
-  rendered bright green instead of red, and a ``Grsc`` beyond black rendered
-  mid-grey. All five colour classes are now guarded where the untrusted number
-  enters, as Lab already was since #743, so ``color_convert``'s documented
-  ``[0, 1]`` input contracts stay unchanged. Hue is excluded on purpose: it is an
-  angle, so it still wraps.
+  saturates instead of corrupting the render (#757). Nothing in the format
+  constrains a component to the range its colour class normalizes by, so a
+  writer emitting ``Rd = 300`` or ``Gry = 150`` produces a value outside
+  ``[0, 1]``.
+
+  A flat opaque fill was shielded from this, because the compositor clips its
+  own arrays before the uint8 cast. What was not shielded is anything that
+  blends the value first -- a layer effect, a partial alpha, an anti-aliased
+  vector edge -- because the clip then runs on arithmetic that is already
+  wrong. A shape whose fill descriptor carries a beyond-black grey rendered
+  white pixels along its stroke, and a beyond-red ``HSBC`` rendered bright
+  cyan ones, where the stroke colour was dark grey.
+
+  All five colour classes are now guarded where the untrusted number enters, as
+  Lab already was since #743, so ``color_convert``'s documented ``[0, 1]``
+  input contracts stay unchanged. The colour-noise gradient's RGB path is
+  guarded too, since its bands come from raw ``"Mnm "``/``"Mxm "`` values. Hue is
+  excluded on purpose: it is an angle, so it still wraps.
 
   :py:func:`psd_tools.color_convert.hsb_to_rgb` is now total, matching
   :py:func:`~psd_tools.color_convert.lab_to_rgb`. Its documented ``[0, 1]``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,23 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Clamp a fill descriptor's colour components so an out-of-range value
+  saturates instead of wrapping to an unrelated colour (#757). Nothing in the
+  format constrains a component to the range its colour class normalizes by, and
+  :py:func:`psd_tools.composite.composite_pil` casts with
+  ``(255 * color).astype(np.uint8)``, which wraps: an ``HSBC`` at ``S = 120,
+  B = 150`` rendered grey-teal instead of red, an ``RGBC`` at ``Rd = 300``
+  rendered bright green instead of red, and a ``Grsc`` beyond black rendered
+  mid-grey. All five colour classes are now guarded where the untrusted number
+  enters, as Lab already was since #743, so ``color_convert``'s documented
+  ``[0, 1]`` input contracts stay unchanged. Hue is excluded on purpose: it is an
+  angle, so it still wraps.
+
+  :py:func:`psd_tools.color_convert.hsb_to_rgb` is now total, matching
+  :py:func:`~psd_tools.color_convert.lab_to_rgb`. Its documented ``[0, 1]``
+  result previously held only for in-range saturation and brightness, and a NaN
+  saturation propagated to the caller.
+
 - [fix] Read a 32-bit document with transparency through
   :py:meth:`~psd_tools.api.psd_image.PSDImage.numpy`, which raised
   ``ValueError: assignment destination is read-only``. Photoshop writes 32-bit

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 -------------------
 
 - [fix] Clamp a fill descriptor's colour components so an out-of-range value
-  saturates instead of corrupting the render (#757). Nothing in the format
+  saturates instead of corrupting the render (#757, #764). Nothing in the format
   constrains a component to the range its colour class normalizes by, so a
   writer emitting ``Rd = 300`` or ``Gry = 150`` produces a value outside
   ``[0, 1]``.

--- a/src/psd_tools/color_convert.py
+++ b/src/psd_tools/color_convert.py
@@ -133,11 +133,20 @@ def hsb_to_rgb(h: float, s: float, v: float) -> tuple[float, float, float]:
     achromatic fallback for everything else out of range, which turned a fully
     saturated hue into grey rather than into the color one turn away (#754).
 
+    Saturation and brightness are not angles, so they clamp rather than wrap.
+
+    Total: any float, including infinities and NaN, returns a triple inside
+    ``[0, 1]`` rather than raising or propagating. Descriptor values are
+    unvalidated file data, and the ``Returns:`` line below used to hold only for
+    in-range ``s``/``v`` -- ``s = 1.2, v = 1.5`` gave ``(1.5, -0.3, -0.3)``,
+    which the uint8 cast in ``composite_pil()`` *wraps* into an unrelated color
+    (#757). Same policy as :py:func:`lab_to_rgb`.
+
     Args:
         h: Hue as a fraction of a full turn, cyclic. Any value is folded
             back onto the circle, where 1.0 is the same hue as 0.0.
-        s: Saturation in [0.0, 1.0].
-        v: Brightness (value) in [0.0, 1.0].
+        s: Saturation in [0.0, 1.0]. Outside that it saturates.
+        v: Brightness (value) in [0.0, 1.0]. Outside that it saturates.
 
     Returns:
         3-tuple ``(R, G, B)`` with each component in [0.0, 1.0].
@@ -145,7 +154,14 @@ def hsb_to_rgb(h: float, s: float, v: float) -> tuple[float, float, float]:
     Examples:
         >>> hsb_to_rgb(0.0, 0.0, 0.5)   # achromatic 50% grey
         (0.5, 0.5, 0.5)
+        >>> hsb_to_rgb(0.0, 1.2, 1.5)   # out of range, saturated not wrapped
+        (1.0, 0.0, 0.0)
     """
+    # Before the ``not s`` test, so that a NaN saturation reaches it as 0.0 and
+    # takes the achromatic answer rather than propagating through the sector
+    # arithmetic below.
+    s = _clamp(s, 0.0, 1.0)
+    v = _clamp(v, 0.0, 1.0)
     if not s:
         return (v, v, v)
     if not math.isfinite(h):

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -226,7 +226,14 @@ def composite_pil(
         color = color[:, :, 0]
     if color.shape[0] == 0 or color.shape[1] == 0:
         return None
-    pixels = (255 * color).astype(np.uint8)
+    # Clipped, not cast straight: numpy *wraps* an out-of-range float, so a
+    # component at 1.2 would arrive as byte 51 rather than as white -- an
+    # unrelated colour instead of a saturated one (#757). Every producer that
+    # can leave [0, 1] is guarded at its own source, and no file under
+    # tests/psd_files reaches here out of range in either force mode, so this
+    # changes nothing today; it is here so that the failure mode of a future
+    # one is a clipped colour rather than a wrapped one.
+    pixels = np.clip(255 * color, 0, 255).astype(np.uint8)
     if mode == "1":
         # `fromarray(uint8, "1")` does not mean "these bytes, as bilevel". PIL
         # takes the raw mode literally at one bit per pixel, so it consumes one

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -227,12 +227,16 @@ def composite_pil(
     if color.shape[0] == 0 or color.shape[1] == 0:
         return None
     # Clipped, not cast straight: numpy *wraps* an out-of-range float, so a
-    # component at 1.2 would arrive as byte 51 rather than as white -- an
-    # unrelated colour instead of a saturated one (#757). Every producer that
-    # can leave [0, 1] is guarded at its own source, and no file under
-    # tests/psd_files reaches here out of range in either force mode, so this
-    # changes nothing today; it is here so that the failure mode of a future
-    # one is a clipped colour rather than a wrapped one.
+    # component at 1.2 would arrive as byte 50 rather than as white -- an
+    # unrelated colour instead of a saturated one (#757).
+    #
+    # Nothing reaches here out of range today: `Compositor` clips its own
+    # arrays, the descriptor readers clamp at the source, and no file under
+    # tests/psd_files arrives out of range in either force mode even with a
+    # deliberately out-of-range backdrop. So this changes no output; it is here
+    # so the failure mode of the next producer is a clipped colour rather than
+    # a wrapped one. Note it does not make the cast total -- np.clip passes NaN
+    # through -- so it is a narrowing of the damage, not a guarantee.
     pixels = np.clip(255 * color, 0, 255).astype(np.uint8)
     if mode == "1":
         # `fromarray(uint8, "1")` does not mean "these bytes, as bilevel". PIL

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -52,18 +52,21 @@ def _clamp01(value: float) -> float:
     writer emitting ``a = 200`` yields 1.29, ``Gry = 150`` yields -0.5 and
     ``Rd   = 300`` yields 1.18.
 
-    Two things then go wrong with a component outside ``[0, 1]``, and the
-    second is the one that shows. ``composite_pil()`` casts with
-    ``(255 * color).astype(np.uint8)``, and numpy *wraps* rather than
-    saturating, so those three land on bytes 72, 129 and 44. That cast is
-    mostly shielded, because ``Compositor`` runs ``utils.clip()`` on its own
-    arrays. But the clip runs *after* the value has been blended, so wherever
+    A component outside ``[0, 1]`` reaches the image by two routes, and only
+    one of them is still open. ``Compositor`` runs ``utils.clip()`` on its own
+    arrays, but the clip runs *after* the value has been blended, so wherever
     the color is composited rather than laid down flat -- an effect, a partial
-    alpha, an anti-aliased vector edge -- it corrupts the arithmetic first and
-    the clip has nothing left to recover. Forging ``Gry = 150`` into
-    ``adjustment-fillers.psd`` puts 194 white pixels along the shape's stroke
-    where the stroke is ``(26, 26, 26)``, and ``H = 0, Strt = 120, Brgh = 150``
-    puts 150 bright cyan ones there (#757).
+    alpha, an anti-aliased vector edge -- the out-of-range component corrupts
+    the arithmetic first and clipping has nothing left to recover. Forging
+    ``Gry = 150`` into ``adjustment-fillers.psd`` puts 194 white pixels along
+    the shape's stroke where the stroke is ``(26, 26, 26)``, and
+    ``H = 0, Strt = 120, Brgh = 150`` puts 150 bright cyan ones there (#757).
+
+    The closed route is the uint8 cast. ``composite_pil()`` used to write
+    ``(255 * color).astype(np.uint8)``, and numpy *wraps* rather than
+    saturating, so those three components would have landed on bytes 72, 129
+    and 44. It clips as of #757, so nothing here depends on that cast to
+    saturate; the two guards are independent on purpose.
 
     Clamping degrades to the end of the axis instead, which is the policy
     :py:func:`psd_tools.color_convert.lab_to_rgb` already follows. Applied

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -47,16 +47,25 @@ _SINGLE_CHANNEL_MODES = (
 def _clamp01(value: float) -> float:
     """Hold *value* inside the range a color array is allowed to carry.
 
-    Only the Lab encoding needs this. Lab's range is a convention the
-    descriptor does not enforce, so a writer emitting ``a = 200`` yields 1.29 --
-    and :py:func:`psd_tools.composite.composite_pil` casts with
-    ``(255 * color).astype(np.uint8)``, which *wraps* rather than saturates,
-    landing that on byte 71: not a clipped chroma but a colour unrelated to the
-    one asked for. Clamping degrades to the end of the axis instead.
+    Every descriptor color class normalizes by a fixed divisor, and nothing in
+    the format constrains the component to the range that divisor assumes: a
+    writer emitting ``a = 200`` yields 1.29, ``Strt = 120`` yields 1.2 and
+    ``Rd   = 300`` yields 1.18. :py:func:`psd_tools.composite.composite_pil`
+    then casts with ``(255 * color).astype(np.uint8)``, and numpy *wraps*
+    rather than saturating, so those land on bytes 71, 51 and 44 -- not clipped
+    components but colours unrelated to the ones asked for. A beyond-white grey
+    rendered mid-grey and a beyond-red RGB rendered bright green (#757).
+    Clamping degrades to the end of the axis instead, which is the policy
+    :py:func:`psd_tools.color_convert.lab_to_rgb` already follows.
 
-    :py:func:`psd_tools.color_convert.lab_to_rgb` clamps its own inputs and
-    output, so the values reaching here through ``_from_rgb()`` are already in
-    range; this guards the direct Lab-to-Lab path, which does no conversion.
+    Applied where the untrusted number enters rather than inside
+    ``color_convert``, so those conversions keep their documented ``[0, 1]``
+    input contracts instead of having to defend them.
+
+    NaN maps to 0.0, because ``nan > 0.0`` is false and ``max`` therefore keeps
+    its first argument. That is wanted -- a malformed descriptor degrades to the
+    end of the axis rather than poisoning the canvas -- but it is a property of
+    the argument order, so do not reverse it.
     """
     return min(1.0, max(0.0, value))
 
@@ -156,17 +165,24 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
     """
 
     def _get_int_color(color_desc: Descriptor, keys: tuple) -> tuple[float, ...]:
-        return tuple(float(color_desc[key]) / 255.0 for key in keys)
+        return tuple(_clamp01(float(color_desc[key]) / 255.0) for key in keys)
 
     def _get_invert_color(color_desc: Descriptor, keys: tuple) -> tuple[float, ...]:
-        return tuple((100.0 - float(color_desc[key])) / 100.0 for key in keys)
+        return tuple(_clamp01((100.0 - float(color_desc[key])) / 100.0) for key in keys)
 
     def _get_rgb(color_mode: ColorMode, color_desc: Descriptor) -> tuple[float, ...]:
         if Key.Red in color_desc:
             rgb = _get_int_color(color_desc, (Key.Red, Key.Green, Key.Blue))
         else:
+            # No divisor, unlike ``Rd  ``/``Grn ``/``Bl  ``: these components
+            # are the format's own normalized spelling. Nothing under
+            # tests/psd_files carries one, so that scale is taken on the
+            # format's word rather than measured here -- which is exactly why
+            # the clamp matters on this path. If the scale is what it claims,
+            # the clamp never fires; if it is not, an unexpected value
+            # saturates instead of wrapping to an unrelated colour (#757).
             rgb = tuple(
-                float(color_desc[key])
+                _clamp01(float(color_desc[key]))
                 for key in (Key.RedFloat, Key.GreenFloat, Key.BlueFloat)
             )
         return _from_rgb(color_mode, rgb)
@@ -178,6 +194,11 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         # six-sector table, where the achromatic fallback turned a fully
         # saturated red into white (#754).
         hue = float(color_desc[Key.Hue]) / 360.0
+        # Not clamped, unlike the other classes. Hue is cyclic, so 400 deg
+        # names a real angle and ``hsb_to_rgb`` wraps it; clamping would turn
+        # it into 360. Saturation and brightness are clamped by ``hsb_to_rgb``
+        # itself, which is total, so guarding them again here would defend the
+        # same two numbers twice (#757).
         saturation = float(color_desc[Key.Saturation]) / 100.0
         brightness = float(color_desc[Key.Brightness]) / 100.0
         # Every mode but RGB and CMYK used to raise here, which made an HSB

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -49,18 +49,29 @@ def _clamp01(value: float) -> float:
 
     Every descriptor color class normalizes by a fixed divisor, and nothing in
     the format constrains the component to the range that divisor assumes: a
-    writer emitting ``a = 200`` yields 1.29, ``Strt = 120`` yields 1.2 and
-    ``Rd   = 300`` yields 1.18. :py:func:`psd_tools.composite.composite_pil`
-    then casts with ``(255 * color).astype(np.uint8)``, and numpy *wraps*
-    rather than saturating, so those land on bytes 71, 51 and 44 -- not clipped
-    components but colours unrelated to the ones asked for. A beyond-white grey
-    rendered mid-grey and a beyond-red RGB rendered bright green (#757).
-    Clamping degrades to the end of the axis instead, which is the policy
-    :py:func:`psd_tools.color_convert.lab_to_rgb` already follows.
+    writer emitting ``a = 200`` yields 1.29, ``Gry = 150`` yields -0.5 and
+    ``Rd   = 300`` yields 1.18.
 
-    Applied where the untrusted number enters rather than inside
-    ``color_convert``, so those conversions keep their documented ``[0, 1]``
-    input contracts instead of having to defend them.
+    Two things then go wrong with a component outside ``[0, 1]``, and the
+    second is the one that shows. ``composite_pil()`` casts with
+    ``(255 * color).astype(np.uint8)``, and numpy *wraps* rather than
+    saturating, so those three land on bytes 72, 129 and 44. That cast is
+    mostly shielded, because ``Compositor`` runs ``utils.clip()`` on its own
+    arrays. But the clip runs *after* the value has been blended, so wherever
+    the color is composited rather than laid down flat -- an effect, a partial
+    alpha, an anti-aliased vector edge -- it corrupts the arithmetic first and
+    the clip has nothing left to recover. Forging ``Gry = 150`` into
+    ``adjustment-fillers.psd`` puts 194 white pixels along the shape's stroke
+    where the stroke is ``(26, 26, 26)``, and ``H = 0, Strt = 120, Brgh = 150``
+    puts 150 bright cyan ones there (#757).
+
+    Clamping degrades to the end of the axis instead, which is the policy
+    :py:func:`psd_tools.color_convert.lab_to_rgb` already follows. Applied
+    where the untrusted number enters rather than inside ``color_convert``, so
+    those conversions keep their documented ``[0, 1]`` input contracts instead
+    of having to defend them. Saturation and brightness are the exception: they
+    reach :py:func:`psd_tools.color_convert.hsb_to_rgb`, which is total and
+    clamps them itself, so they never arrive here.
 
     NaN maps to 0.0, because ``nan > 0.0`` is false and ``max`` therefore keeps
     its first argument. That is wanted -- a malformed descriptor degrades to the
@@ -585,7 +596,13 @@ def _noise_to_canvas(
                 continue
             rgb = lab_to_rgb(c0 * 100.0, c1 * 255.0 - 128.0, c2 * 255.0 - 128.0)
         else:
-            rgb = (c0, c1, c2)
+            # Clamped for the same reason the descriptor readers are: these
+            # components come from ``Mnm ``/``Mxm ``, which are raw file
+            # values, so a band at ``Mxm = 150`` leaves [0, 1]. The other two
+            # spaces are already covered -- HSB by ``hsb_to_rgb`` and Lab by
+            # ``lab_to_rgb`` and ``_clamp01`` above -- which left RGB as the
+            # one unguarded noise path (#757).
+            rgb = (_clamp01(c0), _clamp01(c1), _clamp01(c2))
         rows.append(_from_rgb(color_mode, rgb))
     return np.array(rows, dtype=np.float32)
 
@@ -643,7 +660,10 @@ def _make_noise_gradient_color(
     )
     if not grad.get(Key.ShowTransparency):
         return G, None
+    # Clamped like the color components, and from the same raw ``Mnm ``/``Mxm ``
+    # values (#757).
+    Ya = np.clip(Y[:, -1], 0.0, 1.0)
     Ga = interpolate.interp1d(
-        X, Y[:, -1], axis=0, bounds_error=False, fill_value=(Y[0, -1], Y[-1, -1])
+        X, Ya, axis=0, bounds_error=False, fill_value=(Ya[0], Ya[-1])
     )
     return G, Ga

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -1383,13 +1383,14 @@ def test_composite_pil_clips_rather_than_wrapping_at_the_uint8_cast(
 ) -> None:
     """The cast out of the compositor must saturate, not wrap (#757).
 
-    ``(255 * color).astype(np.uint8)`` wraps, so a component at 1.2 arrived as
-    byte 51 -- an unrelated colour rather than a clipped one. Every producer
-    that can leave [0, 1] is now guarded at its own source, and no file under
-    ``tests/psd_files`` reaches this cast out of range in either force mode
-    even with a deliberately out-of-range backdrop, so nothing in the corpus
-    exercises it. The stand-in below is what keeps the clip from being dropped
-    as dead code: it stands for the next producer that gets this wrong.
+    ``(255 * color).astype(np.uint8)`` wraps, so a component at 1.2 arrives as
+    byte 50 -- an unrelated colour rather than a clipped one. Nothing reaches
+    this cast out of range today: ``Compositor`` clips its own arrays, the
+    descriptor readers clamp at the source, and no file under
+    ``tests/psd_files`` arrives out of range in either force mode even with a
+    deliberately out-of-range backdrop. So nothing in the corpus exercises the
+    clip. The stand-in below is what keeps it from being dropped as dead code:
+    it stands for the next producer that gets this wrong.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"))
     real = composite_module.composite

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import Any, Optional, cast
 
 import numpy as np
@@ -13,6 +14,12 @@ from psd_tools.psd.base import ByteElement
 from PIL import Image
 
 from ..utils import full_name
+
+# ``psd_tools.composite.__init__`` re-exports the ``composite`` function under
+# the same name as the submodule it lives in, so ``psd_tools.composite.composite``
+# resolves to the function rather than to the module. Reach the module itself
+# through sys.modules, which the import above has already populated.
+composite_module = sys.modules["psd_tools.composite.composite"]
 
 logger = logging.getLogger(__name__)
 
@@ -1366,3 +1373,33 @@ def test_lab_composite_converts_to_the_colour_it_encodes(force: bool) -> None:
     assert image.mode == "LAB"
     rendered = np.array(image.convert("RGB").getpixel((4, 20)), dtype=float)
     assert np.abs(rendered - np.array([196.0, 126.0, 101.0])).max() <= 2.0
+
+
+@pytest.mark.parametrize(
+    "value, expected", [(1.2, 255), (5.0, 255), (-0.2, 0), (-5.0, 0)]
+)
+def test_composite_pil_clips_rather_than_wrapping_at_the_uint8_cast(
+    monkeypatch: pytest.MonkeyPatch, value: float, expected: int
+) -> None:
+    """The cast out of the compositor must saturate, not wrap (#757).
+
+    ``(255 * color).astype(np.uint8)`` wraps, so a component at 1.2 arrived as
+    byte 51 -- an unrelated colour rather than a clipped one. Every producer
+    that can leave [0, 1] is now guarded at its own source, and no file under
+    ``tests/psd_files`` reaches this cast out of range in either force mode
+    even with a deliberately out-of-range backdrop, so nothing in the corpus
+    exercises it. The stand-in below is what keeps the clip from being dropped
+    as dead code: it stands for the next producer that gets this wrong.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"))
+    real = composite_module.composite
+
+    def out_of_range(*args: Any, **kwargs: Any) -> Any:
+        color, shape, alpha = real(*args, **kwargs)
+        return np.full_like(color, value), shape, alpha
+
+    monkeypatch.setattr(composite_module, "composite", out_of_range)
+    image = composite_module.composite_pil(psd, 1.0, 0.0, None, None, False)
+    assert isinstance(image, Image.Image)
+    pixels = np.asarray(image.convert("RGB"))
+    assert pixels.min() == expected and pixels.max() == expected, pixels

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -889,3 +889,160 @@ def test_noise_gradient_cross_space_cells_are_pinned(mode: str, band: str) -> No
     row = NOISE_BANDS.index(band) * 8 + 4
     expected = np.array(NOISE_PINNED[(mode, band)])
     assert np.abs(rendered[row, 4] - expected).max() <= 0.1
+
+
+# ---------------------------------------------------------------------------
+# Out-of-range descriptor components (#757)
+#
+# No fixture can carry these. Photoshop will not author a component outside its
+# class's nominal range, and it normalizes a fill descriptor to the document's
+# own colour class besides (#756), so the ground truth is the clamp itself:
+# every class has to land in [0, 1], and the rendered byte has to saturate at
+# the end of the axis rather than wrap to an unrelated colour.
+# ---------------------------------------------------------------------------
+
+
+# (label, document mode, descriptor class, fields, expected canvas tuple).
+# The first four rows are the table measured in the issue; before the clamp
+# they produced (126, 180, 180), (44, 216, 0), (129, 129, 129) and (126, ...)
+# respectively -- a beyond-red HSB rendering grey-teal, a beyond-red RGB
+# rendering bright green, a beyond-white grey rendering mid-grey.
+OUT_OF_RANGE_CASES = [
+    (
+        "HSB S=120 B=150 saturates to red",
+        ColorMode.RGB,
+        Klass.HSBColor.value,
+        {Key.Hue: 0.0, Key.Saturation: 120.0, Key.Brightness: 150.0},
+        (1.0, 0.0, 0.0),
+    ),
+    (
+        "RGB 300/-40/0 saturates to red",
+        ColorMode.RGB,
+        Klass.RGBColor.value,
+        {Key.Red: 300.0, Key.Green: -40.0, Key.Blue: 0.0},
+        (1.0, 0.0, 0.0),
+    ),
+    (
+        "grey beyond black stays black",
+        ColorMode.RGB,
+        Klass.Grayscale.value,
+        {Key.Gray: 150.0},
+        (0.0, 0.0, 0.0),
+    ),
+    (
+        "CMYK negative ink stays at no ink",
+        ColorMode.CMYK,
+        Klass.CMYKColor.value,
+        {Key.Cyan: -50.0, Key.Magenta: 0.0, Key.Yellow: 0.0, Key.Black: 0.0},
+        (1.0, 1.0, 1.0, 1.0),
+    ),
+    (
+        "CMYK beyond full ink stays at full ink",
+        ColorMode.CMYK,
+        Klass.CMYKColor.value,
+        {Key.Cyan: 150.0, Key.Magenta: 0.0, Key.Yellow: 0.0, Key.Black: 0.0},
+        (0.0, 1.0, 1.0, 1.0),
+    ),
+    (
+        "float RGB is normalized already, so 3.0 saturates",
+        ColorMode.RGB,
+        Klass.RGBColor.value,
+        {Key.RedFloat: 3.0, Key.GreenFloat: -1.0, Key.BlueFloat: 0.5},
+        (1.0, 0.0, 0.5),
+    ),
+    (
+        "Lab, the class that arrived with its own guard in #743",
+        ColorMode.LAB,
+        Klass.LabColor.value,
+        {Key.Luminance: 140.0, Key.A: 200.0, Key.B: -200.0},
+        (1.0, 1.0, 0.0),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label, color_mode, class_id, fields, expected",
+    OUT_OF_RANGE_CASES,
+    ids=[case[0] for case in OUT_OF_RANGE_CASES],
+)
+def test_out_of_range_components_saturate_rather_than_wrapping(
+    label: str,
+    color_mode: ColorMode,
+    class_id: bytes,
+    fields: dict,
+    expected: tuple[float, ...],
+) -> None:
+    """An out-of-range component must degrade to the end of its axis.
+
+    Nothing in the descriptor format constrains a component to the range its
+    class's divisor assumes, and ``composite_pil()`` casts with
+    ``(255 * color).astype(np.uint8)``, which *wraps* rather than saturating.
+    So 1.5 arrived as byte 126: not a clipped component but a colour unrelated
+    to the one asked for, and none of it warned.
+    """
+    result = _get_color(color_mode, _color_desc(class_id, fields))
+    assert all(0.0 <= c <= 1.0 for c in result), (label, result)
+    assert result == pytest.approx(expected), label
+    # The point of the clamp is what the cast then does with it. ``astype``
+    # truncates rather than rounds, which is why the model below uses ``int``.
+    pixels = (255 * np.array(result, dtype=np.float32)).astype(np.uint8)
+    want = [int(255 * np.float32(c)) for c in expected]
+    assert pixels.tolist() == want, label
+
+
+@pytest.mark.parametrize("color_mode", list(ColorMode))
+@pytest.mark.parametrize(
+    "class_id, fields",
+    [
+        (Klass.RGBColor.value, {Key.Red: 400.0, Key.Green: -400.0, Key.Blue: 128.0}),
+        (
+            Klass.RGBColor.value,
+            {Key.RedFloat: 9.0, Key.GreenFloat: -9.0, Key.BlueFloat: 0.5},
+        ),
+        (Klass.Grayscale.value, {Key.Gray: -250.0}),
+        (
+            Klass.CMYKColor.value,
+            {Key.Cyan: -200.0, Key.Magenta: 300.0, Key.Yellow: 0.0, Key.Black: 500.0},
+        ),
+        (
+            Klass.LabColor.value,
+            {Key.Luminance: -500.0, Key.A: 900.0, Key.B: -900.0},
+        ),
+        (
+            Klass.HSBColor.value,
+            {Key.Hue: 5000.0, Key.Saturation: 900.0, Key.Brightness: -900.0},
+        ),
+    ],
+    ids=["RGBC-int", "RGBC-float", "Grsc", "CMYC", "LbCl", "HSBC"],
+)
+def test_every_class_lands_in_range_on_every_document(
+    color_mode: ColorMode, class_id: bytes, fields: dict
+) -> None:
+    """Uniform treatment, which is the reason #757 covers all five at once.
+
+    Fixing one class in isolation is what the issue exists to avoid, so this
+    sweeps every colour class against every document mode rather than pinning
+    the handful of pairs that happened to be measured.
+    """
+    result = _get_color(color_mode, _color_desc(class_id, fields))
+    assert all(0.0 <= c <= 1.0 for c in result), (color_mode, class_id, result)
+    assert all(np.isfinite(c) for c in result), (color_mode, class_id, result)
+
+
+def test_out_of_range_hue_still_wraps_rather_than_clamping() -> None:
+    """Hue is the one component that must not be clamped.
+
+    It is an angle, so 400 degrees names a real colour one turn on and
+    ``hsb_to_rgb`` folds it back onto the circle. Clamping it to 360 would turn
+    every hue past the end of the turn into red, which is the shape of the
+    #754 bug rather than a fix for #757.
+    """
+    for degrees in (30.0, 390.0, 750.0, -330.0):
+        result = _get_color(
+            ColorMode.RGB,
+            _color_desc(
+                Klass.HSBColor.value,
+                {Key.Hue: degrees, Key.Saturation: 100.0, Key.Brightness: 100.0},
+            ),
+        )
+        assert result == pytest.approx((1.0, 0.5, 0.0), abs=1e-6), degrees

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -903,10 +903,14 @@ def test_noise_gradient_cross_space_cells_are_pinned(mode: str, band: str) -> No
 
 
 # (label, document mode, descriptor class, fields, expected canvas tuple).
-# The first four rows are the table measured in the issue; before the clamp
-# they produced (126, 180, 180), (44, 216, 0), (129, 129, 129) and (126, ...)
-# respectively -- a beyond-red HSB rendering grey-teal, a beyond-red RGB
-# rendering bright green, a beyond-white grey rendering mid-grey.
+# The first four rows are the table measured in the issue. Before the clamp the
+# tuples reached the uint8 cast as (126, 180, 180), (44, 216, 0),
+# (129, 129, 129) and (126, ...) -- what the cast *would* make of them.
+# `Compositor` clips its own arrays, so a flat opaque fill was shielded from
+# that; what was not shielded is anything that blends the value first, because
+# the clip then runs on arithmetic that is already wrong. Forging these into
+# adjustment-fillers.psd renders 194 white pixels and 150 bright cyan ones
+# along a stroke that should be (26, 26, 26).
 OUT_OF_RANGE_CASES = [
     (
         "HSB S=120 B=150 saturates to red",

--- a/tests/psd_tools/test_color_convert.py
+++ b/tests/psd_tools/test_color_convert.py
@@ -208,6 +208,37 @@ class TestHsbToRgb:
         """
         assert hsb_to_rgb(h, 1.0, 0.5) == (0.5, 0.5, 0.5)
 
+    @pytest.mark.parametrize(
+        ("s", "v", "expected"),
+        [
+            (1.2, 1.5, (1.0, 0.0, 0.0)),  # the pair measured in #757
+            (1.2, 1.0, (1.0, 0.0, 0.0)),
+            (-0.5, 0.5, (0.5, 0.5, 0.5)),  # negative saturation is achromatic
+            (1.0, 2.0, (1.0, 0.0, 0.0)),
+            (1.0, -1.0, (0.0, 0.0, 0.0)),
+            (float("nan"), 0.5, (0.5, 0.5, 0.5)),
+            (float("inf"), 0.5, (0.5, 0.0, 0.0)),
+            (1.0, float("nan"), (0.0, 0.0, 0.0)),
+            (1.0, float("inf"), (1.0, 0.0, 0.0)),
+        ],
+    )
+    def test_out_of_range_saturation_and_brightness_saturate(self, s, v, expected):
+        """The ``Returns:`` contract has to hold for every float, not just for
+        in-range ones.
+
+        Saturation and brightness are not angles, so unlike hue they clamp
+        rather than wrap. Before #757 this function was total only in
+        appearance: #754's non-finite-hue guard made it look as complete as
+        ``lab_to_rgb``, while ``s = 1.2, v = 1.5`` still returned
+        ``(1.5, -0.3, -0.3)`` and a NaN saturation propagated straight out. The
+        harm is downstream -- ``composite_pil()`` casts with
+        ``(255 * color).astype(np.uint8)``, which *wraps*, so 1.5 became byte
+        126 and a fully saturated red rendered grey-teal.
+        """
+        result = hsb_to_rgb(0.0, s, v)
+        assert all(0.0 <= c <= 1.0 for c in result), result
+        assert result == pytest.approx(expected)
+
 
 class TestGrayToRgb:
     def test_mid_gray(self):


### PR DESCRIPTION
Closes #757.

## The bug

`paint._get_color()` normalizes a descriptor's colour components by a fixed
divisor, and nothing in the format constrains the file to stay inside it. A
writer emitting `Rd = 300` or `Gry = 150` produces a component outside `[0, 1]`.

All five of the issue's measurements reproduce on `0793d30`, plus the float RGB
path it flagged:

| descriptor | document | tuple | byte at the cast |
| --- | --- | --- | --- |
| `HSBC` H=0 S=120 B=150 | RGB | `(1.5, -0.3, -0.3)` | `(126, 180, 180)` |
| `RGBC` 300/-40/0 | RGB | `(1.176, -0.157, 0.0)` | `(44, 216, 0)` |
| `Grsc` Gray=150 | RGB | `(-0.5, -0.5, -0.5)` | `(129, 129, 129)` |
| `CMYC` Cyan=-50 | CMYK | `(1.5, 1.0, 1.0, 1.0)` | `(126, …)` |
| `RdFl` 3.0/-1.0/0.5 | RGB | `(3.0, -1.0, 0.5)` | `(253, 1, 127)` |

## Where the harm actually is

Worth correcting the issue on this, because it changes what the fix is for.
That last column is what the uint8 cast *would* make of these, not what
psd-tools renders. `Compositor` already runs `utils.clip()` on its own arrays,
so **a flat opaque fill was shielded** — forging these into a fixture and
rendering gives the right colour on `main`.

The damage is one step earlier. The clip runs *after* the value has been
blended, so anywhere the colour is composited rather than laid down flat — a
layer effect, a partial alpha, an anti-aliased vector edge — the arithmetic is
already wrong and clipping has nothing left to recover. Forging into
`adjustment-fillers.psd` and rendering `Polygon 1` on `main`:

| forged fill | stroke region on `main` | on this branch |
| --- | --- | --- |
| `Grsc` Gray=150 | 194 px `(255, 255, 255)` | `(26, 26, 26)` |
| `HSBC` 0/120/150 | 150 px `(1, 255, 255)` | `(26, 26, 26)` |

White specks and bright cyan where the stroke is dark grey. On
`layers-minimal/shape-layer.psd` the edge pixels come out `(187, 40, 255)` and
`(202, 31, 254)` instead of `(255, 0, 255)`.

## The fix

Clamp where the untrusted number enters, in `_get_color()`'s per-class readers
via the existing `_clamp01()` — the placement `_lab_to_canvas()` has used since
#743. `color_convert`'s documented `[0, 1]` **input** contracts are left alone.

- `_get_int_color` / `_get_invert_color` — covers `RGBC` (int), `Grsc`, `CMYC`.
- `_get_rgb`'s float branch — `RdFl`/`GrnF`/`BlFl`.
- `_noise_to_canvas`'s RGB branch and the noise alpha. Found in review: these
  come from raw `Mnm `/`Mxm ` band values, so they are a producer too, and RGB
  was the only noise space not already covered (HSB goes through `hsb_to_rgb`,
  Lab through `lab_to_rgb`/`_clamp01`).
- `hsb_to_rgb()` becomes **total**, matching `lab_to_rgb`. Its documented
  `[0, 1]` result held only for in-range `s`/`v`, and #756's non-finite-hue
  guard had made it *look* as complete as `lab_to_rgb` while a NaN saturation
  still propagated straight out. This is the issue's "either make it total or
  say so", answered by making it total.
- `composite_pil()` now clips at the uint8 cast.

**Hue is deliberately not clamped.** It is an angle, so 400° names a real colour
one turn on and `hsb_to_rgb` wraps it; clamping to 360 would turn every hue past
the end of the turn into red, which is the shape of the #754 bug rather than a
fix for this one. There is a test pinning the wrap.

## Two things I did not do

**No divisor invented for the float RGB path.** No file under `tests/psd_files`
carries a `redFloat` descriptor, so its scale is not measurable here and the
original branch landed with no divisor, no test and no reference. Clamping is
safe either way — if the format's word is right the clamp never fires, and if it
is not, an unexpected value saturates instead of wrapping. Changing the divisor
on a guess would be the riskier move. The comment says so explicitly.

**No fix for the CMYK cross-mode bug this turned up.** The issue claims
`_get_cmyk()` on an RGB document "happens to escape, but only because
`rgb_to_cmyk()`/`cmyk_to_rgb()` clamp on the way through". Neither clamps, and
it does not escape — underneath is a separate and worse defect where every
in-range CMYK colour renders black on a non-CMYK document. Filed as #763 with
its own evidence and fix; deliberately not folded in here.

## Testing

No fixture can carry any of this: Photoshop will not author an out-of-range
component, and it normalizes a fill descriptor to the document's own colour
class besides (#756). Ground truth is the clamp itself, as the issue proposed.

- `test_out_of_range_components_saturate_rather_than_wrapping` — the issue's
  table plus the float path and Lab, asserting both the tuple and the byte.
- `test_every_class_lands_in_range_on_every_document` — all five classes ×
  every `ColorMode`, since fixing one class in isolation is what #757 exists to
  avoid.
- `test_out_of_range_hue_still_wraps_rather_than_clamping` — guards the
  exclusion above.
- `test_out_of_range_saturation_and_brightness_saturate` — `hsb_to_rgb`
  totality, including nan/±inf.
- `test_composite_pil_clips_rather_than_wrapping_at_the_uint8_cast` — nothing
  in the corpus reaches that cast out of range, so this uses a stand-in
  producer purely to keep the clip from being dropped as dead code.

All four new test functions (54 parametrized cases) **fail against `main`'s
source** and pass here. Full suite 2330 passed, 27 xfailed, 2 xpassed; ruff,
mypy and doctests clean.

**Blast radius: none.** Every PSD under `tests/psd_files` rendered in both force
modes, `(color, shape, alpha)` compared bitwise: **1752/1752 arrays identical**
to `main`. A separate sweep confirms no fixture reaches the uint8 cast out of
range in either mode, even with a deliberately out-of-range backdrop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
