### PR TITLE
fix: read a CMYK fill descriptor as ink, not as canvas (#763)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,17 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Convert a CMYK fill descriptor through ink space, so it no longer
+  renders black on every non-CMYK document (#763). ``_get_cmyk()`` read the
+  descriptor into the compositor's canvas convention, where 1.0 is *no* ink,
+  and then handed that to :py:func:`psd_tools.color_convert.cmyk_to_rgb`, whose
+  contract is ink space, where 0.0 is no ink. The flip was never undone, so on
+  an RGB, indexed, grayscale, bitmap, duotone, multichannel or Lab document
+  every colour arrived as its own opposite and collapsed: white ``C0 M0 Y0 K0``
+  rendered ``(0, 0, 0)``, and so did cyan, magenta and yellow. Black was the
+  one colour that came out right, by coincidence. This is the same confusion as
+  #747 on the opposite leg; a CMYK document was never affected.
+
 - [fix] Clamp a fill descriptor's colour components so an out-of-range value
   saturates instead of corrupting the render (#757, #764). Nothing in the format
   constrains a component to the range its colour class normalizes by, so a

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 -------------------
 
 - [fix] Convert a CMYK fill descriptor through ink space, so it no longer
-  renders black on every non-CMYK document (#763). ``_get_cmyk()`` read the
+  renders black on every non-CMYK document (#763, #765). ``_get_cmyk()`` read the
   descriptor into the compositor's canvas convention, where 1.0 is *no* ink,
   and then handed that to :py:func:`psd_tools.color_convert.cmyk_to_rgb`, whose
   contract is ink space, where 0.0 is no ink. The flip was never undone, so on

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -181,9 +181,6 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
     def _get_int_color(color_desc: Descriptor, keys: tuple) -> tuple[float, ...]:
         return tuple(_clamp01(float(color_desc[key]) / 255.0) for key in keys)
 
-    def _get_invert_color(color_desc: Descriptor, keys: tuple) -> tuple[float, ...]:
-        return tuple(_clamp01((100.0 - float(color_desc[key])) / 100.0) for key in keys)
-
     def _get_rgb(color_mode: ColorMode, color_desc: Descriptor) -> tuple[float, ...]:
         if Key.Red in color_desc:
             rgb = _get_int_color(color_desc, (Key.Red, Key.Green, Key.Blue))
@@ -221,7 +218,11 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         return _from_rgb(color_mode, hsb_to_rgb(hue, saturation, brightness))
 
     def _get_gray(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
-        (gray,) = _get_invert_color(x, (Key.Gray,))
+        # ``Gry `` is percent *black*, so 0 is white. Inverting it yields a
+        # luminance, which is what every helper below takes -- a real
+        # conversion, not the canvas-convention flip that ``_ink_to_canvas()``
+        # performs.
+        gray = _clamp01((100.0 - float(x[Key.Gray])) / 100.0)
         if color_mode == ColorMode.RGB:
             return gray_to_rgb(gray)
         if color_mode == ColorMode.CMYK:
@@ -236,12 +237,27 @@ def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
         return (gray,)
 
     def _get_cmyk(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
-        c, m, y, k = _get_invert_color(
-            x, (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black)
+        # Read as ink -- 0.0 is no ink -- which is both the descriptor's own
+        # spelling and ``color_convert``'s documented contract. The compositor's
+        # arrays store what is *left*, so only the CMYK branch flips, and it
+        # says so by name.
+        #
+        # This used to read through a helper that returned canvas convention
+        # and then hand that straight to ``cmyk_to_rgb()``, which expects ink.
+        # The flip was never undone, so on every non-CMYK document each colour
+        # arrived as its own opposite and collapsed to black: white
+        # ``C0 M0 Y0 K0`` reached ``cmyk_to_rgb(1, 1, 1, 1)`` and rendered
+        # ``(0, 0, 0)``, and so did cyan, magenta and yellow. Black was the one
+        # colour that came out right, by coincidence (#763). The same confusion
+        # in the opposite direction is what ``_ink_to_canvas()`` was added for
+        # (#747); this is the leg that was missed.
+        ink = tuple(
+            _clamp01(float(x[key]) / 100.0)
+            for key in (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black)
         )
         if color_mode == ColorMode.CMYK:
-            return (c, m, y, k)
-        return _from_rgb(color_mode, cmyk_to_rgb(c, m, y, k))
+            return _ink_to_canvas(ink)
+        return _from_rgb(color_mode, cmyk_to_rgb(*ink))
 
     def _get_lab(color_mode: ColorMode, x: Descriptor) -> tuple[float, ...]:
         lightness = float(x[Key.Luminance])

--- a/tests/psd_tools/composite/test_paint.py
+++ b/tests/psd_tools/composite/test_paint.py
@@ -20,7 +20,8 @@ from psd_tools import PSDImage
 from psd_tools.api.layers import Layer
 from psd_tools.api.pil_io import post_process
 from psd_tools.api.utils import EXPECTED_CHANNELS
-from psd_tools.composite import composite
+from psd_tools.color_convert import cmyk_to_rgb
+from psd_tools.composite import composite, paint
 from psd_tools.composite.paint import (
     _get_color,
     draw_gradient_fill,
@@ -539,10 +540,16 @@ def test_rgb_fill_on_a_lab_document_matches_photoshop(
             {Key.Gray: 40.0},
             (0.632226, 128 / 255, 128 / 255),
         ),
+        # Moved in #763. The old pin was (0.060154, 0.495916, 0.468762) -- an
+        # L* of 6.0, near black, for a mid brown whose L* is 52.5. That was the
+        # canvas-for-ink confusion this row had captured rather than caught: it
+        # was pinned to the implementation, and the docstring below says so,
+        # which is exactly why it could not fail when the implementation was
+        # wrong.
         (
             Klass.CMYKColor.value,
             {Key.Cyan: 10.0, Key.Magenta: 20.0, Key.Yellow: 30.0, Key.Black: 40.0},
-            (0.060154, 0.495916, 0.468762),
+            (0.524775, 0.518260, 0.543805),
         ),
     ],
 )
@@ -1050,3 +1057,140 @@ def test_out_of_range_hue_still_wraps_rather_than_clamping() -> None:
             ),
         )
         assert result == pytest.approx((1.0, 0.5, 0.0), abs=1e-6), degrees
+
+
+# ---------------------------------------------------------------------------
+# CMYK is read as ink, not as canvas (#763)
+#
+# The compositor's arrays store what is *left* -- 1.0 is no ink -- while
+# `color_convert`'s CMYK helpers are documented in ink space, where 0.0 is no
+# ink. `_get_cmyk()` read the descriptor into canvas convention and then handed
+# that to `cmyk_to_rgb()` without undoing the flip, so on every non-CMYK
+# document each colour arrived as its own opposite and collapsed to black.
+#
+# No fixture can carry this: Photoshop normalizes a fill descriptor to the
+# document's own colour class on save (#756), so a `CMYC` descriptor on an RGB
+# document is not authorable. Ground truth is `cmyk_to_rgb()` itself, which the
+# RGB rows of tests/psd_tools/test_color_convert.py anchor against Photoshop.
+# ---------------------------------------------------------------------------
+
+
+def _cmyk_desc(c: float, m: float, y: float, k: float) -> Descriptor:
+    return _color_desc(
+        Klass.CMYKColor.value,
+        {Key.Cyan: c, Key.Magenta: m, Key.Yellow: y, Key.Black: k},
+    )
+
+
+# Percent ink, and the RGB the same ink is worth. Before the fix every one of
+# these rendered (0, 0, 0) on an RGB document -- black included, but only by
+# coincidence.
+CMYK_SWATCHES = [
+    ("white", (0.0, 0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+    ("cyan", (100.0, 0.0, 0.0, 0.0), (0.0, 1.0, 1.0)),
+    ("magenta", (0.0, 100.0, 0.0, 0.0), (1.0, 0.0, 1.0)),
+    ("yellow", (0.0, 0.0, 100.0, 0.0), (1.0, 1.0, 0.0)),
+    ("black", (0.0, 0.0, 0.0, 100.0), (0.0, 0.0, 0.0)),
+    ("mid", (20.0, 40.0, 60.0, 10.0), (0.72, 0.54, 0.36)),
+]
+
+
+@pytest.mark.parametrize("color_mode", [ColorMode.RGB, ColorMode.INDEXED])
+@pytest.mark.parametrize(
+    "label, ink, expected", CMYK_SWATCHES, ids=[s[0] for s in CMYK_SWATCHES]
+)
+def test_cmyk_descriptor_converts_through_ink_space(
+    color_mode: ColorMode,
+    label: str,
+    ink: tuple[float, float, float, float],
+    expected: tuple[float, float, float],
+) -> None:
+    """A CMYK fill is the colour its ink says, on a three-channel document."""
+    got = _get_color(color_mode, _cmyk_desc(*ink))
+    assert got == pytest.approx(expected, abs=1e-6), (label, color_mode)
+
+
+@pytest.mark.parametrize("color_mode", list(ColorMode))
+def test_cmyk_white_is_white_on_every_document(color_mode: ColorMode) -> None:
+    """``C0 M0 Y0 K0`` is no ink at all, so it cannot render as black.
+
+    The sharpest statement of the bug: a fill asking for white came back as the
+    darkest value the mode can hold, on RGB, indexed, grayscale, bitmap,
+    duotone, multichannel and Lab alike. Only a CMYK document was spared.
+
+    Expressed per mode rather than as a literal, because "white" is 1.0
+    everywhere except Lab, whose chroma axes are neutral at 128/255 while its
+    lightness is 1.0.
+    """
+    got = _get_color(color_mode, _cmyk_desc(0.0, 0.0, 0.0, 0.0))
+    if color_mode == ColorMode.LAB:
+        assert got == pytest.approx((1.0, 128 / 255, 128 / 255), abs=1e-6)
+    else:
+        assert got == pytest.approx((1.0,) * len(got), abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "label, ink, _expected", CMYK_SWATCHES, ids=[s[0] for s in CMYK_SWATCHES]
+)
+def test_cmyk_document_branch_keeps_its_canvas_values(
+    label: str, ink: tuple[float, float, float, float], _expected: tuple[float, ...]
+) -> None:
+    """The branch that always worked did not move.
+
+    ``_ink_to_canvas(v / 100)`` and the old ``(100 - v) / 100`` are the same
+    number, so rewriting the read in ink space is value-preserving here. Pinned
+    because it is the half of #763 that was correct, and a fix to the other
+    half must not pay for it.
+    """
+    got = _get_color(ColorMode.CMYK, _cmyk_desc(*ink))
+    assert got == pytest.approx(tuple(1.0 - v / 100.0 for v in ink), abs=1e-6)
+
+
+def test_cmyk_fill_reaches_the_canvas_as_ink() -> None:
+    """End to end at the array, not just at the tuple.
+
+    ``_get_color()`` is what ``draw_solid_color_fill()`` calls, so a conversion
+    that is right in isolation but never reaches the canvas would still pass the
+    unit rows above.
+    """
+    color, shape = draw_solid_color_fill(
+        (0, 0, 4, 4), ColorMode.RGB, _cmyk_desc(0.0, 0.0, 0.0, 0.0)
+    )
+    assert shape is None
+    assert color.shape == (4, 4, 3)
+    assert np.allclose(color, 1.0), color[0, 0]
+
+
+def test_cmyk_stroke_on_an_rgb_document_is_the_ink_it_asks_for() -> None:
+    """The one place in the corpus where this is not forged.
+
+    ``issues/issue397.psd`` is an RGB document whose shape layer carries a
+    vector stroke coloured ``C72 M68 Y67 K88`` -- a near-black. Photoshop will
+    not author a cross-mode *fill* descriptor, which is why #743 and #752 needed
+    forged ones, but a stroke's ``strokeStyleContent`` is evidently not
+    normalized the same way, so a real file reaches this path.
+
+    Read as ink, that stroke is ``(8, 9, 9)``. Read the old way it came back
+    ``(162, 152, 150)``, a mid grey, which is the bug at three-quarters of the
+    axis rather than at the extreme the forged white shows.
+
+    Asserted at ``create_fill_desc()`` rather than through a render, because
+    this fixture's stroke does not currently reach the composited output -- the
+    defect it was filed for. The colour is computed either way, so this pins the
+    conversion without depending on that being fixed.
+    """
+    psd = PSDImage.open(full_name("issues/issue397.psd"))
+    layer = next(layer for layer in psd.descendants() if layer.kind == "shape")
+    assert psd.color_mode == ColorMode.RGB
+    assert layer.stroke is not None
+    content = layer.stroke._data.get("strokeStyleContent")
+    assert content.get(Key.Color).classID == Klass.CMYKColor.value
+
+    color, _shape = paint.create_fill_desc(layer, content, layer.bbox)
+    assert color is not None
+    ink = tuple(
+        float(content.get(Key.Color)[key]) / 100.0
+        for key in (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black)
+    )
+    assert color[0, 0] == pytest.approx(cmyk_to_rgb(*ink), abs=1e-6)
+    assert (255 * color[0, 0]).astype(np.uint8).tolist() == [8, 9, 9]


### PR DESCRIPTION
Closes #763.

## The bug

The compositor's arrays store what is **left** — `1.0` is *no* ink — while
`color_convert`'s CMYK helpers are documented in **ink** space, where `0.0` is
no ink. `_get_cmyk()` read the descriptor into canvas convention and then handed
that straight to `cmyk_to_rgb()` without undoing the flip:

```python
c, m, y, k = _get_invert_color(x, (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black))
if color_mode == ColorMode.CMYK:
    return (c, m, y, k)                                  # canvas — correct
return _from_rgb(color_mode, cmyk_to_rgb(c, m, y, k))    # canvas fed to ink space
```

So white `C0 M0 Y0 K0` arrived as `(1, 1, 1, 1)`, and `cmyk_to_rgb(1, 1, 1, 1)`
is `(0, 0, 0)`. On an RGB document:

| descriptor | before | correct |
| --- | --- | --- |
| white `C0 M0 Y0 K0` | `(0.0, 0.0, 0.0)` | `(1, 1, 1)` |
| cyan `C100 M0 Y0 K0` | `(0.0, 0.0, 0.0)` | `(0, 1, 1)` |
| magenta `C0 M100 Y0 K0` | `(0.0, 0.0, 0.0)` | `(1, 0, 1)` |
| yellow `C0 M0 Y100 K0` | `(0.0, 0.0, 0.0)` | `(1, 1, 0)` |
| mid `C20 M40 Y60 K10` | `(.02, .04, .06)` | `(.72, .54, .36)` |

Every colour collapsed to black on RGB, indexed, grayscale, bitmap, duotone,
multichannel and Lab alike. Black was the one that came out right, by
coincidence. A CMYK document was never affected. This is #747's confusion on the
opposite leg — `_ink_to_canvas()` was added for the write side and the read side
was missed.

## The fix

Read in ink space and flip only for the branch that needs canvas, so the
boundary is named rather than implied:

```python
ink = tuple(_clamp01(float(x[key]) / 100.0)
            for key in (Key.Cyan, Key.Magenta, Key.Yellow, Key.Black))
if color_mode == ColorMode.CMYK:
    return _ink_to_canvas(ink)
return _from_rgb(color_mode, cmyk_to_rgb(*ink))
```

`_ink_to_canvas(v / 100)` and the old `(100 - v) / 100` are the same number, so
the CMYK-document branch is value-preserving — pinned by a test, since it is the
half that was already correct.

`_get_invert_color()` goes with its last caller. Its name described a *convention
flip*, which is the confusion that caused this; the inversion left in
`_get_gray()` is a real luminance conversion (`Gry ` is percent black), and now
says so.

## A test that had pinned the bug

`test_other_classes_on_a_lab_document_go_through_the_conversion` expected
`(0.060154, …)` for `C10 M20 Y30 K40` — an L\* of **6.0**, near black, for a mid
brown whose L\* is **52.5**. Its own docstring explains why it could not catch
this: that row is *"pinned as values rather than as agreement"* and *"not
compared against Photoshop's own Lab"*, so it captured whatever the
implementation did. Updated to the correct value, with a note.

## Testing

Photoshop normalizes a fill descriptor to the document's own colour class on
save (#756), so a cross-mode `CMYC` **fill** is not authorable and the forged
rows follow the #743/#752 precedent. Ground truth is `cmyk_to_rgb()` itself,
which is anchored against Photoshop in `test_color_convert.py`.

- `test_cmyk_descriptor_converts_through_ink_space` — six swatches × RGB/indexed.
- `test_cmyk_white_is_white_on_every_document` — the sharpest form of the bug,
  swept over every `ColorMode`.
- `test_cmyk_document_branch_keeps_its_canvas_values` — the half that worked.
- `test_cmyk_fill_reaches_the_canvas_as_ink` — end to end at the array.
- `test_cmyk_stroke_on_an_rgb_document_is_the_ink_it_asks_for` — **not forged**;
  see below.

All five fail against `main`'s source (20 parametrized cases). Full suite 2358
passed, 27 xfailed, 2 xpassed; ruff, mypy and doctests clean.

## Blast radius, and the fixture that does carry it

Corpus renders are unchanged — every PSD under `tests/psd_files` in both force
modes, `(color, shape, alpha)` compared bitwise: **1752/1752 identical**.

But not because nothing carries the trigger, which is what a first (buggy) scan
told me. `tests/psd_files/issues/issue397.psd` is an **RGB document whose vector
stroke is `C72 M68 Y67 K88`** — a stroke's `strokeStyleContent` is evidently not
normalized to the document's colour class the way a fill descriptor is. Its
colour moves from a mid grey to the near-black it asks for:

| | `main` | this branch |
| --- | --- | --- |
| `create_fill_desc()` | `(162, 152, 150)` | `(8, 9, 9)` |

The rendered arrays do not move because that stroke never reaches the composited
output — the defect the fixture was filed for. So the new test asserts at
`create_fill_desc()`, which is what the compositor calls, rather than depending
on that being fixed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
