### PR TITLE
fix: bound the depth-1 allocation by the codec's own output (#737)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,7 +37,10 @@ Changelog
   values at depth 1 than any arithmetic over ``length`` could account for. Such
   a channel is now refused: degraded to black from depth 8 up, where it used to
   raise a length mismatch instead, and ending the read below depth 8, as every
-  undecodable 1-bit channel already did.
+  undecodable 1-bit channel already did. The
+  :class:`psd_tools.compression.PSDDecompressionWarning` that accompanies a
+  failed channel now says which of those two happened, rather than promising a
+  black fill that below depth 8 does not exist.
 
 - [fix] Replace a failed channel with exactly the byte count it declares, at
   every depth (#737, #769). The black fill substituted for an undecodable channel was

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 -------------------
 
 - [fix] Give the ``max_alloc_bytes`` estimate a depth term, so a 1-bit document
-  can no longer allocate eight times its budget (#737). ``check_pixel_size()``
+  can no longer allocate eight times its budget (#737, #769). ``check_pixel_size()``
   sizes an allocation at ``width * height * channels * 4``, but at depth 1
   ``numpy_io._parse_array()`` unpacks the buffer with ``np.unpackbits`` -- one
   float32 per *bit* -- so the array follows the byte count the codec returns
@@ -40,7 +40,7 @@ Changelog
   undecodable 1-bit channel already did.
 
 - [fix] Replace a failed channel with exactly the byte count it declares, at
-  every depth (#737). The black fill substituted for an undecodable channel was
+  every depth (#737, #769). The black fill substituted for an undecodable channel was
   a PIL image whose mode was picked from the depth -- ``"L"`` for 8, ``"RGBA"``
   for anything else -- so depth 16 came back at four bytes per pixel against a
   declared two, and every reader downstream saw the channels at twice their
@@ -438,7 +438,7 @@ Changelog
   small multiple of it for every colour mode; that predates this entry and is
   unchanged by it. 1-bit documents were under-counted eightfold for want of a
   depth term, which predated this entry as well and is fixed by the #737 entry
-  above, in this same release.
+  above (#769), in this same release.
 - [fix] Composite duotone documents at their stored width.
   ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
   pixel data is a single grayscale channel, the one to four ink curves living

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,54 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Give the ``max_alloc_bytes`` estimate a depth term, so a 1-bit document
+  can no longer allocate eight times its budget (#737). ``check_pixel_size()``
+  sizes an allocation at ``width * height * channels * 4``, but at depth 1
+  ``numpy_io._parse_array()`` unpacks the buffer with ``np.unpackbits`` -- one
+  float32 per *bit* -- so the array follows the byte count the codec returns
+  rather than the pixel count. The two disagree eightfold: ``decompress()``'s
+  ``length`` is one byte per pixel at depth 1, where a row of ``width`` pixels
+  packs into ``width // 8``, and a body written that wide is returned in full
+  because the length check is skipped below depth 8. A 64x64 1-bit document
+  therefore returned ``(64, 64, 8)``, 131,072 bytes, against a 16,384-byte
+  estimate, and the guard admitted it -- a gap in a security control
+  (GHSA-8q6g-vjhf-jp8m) whose whole job is to bound the allocation before it
+  happens.
+
+  The estimate now asks the codec, through the new
+  :py:func:`psd_tools.compression.decompressed_size_bound`, rather than
+  multiplying by a flat eight. A properly packed body -- what
+  ``colormodes/4x4_1bit_bitmap.psd`` and any document Photoshop writes carries
+  -- still allocates only the planes it really occupies, where a flat factor
+  would have rejected that fixture at four times its size. ZIP is the one codec
+  whose inflated size cannot be known without inflating it, so a conforming
+  1-bit ZIP body is now bounded at eight times its allocation. Nothing in
+  practice pays for that: of the 293 documents in ``tests/psd_files``, 241 store
+  their merged image data RLE and 52 RAW, and none uses either ZIP codec --
+  which is where the layer channels do use ZIP, and where this bound is not
+  consulted.
+
+  ``_safe_zlib_decompress()`` also now enforces the ceiling it documents. It
+  probes one byte past the limit to catch an oversize stream, and a stream
+  inflating to exactly that was handed back a byte over -- eight more float32
+  values at depth 1 than any arithmetic over ``length`` could account for. Such
+  a channel is now refused: degraded to black from depth 8 up, where it used to
+  raise a length mismatch instead, and ending the read below depth 8, as every
+  undecodable 1-bit channel already did.
+
+- [fix] Replace a failed channel with exactly the byte count it declares, at
+  every depth (#737). The black fill substituted for an undecodable channel was
+  a PIL image whose mode was picked from the depth -- ``"L"`` for 8, ``"RGBA"``
+  for anything else -- so depth 16 came back at four bytes per pixel against a
+  declared two, and every reader downstream saw the channels at twice their
+  width. A 4x4 RGB document whose merged image data fails to decode read
+  ``(4, 4, 6)`` instead of ``(4, 4, 3)`` -- ``ImageData.get_data()``
+  decompresses every channel in one call, so that section fails as a unit -- and
+  allocated twice what the guard had estimated. The same substitute serves the
+  per-channel readers, ``ChannelData.get_data()`` for layers and the pattern
+  reader, so a failed 16-bit channel there came back double-width too. Depths 8
+  and 32 are unaffected, their modes having happened to match.
+
 - [fix] Split a pattern's alpha off by its slot layout rather than by its
   colour mode, so a multichannel-mode pattern composites instead of raising
   (#741). The split was keyed on ``EXPECTED_CHANNELS``, whose multichannel
@@ -387,9 +435,10 @@ Changelog
 
   The estimate bounds the array that is returned, which is what
   ``check_pixel_size()`` has always measured. Peak usage during parsing is a
-  small multiple of it for every colour mode, and 1-bit documents are
-  under-counted eightfold because the estimate carries no depth term; both
-  predate this entry and are unchanged by it.
+  small multiple of it for every colour mode; that predates this entry and is
+  unchanged by it. 1-bit documents were under-counted eightfold for want of a
+  depth term, which predated this entry as well and is fixed by the #737 entry
+  above, in this same release.
 - [fix] Composite duotone documents at their stored width.
   ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
   pixel data is a single grayscale channel, the one to four ink curves living

--- a/docs/reference/psd_tools.compression.rst
+++ b/docs/reference/psd_tools.compression.rst
@@ -12,6 +12,8 @@ Compression Functions
 
 .. autofunction:: psd_tools.compression.decompress
 
+.. autofunction:: psd_tools.compression.decompressed_size_bound
+
 RLE Codec
 ---------
 

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -68,18 +68,52 @@ def _image_data_planes(psdimage: "PSDProtocol", flat: bool = False) -> int:
     16- or 32-bit indexed document -- malformed, indexed being an 8-bit mode --
     keeps its stored width and must not be tripled either.
 
+    Depth 1 is the case the pixel count cannot express at all, and it is
+    settled first because it settles the width on its own. :func:`_parse_array`
+    unpacks such a buffer with ``np.unpackbits``, one float32 per *bit*, so the
+    array follows the byte count
+    :py:func:`~psd_tools.compression.decompress` returns rather than the pixel
+    count -- and at depth 1 those two disagree eightfold, ``length`` being one
+    byte per pixel where a row of ``width`` pixels packs into ``width // 8``
+    (#737).
+
+    Which is why the question goes to
+    :py:func:`~psd_tools.compression.decompressed_size_bound` rather than to a
+    flat factor of eight. Both directions of that estimate have a real document
+    behind them: a body written a byte per pixel is returned in full, since the
+    length check is skipped below depth 8, and unpacks to eight planes; while
+    ``colormodes/4x4_1bit_bitmap.psd`` is packed as Photoshop writes it, four
+    bytes for four rows, and allocates two planes for a four-pixel width. A flat
+    factor would have rejected the second at four times its size. The division
+    rounds up, and never to zero: a width that is not a multiple of eight leaves
+    a part-used plane, and a part-used plane still has to be paid for.
+
+    What it does not do is repair that width. Those padding bits are returned as
+    pixels, so a bitmap document whose width is not a multiple of eight comes
+    back scrambled or does not reshape at all -- #768, whose fix will change the
+    reshape this arithmetic is written against.
+
     This bounds the array that is returned, which is what
     :func:`~psd_tools.api.utils.check_pixel_size` estimates by construction. It
     does not model the transient peak: :func:`_parse_array` holds the raw bytes
     and two float32 arrays at once, and :func:`_remove_background` adds several
     more, so the true high-water mark is a small multiple of this for every
-    colour mode. Nor does it carry a depth term, so a 1-bit document still
-    under-counts -- rows unpack to eight times the byte count the estimate
-    assumes. Both are pre-existing properties of this estimate rather than
-    anything a colour mode causes; the second is tracked in #737.
+    colour mode -- a pre-existing property of this estimate rather than
+    anything a colour mode or a depth causes.
     """
     if flat:
         return 1
+    if psdimage.depth == 1:
+        values = 8 * psdimage._record.image_data.decompressed_size_bound(
+            psdimage._record.header
+        )
+        pixels = psdimage.width * psdimage.height
+        # Never below one: an empty image data section bounds at zero bytes, and
+        # while `check_pixel_size()` clamps its own `channels` argument, this
+        # function's return value is read directly -- by the compositor's
+        # sibling estimate and by tests -- so a zero plane count would be a
+        # claim about the array rather than an artefact absorbed downstream.
+        return max(1, -(-values // pixels))
     planes = psdimage.channels
     if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:
         planes *= EXPECTED_CHANNELS[ColorMode.INDEXED]

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -113,7 +113,7 @@ def _image_data_planes(psdimage: "PSDProtocol", flat: bool = False) -> int:
         # function's return value is read directly -- by the compositor's
         # sibling estimate and by tests -- so a zero plane count would be a
         # claim about the array rather than an artefact absorbed downstream.
-        return max(1, -(-values // pixels))
+        return max(1, (values + pixels - 1) // pixels)
     planes = psdimage.channels
     if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:
         planes *= EXPECTED_CHANNELS[ColorMode.INDEXED]

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -86,6 +86,20 @@ def convert_image_data_to_pil(
     :raises ValueError: If an invalid channel is specified
     """
 
+    # The header's own channel count, with none of the corrections the numpy
+    # path needs (:func:`~psd_tools.api.numpy_io._image_data_planes`), because
+    # PIL allocates a plane per stored channel at every depth and mode:
+    # `_create_image()` builds one image per channel from a buffer whose pixel
+    # count is the canvas's, and PIL's "1" mode holds a byte per pixel, so a
+    # 1-bit document allocates a quarter of this estimate rather than the eight
+    # times it costs in float32.
+    #
+    # What this does not cover is the transient peak in the 16- and 32-bit
+    # branches, which build an "I"/"F" image at four bytes per pixel and then
+    # allocate a second through `.point()` before narrowing to "L" -- roughly
+    # twice the estimate, alive for as long as the conversion. That is a peak
+    # rather than a returned size, which this guard has never modelled on any
+    # path, and it is tracked in #767.
     check_pixel_size(
         psd.width,
         psd.height,

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -228,9 +228,11 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
 
         :param fp: filename or file-like object.
         :param max_alloc_bytes: optional per-document cap (bytes) on the buffer
-            that :py:meth:`composite`/:py:meth:`numpy`/:py:meth:`topil` allocate
-            from the declared geometry; rendering raises :class:`ValueError` if
-            the estimate exceeds it. Defaults to the ``$PSD_TOOLS_MAX_ALLOC_BYTES``
+            that :py:meth:`composite`/:py:meth:`numpy`/:py:meth:`topil` allocate;
+            rendering raises :class:`ValueError` if the estimate exceeds it. The
+            estimate comes from the declared geometry, except at depth 1, where
+            the array follows the byte count the codec returns and the
+            compressed body's own length is read as well. Defaults to the ``$PSD_TOOLS_MAX_ALLOC_BYTES``
             env var (or :data:`psd_tools.api.utils.MAX_ALLOC_BYTES`) when ``None``.
         :param encoding: charset encoding of the pascal string within the file,
             default 'macroman'. Some psd files need explicit encoding option.

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -89,9 +89,14 @@ def check_pixel_size(
 
     :param width: canvas width in pixels.
     :param height: canvas height in pixels.
-    :param channels: channel count, used only to estimate the float32 allocation
-        (``width * height * channels * 4``) for the :data:`MAX_ALLOC_BYTES` budget.
-        Defaults to 1.
+    :param channels: number of float32 planes, used only to estimate the
+        allocation (``width * height * channels * 4``) for the
+        :data:`MAX_ALLOC_BYTES` budget. Defaults to 1. Callers may pass a count
+        that differs from the header's channels, because for some colour modes
+        and depths the array is not one plane per stored channel: see
+        :func:`~psd_tools.api.numpy_io._image_data_planes`, which triples an
+        indexed document for its palette and sizes a 1-bit one by the bytes its
+        codec returns.
     :param max_alloc_bytes: per-call budget in bytes; overrides the module-level
         :data:`MAX_ALLOC_BYTES` default when not ``None``.
     """

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -21,6 +21,8 @@ Key functions:
 
 - :py:func:`compress`: Compress raw pixel data using specified method
 - :py:func:`decompress`: Decompress pixel data back to raw bytes
+- :py:func:`decompressed_size_bound`: Upper bound on what :py:func:`decompress`
+  will return, without decompressing anything
 - :py:func:`encode_rle`: RLE encoding for a single channel
 - :py:func:`decode_rle`: RLE decoding for a single channel
 
@@ -68,8 +70,6 @@ import warnings
 import zlib
 from typing import Iterator
 
-from PIL import Image
-
 from psd_tools.constants import Compression
 from psd_tools.psd.bin_utils import (
     be_array_from_bytes,
@@ -89,7 +89,10 @@ logger = logging.getLogger(__name__)
 class PSDDecompressionWarning(UserWarning):
     """Issued when channel data cannot be fully decompressed.
 
-    The affected channel is replaced with black pixels.  Catch or filter this
+    From depth 8 up the affected channel is replaced with black pixels. Below
+    it there is no substitute -- the fill is gated on ``depth >= 8``, a 1-bit
+    channel having no byte-per-pixel form to fill -- so the warning is followed
+    by a ``RuntimeError`` rather than a degraded read. Catch or filter this
     warning to detect silently degraded images::
 
         import warnings
@@ -110,6 +113,30 @@ MAX_DEGRADED_BYTES: int | None = 16 * 1024 * 1024
 MAX_DEGRADED_RATIO: int = 1000
 
 
+def _channel_length(width: int, height: int, depth: int) -> int:
+    """Bytes a channel of these dimensions occupies once decompressed.
+
+    Shared by :func:`decompress`, which sizes every codec's output by it, and by
+    :func:`decompressed_size_bound`, which has to predict that output without
+    producing it. Note what it is *not*: at depth 1 it is one byte per pixel,
+    eight times the packed size a row of ``width`` pixels really occupies, which
+    is why the bound cannot be stated in pixels alone (#737).
+    """
+    return width * height * max(1, depth // 8)
+
+
+def _rle_row_size(width: int, depth: int) -> int:
+    """Bytes per row as :func:`decode_rle` reads and writes them.
+
+    Floor division, and never zero: at depth 1 a row of fewer than eight pixels
+    still occupies a byte. Shared with :func:`decompressed_size_bound` so the
+    two cannot drift apart -- a bound on this codec has to track what the
+    decoder reads, which is not quite what :func:`encode_rle` writes: that
+    keeps its own expression, with the same floor but no clamp.
+    """
+    return max(width * depth // 8, 1)
+
+
 def _warn_decompress_failure(
     codec: str,
     exc: Exception,
@@ -118,7 +145,11 @@ def _warn_decompress_failure(
     depth: int,
     version: int,
 ) -> None:
-    """Log and emit a PSDDecompressionWarning for a failed channel decode."""
+    """Log and emit a PSDDecompressionWarning for a failed channel decode.
+
+    The message names the black fill that follows from depth 8 up; below it the
+    caller raises instead, as :class:`PSDDecompressionWarning` records.
+    """
     msg = (
         "%s decode failed (%s: %s); channel replaced with black. "
         "width=%d height=%d depth=%d version=%d"
@@ -136,8 +167,16 @@ def _safe_zlib_decompress(data: bytes, max_length: int) -> bytes:
     memory exhaustion from crafted ZIP-bomb payloads.
     """
     d = zlib.decompressobj()
+    # One byte more than the limit, so that a stream which really is oversize
+    # gives that byte away instead of ending exactly at the boundary. It has to
+    # be rejected as well: without the length test a stream inflating to
+    # precisely `max_length + 1` was consumed whole, left no
+    # `unconsumed_tail`, and was returned a byte over the ceiling this function
+    # documents. At depth 8 and up `decompress()` caught it as a length
+    # mismatch; at depth 1 that check is skipped and the byte became eight more
+    # float32 values than any estimate allowed for (#737).
     out = d.decompress(data, max_length + 1)
-    if d.unconsumed_tail:
+    if d.unconsumed_tail or len(out) > max_length:
         raise ValueError(
             "Decompressed size exceeds expected maximum of %d bytes" % max_length
         )
@@ -203,7 +242,7 @@ def decompress(
     if depth not in _VALID_DEPTHS:
         raise ValueError("depth %d not in %s" % (depth, sorted(_VALID_DEPTHS)))
 
-    length = width * height * max(1, depth // 8)
+    length = _channel_length(width, height, depth)
 
     result: bytes | None = None
     if compression == Compression.RAW:
@@ -243,8 +282,13 @@ def decompress(
                     "psd_tools.compression.MAX_DEGRADED_BYTES = None to allow it."
                     % (length, len(data), width, height)
                 )
-            mode = "L" if depth == 8 else "RGB" if depth == 24 else "RGBA"
-            result = Image.new(mode, (width, height), color=0).tobytes()
+            # Exactly `length`, which the mismatch check below demands of a
+            # successful decode and this substitute has to honour too. It was
+            # built as a PIL image whose mode was picked from the depth -- "L"
+            # for 8, "RGBA" otherwise -- so depth 16 came back at four bytes per
+            # pixel against a `length` of two, and every reader downstream saw a
+            # channel twice its declared width (#737).
+            result = bytes(length)
             logger.warning("Failed channel has been replaced by black")
         else:
             if len(result) != length:
@@ -256,6 +300,66 @@ def decompress(
     if result is None:
         raise RuntimeError("decompress() produced no result for depth=%d" % depth)
     return result
+
+
+def decompressed_size_bound(
+    data: bytes,
+    compression: Compression,
+    width: int,
+    height: int,
+    depth: int,
+    version: int = 1,
+) -> int:
+    """Upper bound on the number of bytes :py:func:`decompress` will return.
+
+    Answerable without decompressing anything, which is what makes it usable
+    as an allocation guard's estimate:
+    :py:func:`psd_tools.api.utils.check_pixel_size` has to reject a document
+    *before* the buffer exists. It is reached today through
+    :py:meth:`psd_tools.psd.image_data.ImageData.decompressed_size_bound`, from
+    the depth-1 arm of ``psd_tools.api.numpy_io._image_data_planes()``, where
+    the byte count and the pixel count part company -- ``np.unpackbits`` yields
+    one value per *bit* -- and the pixel count alone under-counted the array
+    eightfold (#737).
+
+    ``length`` below is :py:func:`decompress`'s own ``width * height *
+    max(1, depth // 8)``; the two are meant to be read together. For a
+    well-formed body the bound is exact for RAW and RLE, and an over-estimate
+    for the two ZIP codecs, whose inflated size cannot be known without
+    inflating the stream. A malformed body only ever comes back smaller -- a
+    truncated RLE byte-count table yields fewer rows than ``height`` -- which is
+    the safe direction for a guard:
+
+    - RAW returns ``data[:length]``, so the body's own length caps it. At depth
+      8 and up a body shorter than ``length`` raises the mismatch check instead
+      of returning, so the ``min`` only bites at depth 1, where that check is
+      skipped.
+    - RLE returns exactly ``height`` rows of ``max(width * depth // 8, 1)``
+      bytes, each row padded or clipped to that size by ``decode()`` rather
+      than raising. At depth 1 that is *below* ``length``: a row of ``width``
+      pixels packs into ``width // 8`` bytes, not ``width``.
+    - Both ZIP codecs are capped at ``length`` by ``_safe_zlib_decompress()``,
+      and so is the black fill substituted for a channel that fails to decode.
+
+    :param data: the compressed body; read for its length only.
+    :param compression: compression type, see :py:class:`.Compression`.
+    :param width: width in pixels.
+    :param height: height in pixels. Pass ``height * channels`` wherever the
+        caller decompresses every channel in one call, as
+        :py:meth:`psd_tools.psd.image_data.ImageData.get_data` does.
+    :param depth: bit depth of the pixel; one of 1, 8, 16, 32.
+    :param version: psd file version. Accepted for symmetry with
+        :py:func:`decompress`; the bound does not depend on it, the row
+        byte-count table being read past rather than returned.
+    :return: the largest number of bytes ``decompress()`` can return for these
+        arguments.
+    """
+    length = _channel_length(width, height, depth)
+    if compression == Compression.RAW:
+        return min(len(data), length)
+    if compression == Compression.RLE:
+        return height * _rle_row_size(width, depth)
+    return length
 
 
 def encode_rle(data: bytes, width: int, height: int, depth: int, version: int) -> bytes:
@@ -275,7 +379,7 @@ def encode_rle(data: bytes, width: int, height: int, depth: int, version: int) -
 
 def decode_rle(data: bytes, width: int, height: int, depth: int, version: int) -> bytes:
     try:
-        row_size = max(width * depth // 8, 1)
+        row_size = _rle_row_size(width, depth)
         with io.BytesIO(data) as fp:
             bytes_counts = read_be_array(("H", "I")[version - 1], height, fp)
             return b"".join(

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -147,13 +147,25 @@ def _warn_decompress_failure(
 ) -> None:
     """Log and emit a PSDDecompressionWarning for a failed channel decode.
 
-    The message names the black fill that follows from depth 8 up; below it the
-    caller raises instead, as :class:`PSDDecompressionWarning` records.
+    The message states what actually follows, which depends on the depth: the
+    black fill exists only from depth 8 up, and below it :func:`decompress`
+    raises rather than substituting anything, so promising a degraded read
+    there would describe a document the caller never receives.
     """
-    msg = (
-        "%s decode failed (%s: %s); channel replaced with black. "
-        "width=%d height=%d depth=%d version=%d"
-        % (codec, type(exc).__name__, exc, width, height, depth, version)
+    outcome = (
+        "channel replaced with black"
+        if depth >= 8
+        else "read abandoned; no black fill exists below depth 8"
+    )
+    msg = "%s decode failed (%s: %s); %s. width=%d height=%d depth=%d version=%d" % (
+        codec,
+        type(exc).__name__,
+        exc,
+        outcome,
+        width,
+        height,
+        depth,
+        version,
     )
     logger.warning(msg)
     warnings.warn(msg, PSDDecompressionWarning, stacklevel=3)
@@ -176,11 +188,26 @@ def _safe_zlib_decompress(data: bytes, max_length: int) -> bytes:
     # mismatch; at depth 1 that check is skipped and the byte became eight more
     # float32 values than any estimate allowed for (#737).
     out = d.decompress(data, max_length + 1)
+    # Then drain whatever the codec still holds, bounded the same way, rather
+    # than calling `flush()`: output can outlive its input, a match being
+    # expanded from state as it is written, so inflate can in principle stop
+    # with the input consumed and bytes still pending -- and `flush()` emits
+    # that remainder with no ceiling at all, which is the allocation this
+    # function exists to prevent. CPython appears never to do it (it leaves the
+    # unread input, the trailing adler32 at the least, in `unconsumed_tail`
+    # whenever output is pending; 140k crafted and truncated streams produced
+    # no such case, and 36k inputs agree byte for byte and exception for
+    # exception with the `flush()` form). The loop is so that the ceiling does
+    # not rest on that.
+    while not d.unconsumed_tail and len(out) <= max_length:
+        chunk = d.decompress(b"", max_length + 1 - len(out))
+        if not chunk:
+            break
+        out += chunk
     if d.unconsumed_tail or len(out) > max_length:
         raise ValueError(
             "Decompressed size exceeds expected maximum of %d bytes" % max_length
         )
-    out += d.flush()
     return out
 
 

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -199,15 +199,26 @@ def _safe_zlib_decompress(data: bytes, max_length: int) -> bytes:
     # no such case, and 36k inputs agree byte for byte and exception for
     # exception with the `flush()` form). The loop is so that the ceiling does
     # not rest on that.
-    while not d.unconsumed_tail and len(out) <= max_length:
-        chunk = d.decompress(b"", max_length + 1 - len(out))
+    #
+    # Collected rather than concatenated: `out += chunk` on a `bytes` copies the
+    # whole buffer every iteration. Accumulating into a `bytearray` from the
+    # start would instead copy every ZIP channel in the file one extra time on
+    # the way out -- on the path where the loop yields nothing, which is every
+    # path measured -- so the join happens only if the loop produced something.
+    extra: list[bytes] = []
+    total = len(out)
+    while not d.unconsumed_tail and total <= max_length:
+        chunk = d.decompress(b"", max_length + 1 - total)
         if not chunk:
             break
-        out += chunk
-    if d.unconsumed_tail or len(out) > max_length:
+        extra.append(chunk)
+        total += len(chunk)
+    if d.unconsumed_tail or total > max_length:
         raise ValueError(
             "Decompressed size exceeds expected maximum of %d bytes" % max_length
         )
+    if extra:
+        return b"".join([out, *extra])
     return out
 
 

--- a/src/psd_tools/psd/image_data.py
+++ b/src/psd_tools/psd/image_data.py
@@ -12,7 +12,7 @@ from typing import IO, Any, Sequence, TypeVar
 
 from attrs import define, field
 
-from psd_tools.compression import compress, decompress
+from psd_tools.compression import compress, decompress, decompressed_size_bound
 from psd_tools.constants import Compression
 from psd_tools.psd.header import FileHeader
 from psd_tools.psd.base import BaseElement
@@ -78,6 +78,29 @@ class ImageData(BaseElement):
             with io.BytesIO(data) as f:
                 return [f.read(plane_size) for _ in range(header.channels)]
         return data
+
+    def decompressed_size_bound(self, header: FileHeader) -> int:
+        """
+        Upper bound on the number of bytes :py:meth:`get_data` will decompress.
+
+        Answerable without decompressing anything, so an allocation guard can
+        size the array before it exists -- see
+        :py:func:`psd_tools.compression.decompressed_size_bound`. It lives next
+        to :py:meth:`get_data` because it has to mirror that call exactly,
+        including the part a caller would most easily get wrong: every channel
+        is decompressed in one pass, ``height * channels`` rows at a time.
+
+        :param header: See :py:class:`~psd_tools.psd.header.FileHeader`.
+        :return: the maximum byte count, for all channels together.
+        """
+        return decompressed_size_bound(
+            self.data,
+            self.compression,
+            header.width,
+            header.height * header.channels,
+            header.depth,
+            header.version,
+        )
 
     def set_data(self, data: Sequence[bytes], header: FileHeader) -> int:
         """

--- a/tests/psd_tools/compression/test_compression.py
+++ b/tests/psd_tools/compression/test_compression.py
@@ -371,3 +371,25 @@ def test_zip_with_prediction_at_depth_1_cannot_produce_pixels() -> None:
         pytest.raises(RuntimeError, match="produced no result"),
     ):
         decompress(body, Compression.ZIP_WITH_PREDICTION, 4, 4, 1)
+
+
+@pytest.mark.parametrize(
+    "depth, phrase",
+    [(8, "channel replaced with black"), (1, "read abandoned")],
+)
+def test_decompress_failure_warning_states_what_follows(
+    depth: int, phrase: str
+) -> None:
+    """The warning must not promise a black fill below depth 8, where none exists.
+
+    Raised in review of #769: the text was fixed at "channel replaced with
+    black" whatever the depth, so a 1-bit failure announced a degraded read and
+    then raised, leaving a caller who reads the warning to conclude it had
+    pixels.
+    """
+    corrupt = b"\x78\x9c" + b"\xff" * 20  # valid zlib header, garbage deflate
+    with pytest.warns(PSDDecompressionWarning, match=phrase):
+        try:
+            decompress(corrupt, Compression.ZIP, 4, 4, depth)
+        except RuntimeError:
+            pass  # below depth 8 the read ends; the warning is what is asserted

--- a/tests/psd_tools/compression/test_compression.py
+++ b/tests/psd_tools/compression/test_compression.py
@@ -5,11 +5,13 @@ import zlib
 import pytest
 
 from psd_tools.compression import (
+    _safe_zlib_decompress,
     PSDDecompressionWarning,
     compress,
     decode_prediction,
     decode_rle,
     decompress,
+    decompressed_size_bound,
     encode_prediction,
     encode_rle,
     rle_impl,
@@ -253,3 +255,119 @@ def test_decompress_length_mismatch_raises() -> None:
     short_data = zlib.compress(b"\x00" * 5)
     with pytest.raises(ValueError, match="Decompressed length mismatch"):
         decompress(short_data, Compression.ZIP, width=3, height=3, depth=8)
+
+
+# ---------------------------------------------------------------------------
+# decompressed_size_bound() must bound what decompress() returns (#737)
+# ---------------------------------------------------------------------------
+#
+# The bound is what an allocation guard has to work from: it answers "how many
+# bytes can this body become" without inflating anything, so a document can be
+# rejected before the buffer exists. Falling below the real result is the
+# failure that matters -- that is the hole #737 reports at depth 1 -- so these
+# assert the inequality in that direction over every codec and depth, and
+# equality for the two codecs whose output size is knowable exactly.
+
+
+def _packed(width: int, height: int, depth: int) -> bytes:
+    """A payload of the row size the codecs actually read.
+
+    ``max(width * depth // 8, 1)`` bytes per row, which is ``decode_rle()``'s
+    ``row_size`` and, from depth 8 up, exactly ``decompress()``'s ``length``.
+    """
+    return bytes(height * max(width * depth // 8, 1))
+
+
+@pytest.mark.parametrize("width, height", [(8, 4), (64, 3), (4, 4)])
+@pytest.mark.parametrize("kind", [Compression.RAW, Compression.RLE, Compression.ZIP])
+@pytest.mark.parametrize("depth", [1, 8, 16, 32])
+def test_decompressed_size_bound_is_never_below_the_result(
+    depth: int, kind: Compression, width: int, height: int
+) -> None:
+    """Sweep of the invariant the guard depends on, over codec x depth."""
+    body = compress(_packed(width, height, depth), kind, width, height, depth)
+    bound = decompressed_size_bound(body, kind, width, height, depth)
+    produced = len(decompress(body, kind, width, height, depth))
+    assert produced <= bound
+    if kind in (Compression.RAW, Compression.RLE):
+        # Exact, not merely bounded: RAW returns `data[:length]`, and every RLE
+        # row is padded or clipped to `row_size` rather than raising. Only ZIP,
+        # whose inflated size cannot be known without inflating, is loose.
+        assert produced == bound
+
+
+@pytest.mark.parametrize("kind", [Compression.RAW, Compression.ZIP])
+def test_decompressed_size_bound_covers_a_padded_1bit_body(kind: Compression) -> None:
+    """At depth 1, ``length`` is a byte per *pixel* -- eight times the packed size.
+
+    A body written that wide is returned in full: the ``len(result) != length``
+    check is skipped below depth 8, so nothing reconciles the two. Those bytes
+    then unpack to one float32 per bit, which is the allocation #737's estimate
+    missed eightfold, so the bound has to reach them.
+    """
+    padded = bytes(64 * 64)  # `length` for a 64x64 1-bit channel
+    body = compress(padded, kind, 64, 64, 1)
+    bound = decompressed_size_bound(body, kind, 64, 64, 1)
+    assert len(decompress(body, kind, 64, 64, 1)) == bound == 64 * 64
+
+
+@pytest.mark.parametrize("depth", [8, 16, 32])
+def test_black_fill_matches_the_declared_length(depth: int) -> None:
+    """A failed channel is replaced by exactly ``length`` bytes, at every depth.
+
+    The substitute used to be a PIL image whose mode was picked from the depth
+    -- ``"L"`` for 8, ``"RGBA"`` for anything else -- so depth 16 came back at
+    four bytes per pixel where the channel declares two. Every reader
+    downstream then saw a 16-bit document's channels at twice their width, and
+    the bound above could not have held either.
+    """
+    corrupt = b"\x78\x9c" + b"\xff" * 20  # valid zlib header, garbage deflate
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", PSDDecompressionWarning)
+        result = decompress(corrupt, Compression.ZIP, width=4, height=4, depth=depth)
+    length = 4 * 4 * depth // 8
+    assert result == bytes(length)
+    assert length <= decompressed_size_bound(corrupt, Compression.ZIP, 4, 4, depth)
+
+
+def test_safe_zlib_decompress_honours_its_own_ceiling() -> None:
+    """Exactly ``max_length + 1`` bytes must be refused, not returned.
+
+    The probe asks zlib for one byte more than the limit so that an oversize
+    stream reveals itself through ``unconsumed_tail``. A stream inflating to
+    precisely ``max_length + 1`` consumed all of its input, left no tail, and so
+    was returned a byte over the ceiling this function documents -- eight extra
+    float32 values once a 1-bit reader unpacked it (#737).
+    """
+    assert len(_safe_zlib_decompress(zlib.compress(bytes(8)), 8)) == 8
+    for oversize in (9, 10, 4096):
+        with pytest.raises(ValueError, match="exceeds expected maximum"):
+            _safe_zlib_decompress(zlib.compress(bytes(oversize)), 8)
+
+
+def test_a_zip_stream_one_byte_over_length_degrades_to_black() -> None:
+    """From depth 8 up, the refused stream black-fills rather than raising.
+
+    It used to reach the ``len(result) != length`` check and raise; being caught
+    by the ceiling instead turns it into the warning-and-degrade path every other
+    undecodable channel takes.
+    """
+    body = zlib.compress(bytes(4 * 4 + 1))  # `length` + 1 for a 4x4 8-bit channel
+    with pytest.warns(PSDDecompressionWarning, match="exceeds expected"):
+        result = decompress(body, Compression.ZIP, 4, 4, 8)
+    assert result == bytes(4 * 4)
+
+
+def test_zip_with_prediction_at_depth_1_cannot_produce_pixels() -> None:
+    """The one codec/depth pair that never allocates, pinned so the bound's
+    slack there is understood as dead rather than wrong.
+
+    ``decode_prediction`` rejects depth 1 outright, and below depth 8 there is no
+    black fill to substitute, so the read ends instead.
+    """
+    body = compress(bytes(16), Compression.ZIP, 4, 4, 8)
+    with (
+        pytest.warns(PSDDecompressionWarning, match="Invalid pixel size"),
+        pytest.raises(RuntimeError, match="produced no result"),
+    ):
+        decompress(body, Compression.ZIP_WITH_PREDICTION, 4, 4, 1)

--- a/tests/psd_tools/psd/test_image_data.py
+++ b/tests/psd_tools/psd/test_image_data.py
@@ -17,58 +17,78 @@ def test_image_data() -> None:
     check_write_read(ImageData(data=b"\x00"))
 
 
-@pytest.mark.parametrize(
-    "compression, data, header",
-    [
-        (
-            Compression.RAW,
-            [RAW_IMAGE_3x3_8bit] * 3,
-            FileHeader(width=3, height=3, depth=8, channels=3, version=1),
-        ),
-        (
-            Compression.RLE,
-            [RAW_IMAGE_3x3_8bit] * 3,
-            FileHeader(width=3, height=3, depth=8, channels=3, version=1),
-        ),
-        (
-            Compression.ZIP,
-            [RAW_IMAGE_3x3_8bit] * 3,
-            FileHeader(width=3, height=3, depth=8, channels=3, version=1),
-        ),
-        (
-            Compression.RAW,
-            [RAW_IMAGE_3x3_8bit] * 3,
-            FileHeader(width=3, height=3, depth=8, channels=3, version=2),
-        ),
-        (
-            Compression.RLE,
-            [RAW_IMAGE_3x3_8bit] * 3,
-            FileHeader(width=3, height=3, depth=8, channels=3, version=2),
-        ),
-        (
-            Compression.ZIP,
-            [RAW_IMAGE_3x3_8bit] * 3,
-            FileHeader(width=3, height=3, depth=8, channels=3, version=2),
-        ),
-        (
-            Compression.RAW,
-            [RAW_IMAGE_2x2_16bit] * 3,
-            FileHeader(width=2, height=2, depth=16, channels=3, version=1),
-        ),
-        (
-            Compression.RLE,
-            [RAW_IMAGE_2x2_16bit] * 3,
-            FileHeader(width=2, height=2, depth=16, channels=3, version=1),
-        ),
-        (
-            Compression.ZIP,
-            [RAW_IMAGE_2x2_16bit] * 3,
-            FileHeader(width=2, height=2, depth=16, channels=3, version=1),
-        ),
-    ],
-)
+_CHANNEL_CASES = [
+    (
+        Compression.RAW,
+        [RAW_IMAGE_3x3_8bit] * 3,
+        FileHeader(width=3, height=3, depth=8, channels=3, version=1),
+    ),
+    (
+        Compression.RLE,
+        [RAW_IMAGE_3x3_8bit] * 3,
+        FileHeader(width=3, height=3, depth=8, channels=3, version=1),
+    ),
+    (
+        Compression.ZIP,
+        [RAW_IMAGE_3x3_8bit] * 3,
+        FileHeader(width=3, height=3, depth=8, channels=3, version=1),
+    ),
+    (
+        Compression.RAW,
+        [RAW_IMAGE_3x3_8bit] * 3,
+        FileHeader(width=3, height=3, depth=8, channels=3, version=2),
+    ),
+    (
+        Compression.RLE,
+        [RAW_IMAGE_3x3_8bit] * 3,
+        FileHeader(width=3, height=3, depth=8, channels=3, version=2),
+    ),
+    (
+        Compression.ZIP,
+        [RAW_IMAGE_3x3_8bit] * 3,
+        FileHeader(width=3, height=3, depth=8, channels=3, version=2),
+    ),
+    (
+        Compression.RAW,
+        [RAW_IMAGE_2x2_16bit] * 3,
+        FileHeader(width=2, height=2, depth=16, channels=3, version=1),
+    ),
+    (
+        Compression.RLE,
+        [RAW_IMAGE_2x2_16bit] * 3,
+        FileHeader(width=2, height=2, depth=16, channels=3, version=1),
+    ),
+    (
+        Compression.ZIP,
+        [RAW_IMAGE_2x2_16bit] * 3,
+        FileHeader(width=2, height=2, depth=16, channels=3, version=1),
+    ),
+]
+
+
+@pytest.mark.parametrize("compression, data, header", _CHANNEL_CASES)
 def test_image_data_data(compression: int, data: List[bytes], header: Any) -> None:
     image_data = ImageData(compression)
     image_data.set_data(data, header)
     output = image_data.get_data(header)
     assert output == data, "output=%r, expected=%r" % (output, data)
+
+
+@pytest.mark.parametrize("compression, data, header", _CHANNEL_CASES)
+def test_image_data_decompressed_size_bound(
+    compression: int, data: List[bytes], header: Any
+) -> None:
+    """The bound must cover what :py:meth:`ImageData.get_data` really produces.
+
+    Every channel at once, which is the part of the mapping the bound exists to
+    keep in one place: ``get_data`` passes ``height * channels`` rows to the
+    codec, so a bound derived from ``height`` alone would be short by a factor
+    of the channel count. Read together with
+    :py:func:`psd_tools.compression.decompressed_size_bound`, whose own tests
+    pin the per-codec arithmetic.
+    """
+    image_data = ImageData(compression)
+    image_data.set_data(data, header)
+    produced = image_data.get_data(header, split=False)
+    assert isinstance(produced, bytes)
+    assert len(produced) <= image_data.decompressed_size_bound(header)

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -10,6 +10,7 @@ import base64
 import io
 import struct
 import warnings
+import zlib
 
 import pytest
 
@@ -17,10 +18,11 @@ from typing import Any, Literal, Optional
 
 from psd_tools import PSDImage, PSDLargeImageWarning
 from psd_tools import compression as _compression
+from psd_tools.compression import compress
 from psd_tools.api import utils as _utils
 from psd_tools.api.numpy_io import _image_data_planes
 from psd_tools.api.utils import has_transparency
-from psd_tools.constants import ColorMode
+from psd_tools.constants import ColorMode, Compression
 from psd_tools.api.utils import (
     MAX_DIMENSION_PSD,
     MAX_PIXELS_PSD,
@@ -422,10 +424,9 @@ def test_numpy_guard_estimate_never_exceeds_the_allocation(
     """No shipped fixture may be rejected at a budget it actually fits inside.
 
     The same invariant as above swept over the real corpus, covering every
-    colour mode and all four depths. (Bitmap has slack in the other direction:
-    a 1-bit document unpacks to more values than the byte count this estimate
-    assumes, which has no depth term -- #737. That is a separate gap, not
-    something this assertion claims is absent.)
+    colour mode and all four depths -- bitmap included, since #737 gave the
+    estimate a depth term; see the depth-1 section below for what that has to
+    get right.
 
     Swept over ``channel`` as well, because the estimate has to match whichever
     branch the argument selects -- see the synthesised paths below, which this
@@ -465,3 +466,282 @@ def test_numpy_guard_estimate_matches_the_synthesised_paths(
     assert _colormode(filename).numpy(channel).nbytes == one_plane
     assert _image_data_planes(_colormode(filename)) > 1  # the stored width differs
     _colormode(filename, one_plane).numpy(channel)
+
+
+# ---------------------------------------------------------------------------
+# Depth 1: the estimate follows the codec, not the pixel count (#737)
+# ---------------------------------------------------------------------------
+#
+# At depth 1 the byte count and the pixel count part company. `_parse_array()`
+# unpacks the buffer with `np.unpackbits`, one float32 per *bit*, so the array
+# is eight values per stored byte -- and `decompress()`'s `length` is
+# `width * height` *bytes* at depth 1, eight times the packed size a row of
+# `width` pixels actually occupies. A RAW or ZIP body written that wide is
+# returned in full (the length check is skipped below depth 8), so the array
+# came back eight times wider than the estimate assumed.
+#
+# The estimate therefore asks the codec rather than the header. Both directions
+# are pinned below, as everywhere else in this file: exact for RAW and RLE,
+# and for ZIP an upper bound, which is the one place this trades a false
+# positive for closing the hole.
+
+
+def _forge_1bit(
+    width: int,
+    height: int,
+    channels: int,
+    color_mode: int,
+    compression: Compression,
+    body: str = "packed",
+    max_alloc_bytes: int | None = None,
+) -> PSDImage:
+    """A structurally valid 1-bit document with a body of the requested shape.
+
+    ``"packed"`` is ``height * channels`` rows of ``max(width // 8, 1)`` bytes:
+    the row size the codecs read, and for a width that is a multiple of eight
+    also the row a conforming writer packs. (At any other width the two part
+    company -- a row occupies ``ceil(width / 8)`` bytes and the reader floors
+    it, which is #768. Every width parametrised below is a multiple of eight or
+    smaller than eight, so that distinction does not arise here.) ``"padded"``
+    is one byte per pixel -- ``decompress()``'s own ``length`` at depth 1, eight
+    times the packed size -- which is what a crafted file supplies to get eight
+    times the allocation out of the estimate.
+    """
+    rows = height * channels
+    if body == "packed":
+        payload = bytes(rows * max(width // 8, 1))
+    else:
+        payload = bytes(width * rows)
+    buf = io.BytesIO()
+    buf.write(
+        struct.pack(">4sH6xHIIHH", b"8BPS", 1, channels, height, width, 1, color_mode)
+    )
+    buf.write(struct.pack(">I", 0))  # colour mode data
+    buf.write(struct.pack(">I", 0))  # image resources
+    buf.write(struct.pack(">I", 0))  # layer and mask info
+    buf.write(struct.pack(">H", compression))
+    buf.write(compress(payload, compression, width, rows, 1, 1))
+    buf.seek(0)
+    return PSDImage.open(buf, max_alloc_bytes=max_alloc_bytes)
+
+
+# Widths are multiples of eight, or below eight where the codecs' `max(..., 1)`
+# row floor applies: at any other width the unpacked value count does not
+# divide into `(-1, height, width)` and `numpy()` cannot form the array at all.
+# `test_depth_1_estimate_rounds_up_a_part_used_plane` covers that case.
+_DEPTH_1_DOCUMENTS = [
+    (4, 4, 1, ColorMode.BITMAP),
+    (64, 64, 1, ColorMode.BITMAP),
+    (64, 64, 1, ColorMode.GRAYSCALE),
+    (64, 64, 3, ColorMode.RGB),
+    (8, 3, 1, ColorMode.BITMAP),
+]
+
+
+@pytest.mark.parametrize(
+    "compression, body",
+    [
+        (Compression.RAW, "packed"),
+        (Compression.RAW, "padded"),
+        (Compression.RLE, "packed"),
+        (Compression.ZIP, "padded"),
+    ],
+)
+@pytest.mark.parametrize("width, height, channels, color_mode", _DEPTH_1_DOCUMENTS)
+def test_numpy_guard_estimate_is_exact_at_depth_1(
+    width: int,
+    height: int,
+    channels: int,
+    color_mode: int,
+    compression: Compression,
+    body: str,
+) -> None:
+    """Every depth-1 combination whose allocation is knowable, bracketed.
+
+    The ``"padded"`` rows are the under-count #737 reports -- eight planes where
+    the header implies one -- and the ``"packed"`` rows are the documents that
+    must not be rejected for it: a conforming 1-bit body allocates a single
+    plane, and estimating it at eight would refuse a sound file. Both come out
+    of the same arithmetic, which is the point.
+    """
+    _assert_estimate_is_exact(
+        lambda budget=None: _forge_1bit(
+            width, height, channels, color_mode, compression, body, budget
+        )
+    )
+
+
+@pytest.mark.parametrize("compression", [Compression.RAW, Compression.ZIP])
+def test_numpy_guard_rejects_the_padded_1bit_allocation(
+    compression: Compression,
+) -> None:
+    """The issue's reproduction: 8x the budget, allocated without a raise.
+
+    A 64x64 1-bit document returns ``(64, 64, 8)`` = 131,072 bytes; the estimate
+    without a depth term put it at 16,384. The budget below is that old
+    estimate, which must now be refused rather than exceeded eightfold.
+    """
+    budget = 64 * 64 * 1 * 4
+    psd = _forge_1bit(64, 64, 1, ColorMode.BITMAP, compression, "padded", budget)
+    with pytest.raises(ValueError, match="configured budget"):
+        psd.numpy()
+    # ... and the allocation it was hiding, for the record.
+    assert (
+        _forge_1bit(64, 64, 1, ColorMode.BITMAP, compression, "padded").numpy().nbytes
+        == 8 * budget
+    )
+
+
+def test_numpy_guard_estimate_covers_the_shipped_bitmap_fixture() -> None:
+    """``4x4_1bit_bitmap.psd`` allocates two planes, not the header's one.
+
+    The one 1-bit document in the corpus, and the shape a real one has: RAW with
+    a properly packed body, four bytes for four rows. A four-pixel row occupies
+    a whole byte, so it unpacks to twice its pixel count -- the 2.0x reading in
+    #737, well below the 8x a byte-per-pixel body reaches.
+
+    So this is also the case a flat factor of eight would have broken: it would
+    put this fixture at 512 bytes and reject it at the 128 it allocates. What
+    admits it is the body's own length, ``min(len(data), length)``, which is the
+    term that makes the estimate exact here rather than merely safe.
+    """
+    psd = _colormode("4x4_1bit_bitmap.psd")
+    assert psd._record.image_data.compression == Compression.RAW
+    assert len(psd._record.image_data.data) == 4  # packed: one byte per row
+    assert psd.channels == 1  # the header says one plane...
+    allocated = _assert_estimate_is_exact(
+        lambda budget=None: _colormode("4x4_1bit_bitmap.psd", budget)
+    )
+    assert allocated == 4 * 4 * 2 * 4  # ...the array is two planes wide
+
+
+def test_composite_guard_estimate_is_exact_for_the_bitmap_fixture() -> None:
+    """The same bracket through ``composite()``, the shipped 1-bit path.
+
+    A layerless document composites by reading its own image data, so the
+    depth-1 estimate is what bounds it -- with ``ignore_preview=True``, since
+    the default path returns the flattened preview through
+    :func:`~psd_tools.api.pil_io.convert_image_data_to_pil` and is bounded by
+    the PIL estimate instead.
+    """
+    pytest.importorskip("aggdraw")
+    pytest.importorskip("scipy")
+    pytest.importorskip("skimage")
+    allocated = _colormode("4x4_1bit_bitmap.psd").numpy(None).nbytes
+    _colormode("4x4_1bit_bitmap.psd", allocated).composite(ignore_preview=True)
+    with pytest.raises(ValueError, match="configured budget"):
+        _colormode("4x4_1bit_bitmap.psd", allocated - 1).composite(ignore_preview=True)
+
+
+def test_zip_at_depth_1_is_bounded_rather_than_measured() -> None:
+    """ZIP's inflated size is unknowable without inflating it, so the bound is ``length``.
+
+    That is exact for the crafted body above and eight times over for a
+    conforming one, the single over-estimate this fix accepts. It is the right
+    way round: ``_safe_zlib_decompress()`` caps the output at ``length``, so a
+    body of 26 bytes -- what ``length`` zero bytes deflate to for a 64x64
+    channel -- really can become 131,072 bytes of float32. Nothing pays for the
+    slack in practice: of the 293 documents in ``tests/psd_files``, 241 store
+    their merged image data RLE and 52 RAW, and none uses either ZIP codec.
+    """
+    psd = _forge_1bit(64, 64, 1, ColorMode.BITMAP, Compression.ZIP, "packed")
+    assert psd.numpy().nbytes == 64 * 64 * 1 * 4  # one plane, in fact
+    assert _image_data_planes(psd) == 8  # bounded at `length`, eight times over
+
+
+@pytest.mark.parametrize(
+    "body_bytes, values, planes",
+    [
+        # Two bytes per row: 16 values against a 20-pixel row, four fifths of a
+        # plane. Rounding down would floor the estimate to nothing at all.
+        (3 * 2, 48, 1),
+        # Between one and two planes' worth, the only shape that tells ceil from
+        # floor once the `max(1, ...)` clamp is in play: floor says one plane,
+        # 240 bytes, below the 320 the values really occupy.
+        (10, 80, 2),
+    ],
+)
+def test_depth_1_estimate_rounds_a_part_used_plane_up(
+    body_bytes: int, values: int, planes: int
+) -> None:
+    """A width that is not a multiple of eight leaves a partial plane, which costs.
+
+    A stored byte spans eight pixels and the rows here are 20 wide, so the
+    unpacked values never land on a plane boundary. ``numpy()`` cannot form such
+    an array at all -- neither 48 nor 80 values divide into ``(-1, 3, 20)`` --
+    so what is pinned is the arithmetic, whose job is to stay above the values
+    ``_parse_array()`` transiently holds either way.
+
+    That the read fails is #768, not something this asserts is correct: the
+    depth-1 path returns padding bits as pixels. When it stops doing so, the
+    ``reshape`` expectation below is what should be revisited.
+    """
+    psd = _forge_1bit(20, 3, 1, ColorMode.BITMAP, Compression.RAW, "padded")
+    psd._record.image_data.data = bytes(body_bytes)
+    bound = psd._record.image_data.decompressed_size_bound(psd._record.header)
+    assert 8 * bound == values
+    assert _image_data_planes(psd) == planes
+    assert planes * 20 * 3 >= values  # the estimate covers what is unpacked
+    with pytest.raises(ValueError, match="reshape"):
+        psd.numpy()
+
+
+def test_a_zip_stream_one_byte_over_length_is_refused() -> None:
+    """The boundary case in ``_safe_zlib_decompress``'s own ceiling.
+
+    It asks zlib for ``max_length + 1`` bytes so an oversize stream gives a byte
+    away instead of ending exactly at the limit -- and a stream inflating to
+    precisely that handed the byte back: all its input consumed, no
+    ``unconsumed_tail`` left to catch it. At depth 1 those eight extra bits
+    became eight more float32 values than any arithmetic over ``length`` could
+    reach: an 8x1 document returned ``(1, 8, 9)``, 288 bytes, against a
+    256-byte estimate.
+
+    The ceiling now holds, so the channel is refused. Below depth 8 that ends
+    the read -- the black-fill fallback is gated on ``depth >= 8`` -- which is
+    what any undecodable 1-bit channel has always done; from depth 8 up the same
+    stream degrades to black instead of raising the length mismatch it used to.
+    """
+    psd = _forge_1bit(8, 1, 1, ColorMode.BITMAP, Compression.ZIP, "padded")
+    psd._record.image_data.data = zlib.compress(bytes(8 * 1 + 1))  # `length` + 1
+    with (
+        pytest.warns(_compression.PSDDecompressionWarning, match="exceeds expected"),
+        pytest.raises(RuntimeError, match="produced no result"),
+    ):
+        psd.numpy()
+
+
+def test_16bit_degraded_image_data_keeps_its_declared_width() -> None:
+    """16-bit image data that fails to decode black-fills at its declared width.
+
+    ``decompress()``'s substitute was a PIL image whose mode came from the depth
+    -- ``"L"`` for 8, ``"RGBA"`` for anything else -- so depth 16 came back at
+    four bytes per pixel against a ``length`` of two, and parsed twice as wide:
+    a 4x4 RGB document read ``(4, 4, 6)``, 384 bytes, against a 192-byte
+    estimate, and a budget of exactly 192 admitted it.
+
+    Note what fails together here. :py:meth:`ImageData.get_data` decompresses
+    every channel in one call, so a corrupt merged section fails as a unit; the
+    same substitute serves the per-channel readers, ``ChannelData.get_data()``
+    for layers and the pattern reader, which were wrong at depth 16 the same
+    way.
+
+    The estimate is unchanged; what was wrong was the array. Bracketed here
+    rather than merely bounded, because the fill is now exactly ``length``.
+    """
+    corrupt = b"\x78\x9c" + b"\xff" * 20  # valid zlib header, garbage deflate
+
+    def open_doc(budget: int | None = None) -> PSDImage:
+        psd = _forge(4, 4, 3, 16, ColorMode.RGB, budget)
+        psd._record.image_data.compression = Compression.ZIP
+        psd._record.image_data.data = corrupt
+        return psd
+
+    with pytest.warns(_compression.PSDDecompressionWarning):
+        array = open_doc().numpy()
+    assert array.shape == (4, 4, 3)  # three planes, as the header declares
+    assert array.nbytes == 4 * 4 * 3 * 4
+    with pytest.warns(_compression.PSDDecompressionWarning):
+        open_doc(array.nbytes).numpy()
+    with pytest.raises(ValueError, match="configured budget"):
+        open_doc(array.nbytes - 1).numpy()


### PR DESCRIPTION
Fixes #737.

## The gap

`check_pixel_size()` sizes an allocation at `width * height * channels * 4`,
with no depth term. At depth 1 `_parse_array()` unpacks the buffer with
`np.unpackbits` — one float32 per *bit* — so the array follows the byte count
the codec returns, not the pixel count. At depth 1 those two disagree
eightfold: `decompress()`'s `length` is one byte per pixel where a row of
`width` pixels packs into `width // 8`, and a body written that wide comes back
in full because the `len(result) != length` check is skipped below depth 8.

```python
psd = PSDImage.open("bitmap_64x64.psd", max_alloc_bytes=64 * 64 * 1 * 4)  # 16,384
psd.numpy()      # (64, 64, 8) = 131,072 bytes — 8x the budget, no raise
```

A gap in a security control (GHSA-8q6g-vjhf-jp8m) whose entire job is to bound
the allocation before it happens.

## The fix: ask the codec, not a factor of eight

New `psd_tools.compression.decompressed_size_bound()`, beside `decompress()`
and sharing its `length` and `row_size` expressions (extracted as
`_channel_length()` / `_rle_row_size()` so the two cannot drift):

| codec | bound | |
| --- | --- | --- |
| RAW | `min(len(data), length)` | exact — `data[:length]` |
| RLE | `height * max(width * depth // 8, 1)` | exact — every row is padded or clipped to `row_size` |
| ZIP, ZIP+prediction | `length` | upper bound — the inflated size is unknowable without inflating |

`ImageData.decompressed_size_bound(header)` mirrors `get_data()`'s call so the
`height * channels` mapping stays stated once, and
`numpy_io._image_data_planes()` gains a depth-1 arm:
`max(1, ceil(8 * bound / (w * h)))` planes, after the `flat` early return.

Why not a flat 8x: a packed body is what the format specifies, and the corpus
fixture `colormodes/4x4_1bit_bitmap.psd` is RAW with a 4-byte body allocating 2
planes. A flat factor would reject it at four times its size, and this project
treats a guard that refuses sound documents as its own bug. The one
over-estimate left is a *conforming* 1-bit ZIP body, bounded at eight times its
allocation — of the 293 documents in `tests/psd_files`, 241 store their merged
image data RLE and 52 RAW, and none uses either ZIP codec.

## Two adjacent contract fixes the bound could not be stated without

Both found while writing it, both pre-existing, both with their own changelog
line:

- **`_safe_zlib_decompress()` did not honour its own documented ceiling.** It
  probes `max_length + 1` bytes so an oversize stream reveals itself through
  `unconsumed_tail` — and a stream inflating to *exactly* that consumed all its
  input, left no tail, and was returned a byte over the limit. At depth 8 and up
  that surfaced as a length mismatch; at depth 1 it became eight more float32
  values than any arithmetic over `length` could reach (an 8x1 document returned
  `(1, 8, 9)`, 288 bytes, against a 256-byte estimate). Now refused: degraded to
  black from depth 8 up, ending the read below it, as every undecodable 1-bit
  channel already did.
- **The degraded black fill returned the wrong length at depth 16.** It was a
  PIL image whose mode came from the depth (`"L"` for 8, `"RGBA"` otherwise), so
  depth 16 gave four bytes per pixel against a declared two, and every reader
  downstream saw a 16-bit document's channels at twice their width: a 4x4 RGB
  document whose merged image data fails to decode read `(4, 4, 6)` instead of
  `(4, 4, 3)`, allocating twice what the guard estimated. The same substitute
  serves `ChannelData.get_data()` and the pattern reader, so a failed 16-bit
  channel there was double-width too. Now `bytes(length)` — identical output at
  depths 8 and 32, whose modes happened to match.

## Verification

- Depth-1 exactness bracketed both ways (budget == allocation admits, one byte
  less rejects) over compression × body shape × {bitmap, grayscale, RGB} ×
  sizes, plus the shipped fixture through `numpy()` and `composite()`.
- `decompressed_size_bound()` swept against `len(decompress(...))` over codec ×
  depth {1, 8, 16, 32}, with equality asserted for RAW and RLE.
- Rendering bitwise unchanged over the 293 documents in `tests/psd_files`:
  `composite()` in both force modes and `numpy()`, 879 rows, identical hashes.
- Reviewed adversarially by a subagent, which swept 5,220 forged documents
  (widths divisible and not divisible by 8, channels 1–56, six colour modes,
  four codecs, versions 1 and 2, bodies packed/padded/empty/oversize/truncated)
  looking for a case where the guard admits and `numpy()` then over-allocates:
  none found, and the estimate is exact for all 293 corpus documents. Its ten
  findings — one real test-coverage gap (the ceil-vs-floor case now
  parametrised) and nine prose defects — are all addressed in this branch.
- Full suite, ruff, mypy and the docs build clean.

## Out of scope

- #767 — the PIL path's 16/32-bit transient peak, the other item on #737's
  "scope to check" list. Different mechanism (a peak, not a returned size), and
  `pil_io.py` has no depth-1 under-count at all; recorded as a comment at its
  guard.
- `get_layer_data()` and the pattern reader still have no guard at all, as
  `composite.py` already records, so this bounds the merged image data path
  only — a 1-bit *layer* still unpacks 8 values per stored byte unguarded.
- #768 — the depth-1 read path returns a padded row's spare bits as pixels, so a
  bitmap document whose width is not a multiple of 8 comes back scrambled (the
  shipped fixture's own class) or does not reshape at all. Found here, fixed
  separately; this branch's arithmetic is written against today's reshape and
  says so at both places that assume it.
