### PR TITLE
chore: add a prose sweep to the release, with a tool to measure it

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -47,6 +47,30 @@ Now list the commits since the last release by running one of these commands:
 
 You must run this command and review the output before proceeding to Step 0 or Step 2.
 
+## Step 1b — Prose sweep
+
+Rationale docstrings and comments accumulate across a release: each fix PR appends a
+paragraph explaining what it measured, and none compresses what is already there. Trim
+them now, while the release is the unit of review — nothing enforces this mechanically
+(ruff's docstring rules are off, `ruff format` does not reflow comments or docstrings,
+and no line-length rule is selected), so this step is the only thing that catches it.
+
+Measure rather than eyeball — the worst ratios sit on the smallest helpers, which read
+as fine in a diff:
+
+```bash
+uv run python tools/prose_density.py
+```
+
+Anything above roughly 3x prose-to-code deserves a look. Keep what cost real
+measurement, and what stops a future reader undoing a fix: why a bound is shaped the
+way it is, why a guard cannot be tighter, what an experiment ruled out. Cut history the
+changelog already holds, corpus statistics the tests already assert, and the same
+explanation repeated at three layers.
+
+Trimming is a separate commit from the release commit, and touches comments and
+docstrings only. If any line of code moves, stop and treat it as a code change.
+
 ## Step 2 — Draft changelog entry
 
 Read `docs/changelog.rst` to understand the current format, then draft a new entry for **VERSION**
@@ -116,6 +140,7 @@ Run `gh pr create` with `--title "Release vVERSION"` and a `--body` containing:
 - A `### Release checklist` section with these items:
   - `[ ] Changelog entry reviewed and accurate`
   - `[ ] Version follows PEP 440`
+  - `[ ] Prose sweep done (Step 1b), or explicitly skipped`
 - A closing note: "After this PR is merged, the `auto-tag` workflow will tag the merge commit
   as `vVERSION` and the `release` workflow will build wheels and publish to PyPI automatically."
 

--- a/tests/test_prose_density.py
+++ b/tests/test_prose_density.py
@@ -1,0 +1,138 @@
+"""Tests for ``tools/prose_density.py``.
+
+The tool exists to make the release's prose sweep a measurement rather than an
+argument, so a wrong count is worse than no tool: the first version overstated
+every single-expression function by roughly 2x, because it derived the docstring
+size from ``ast.get_docstring()`` -- the *cleaned* text -- and added a flat two
+for the quote lines. That inflated the prose count and, since code is the
+remainder, deflated the divisor at the same time. It put
+``get_color_channels()`` at 40:1 where the file says 19.5:1, and those numbers
+were quoted in a PR and an issue before anyone checked them.
+"""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parents[1] / "tools" / "prose_density.py"
+_spec = importlib.util.spec_from_file_location("prose_density", _TOOL)
+assert _spec is not None and _spec.loader is not None
+prose_density = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prose_density)
+
+
+def _measure(tmp_path: Path, source: str) -> dict[str, Any]:
+    path = tmp_path / "sample.py"
+    path.write_text(source)
+    return {e.name: e for e in prose_density.measure(path)}
+
+
+def test_one_line_docstring_counts_one_line(tmp_path: Path) -> None:
+    """``\"\"\"x\"\"\"`` occupies one line, not three."""
+    entries = _measure(tmp_path, 'def f():\n    """x"""\n    return 1\n')
+    assert entries["f"].docstring == 1
+    assert entries["f"].code == 2  # the def line and the return
+
+
+def test_multiline_docstring_counts_its_physical_span(tmp_path: Path) -> None:
+    """Including the quote lines, and including blank lines inside it."""
+    source = 'def f():\n    """Summary.\n\n    Body.\n    """\n    return 1\n'
+    assert _measure(tmp_path, source)["f"].docstring == 4
+
+
+def test_trailing_blank_lines_in_a_docstring_are_counted(tmp_path: Path) -> None:
+    """``get_docstring()`` strips these; a reader still scrolls past them."""
+    source = 'def f():\n    """Summary.\n\n\n    """\n    return 1\n'
+    assert _measure(tmp_path, source)["f"].docstring == 4
+
+
+def test_function_without_a_docstring_counts_none(tmp_path: Path) -> None:
+    entries = _measure(tmp_path, "def f():\n    return 1\n")
+    assert entries["f"].docstring == 0
+    assert entries["f"].prose == 0
+
+
+def test_a_string_expression_that_is_not_a_docstring_is_not_counted(
+    tmp_path: Path,
+) -> None:
+    """Only the *first* statement is a docstring."""
+    source = 'def f():\n    x = 1\n    "not a docstring"\n    return x\n'
+    assert _measure(tmp_path, source)["f"].docstring == 0
+
+
+def test_comments_in_an_indented_method_are_counted(tmp_path: Path) -> None:
+    """A method body arrives indented; the count must survive that.
+
+    ``tokenize`` accepts a leading-indented snippet on every supported Python
+    (3.10 through 3.14 all count it correctly, and all 1348 functions in ``src``
+    tokenize identically with and without a dedent), but the tool dedents first
+    so the result cannot depend on that.
+    """
+    source = (
+        "class C:\n"
+        "    def m(self):\n"
+        '        """Doc."""\n'
+        "        # one\n"
+        "        # two\n"
+        "        return 1  # trailing, same line as code\n"
+    )
+    entry = _measure(tmp_path, source)["m"]
+    assert entry.comments == 3
+    assert entry.docstring == 1
+
+
+def test_multiple_comment_tokens_on_one_line_count_once(tmp_path: Path) -> None:
+    """The unit is lines a reader scrolls past, not tokens."""
+    source = "def f():\n    return 1  # a\n"
+    assert _measure(tmp_path, source)["f"].comments == 1
+
+
+def test_ratio_uses_the_remaining_lines_as_code(tmp_path: Path) -> None:
+    source = 'def f():\n    """x"""\n    # c\n    return 1\n'
+    entry = _measure(tmp_path, source)
+    assert entry["f"].prose == 2  # one docstring line, one comment
+    assert entry["f"].code == 2  # def and return
+    assert entry["f"].ratio == 1.0
+
+
+def test_unparsable_file_yields_nothing(tmp_path: Path) -> None:
+    """A syntax error is skipped rather than crashing a release-time sweep."""
+    path = tmp_path / "broken.py"
+    path.write_text("def f(:\n")
+    assert list(prose_density.measure(path)) == []
+
+
+def test_untokenizable_body_warns_instead_of_scoring_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Silently counting an unmeasurable function as prose-free is the one
+    failure this tool must not have."""
+
+    def boom(readline: Any) -> Any:
+        raise SyntaxError("synthetic")
+
+    monkeypatch.setattr(prose_density.tokenize, "generate_tokens", boom)
+    assert prose_density._comment_lines("# c\n", "somewhere.py:1 f()") == 0
+    assert "cannot tokenize somewhere.py:1 f()" in capsys.readouterr().err
+
+
+def test_since_with_a_bad_revision_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing ``git diff`` must not read as "nothing changed"."""
+
+    def fail(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args, 128, "", "fatal: unknown revision")
+
+    monkeypatch.setattr(prose_density.subprocess, "run", fail)
+    with pytest.raises(SystemExit, match="fatal: unknown revision"):
+        prose_density._changed_files("no-such-rev")
+
+
+def test_the_tool_measures_itself(tmp_path: Path) -> None:
+    """An end-to-end sanity check against a real file with real docstrings."""
+    entries = {e.name: e for e in prose_density.measure(_TOOL)}
+    assert entries  # the module defines functions
+    assert all(e.code >= 1 for e in entries.values())
+    assert entries["_docstring_lines"].docstring > 5

--- a/tools/prose_density.py
+++ b/tools/prose_density.py
@@ -14,8 +14,9 @@ Measuring matters because the eye misjudges it: the worst ratios sit on the
 smallest helpers, where nine lines of docstring over a one-line body reads as
 perfectly reasonable inside a diff.
 
-Prose is docstring lines plus comment lines; code is every other line of the
-function body. A ratio above roughly 3x deserves a look -- not a rewrite, since
+Prose is docstring lines plus comment lines, each counted as the lines it
+physically occupies; code is every other line of the function body. A ratio above
+roughly 3x deserves a look -- not a rewrite, since
 what a guard's shape cost to establish is worth keeping. What is worth cutting
 is history the changelog already holds, corpus statistics the tests already
 assert, and one explanation repeated at three layers.
@@ -36,6 +37,8 @@ import argparse
 import ast
 import io
 import subprocess
+import sys
+import textwrap
 import tokenize
 from pathlib import Path
 from typing import Iterator, NamedTuple
@@ -52,18 +55,49 @@ class Entry(NamedTuple):
     comments: int
 
 
-def _comment_lines(source: str) -> int:
-    """Comment tokens in *source*, counted once per line."""
+def _comment_lines(source: str, where: str) -> int:
+    """Comment tokens in *source*, counted once per line.
+
+    *source* is dedented first. A method's body arrives indented, which
+    ``tokenize`` accepts on every supported Python -- 3.10 through 3.14 all
+    count it correctly, and all 1348 functions in ``src`` tokenize identically
+    with and without the dedent -- so this is insurance rather than a fix.
+
+    A snippet that cannot be tokenized is reported rather than counted as zero:
+    silently scoring an unmeasurable function as having no prose is the one
+    failure this tool must not have.
+    """
     lines = set()
     try:
-        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+        for token in tokenize.generate_tokens(
+            io.StringIO(textwrap.dedent(source)).readline
+        ):
             if token.type == tokenize.COMMENT:
                 lines.add(token.start[0])
-    except (tokenize.TokenError, IndentationError, SyntaxError):
-        # A function body dedented out of its class is not tokenizable on its
-        # own; counting no comments is the conservative answer.
+    except (tokenize.TokenError, IndentationError, SyntaxError) as exc:
+        print(f"warning: cannot tokenize {where}: {exc}", file=sys.stderr)
         return 0
     return len(lines)
+
+
+def _docstring_lines(node: ast.AST) -> int:
+    """Lines the docstring physically occupies, quotes included.
+
+    Not ``len(ast.get_docstring(node).splitlines()) + 2``: ``get_docstring``
+    returns the *cleaned* text, dedented and stripped of leading and trailing
+    blank lines, so that estimate overcounts a one-line docstring by two and a
+    typical multi-line one by one. What this measures is what a reader scrolls
+    past, which is the point of the report.
+    """
+    body = getattr(node, "body", None)
+    if not body:
+        return 0
+    first = body[0]
+    if not isinstance(first, ast.Expr) or not isinstance(first.value, ast.Constant):
+        return 0
+    if not isinstance(first.value.value, str):
+        return 0
+    return (first.end_lineno or first.lineno) - first.lineno + 1
 
 
 def measure(path: Path) -> Iterator[Entry]:
@@ -78,11 +112,9 @@ def measure(path: Path) -> Iterator[Entry]:
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         total = node.end_lineno - node.lineno + 1 if node.end_lineno else 1
-        doc = ast.get_docstring(node)
-        # +2 for the quote lines, which are prose the reader still scrolls past.
-        docstring = len(doc.splitlines()) + 2 if doc else 0
+        docstring = _docstring_lines(node)
         body = "".join(lines[node.lineno - 1 : node.end_lineno])
-        comments = _comment_lines(body)
+        comments = _comment_lines(body, f"{path}:{node.lineno} {node.name}()")
         code = max(total - docstring - comments, 1)
         prose = docstring + comments
         yield Entry(
@@ -91,13 +123,22 @@ def measure(path: Path) -> Iterator[Entry]:
 
 
 def _changed_files(since: str) -> set[Path]:
-    """Python files touched since *since*, as a git revision."""
+    """Python files touched since *since*, as a git revision.
+
+    A failing ``git diff`` exits rather than returning nothing: an unknown
+    revision or a checkout-less directory would otherwise print "no Python
+    files changed", which reads as a clean sweep and is the wrong answer to act
+    on at release time.
+    """
     out = subprocess.run(
         ["git", "diff", "--name-only", f"{since}..HEAD"],
         capture_output=True,
         text=True,
         check=False,
     )
+    if out.returncode != 0:
+        message = out.stderr.strip() or f"git diff {since}..HEAD failed"
+        raise SystemExit(f"error: {message}")
     return {Path(p) for p in out.stdout.split() if p.endswith(".py")}
 
 

--- a/tools/prose_density.py
+++ b/tools/prose_density.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+"""Report prose-to-code ratios per function, to find comment blocks worth trimming.
+
+Rationale prose accumulates across a release: a fix PR appends a paragraph
+recording what it measured, the next appends another, and nothing compresses
+what is already there. Nothing catches it mechanically either -- ruff's
+docstring rules are not selected, no line-length rule is either, and
+``ruff format`` reflows neither comments nor docstrings -- so the release's
+prose sweep (see ``.claude/skills/release/SKILL.md``, Step 1b) is where it gets
+caught, and this is what makes that sweep a measurement rather than a taste
+argument.
+
+Measuring matters because the eye misjudges it: the worst ratios sit on the
+smallest helpers, where nine lines of docstring over a one-line body reads as
+perfectly reasonable inside a diff.
+
+Prose is docstring lines plus comment lines; code is every other line of the
+function body. A ratio above roughly 3x deserves a look -- not a rewrite, since
+what a guard's shape cost to establish is worth keeping. What is worth cutting
+is history the changelog already holds, corpus statistics the tests already
+assert, and one explanation repeated at three layers.
+
+Usage::
+
+    uv run python tools/prose_density.py
+    uv run python tools/prose_density.py --min-ratio 2 --paths src tests
+    uv run python tools/prose_density.py --since v1.18.0
+
+``--since`` narrows the report to functions in files a release touched, which is
+the form the sweep wants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import subprocess
+import tokenize
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+
+class Entry(NamedTuple):
+    ratio: float
+    prose: int
+    code: int
+    path: Path
+    lineno: int
+    name: str
+    docstring: int
+    comments: int
+
+
+def _comment_lines(source: str) -> int:
+    """Comment tokens in *source*, counted once per line."""
+    lines = set()
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(source).readline):
+            if token.type == tokenize.COMMENT:
+                lines.add(token.start[0])
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        # A function body dedented out of its class is not tokenizable on its
+        # own; counting no comments is the conservative answer.
+        return 0
+    return len(lines)
+
+
+def measure(path: Path) -> Iterator[Entry]:
+    """Yield one entry per function or method defined in *path*."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        total = node.end_lineno - node.lineno + 1 if node.end_lineno else 1
+        doc = ast.get_docstring(node)
+        # +2 for the quote lines, which are prose the reader still scrolls past.
+        docstring = len(doc.splitlines()) + 2 if doc else 0
+        body = "".join(lines[node.lineno - 1 : node.end_lineno])
+        comments = _comment_lines(body)
+        code = max(total - docstring - comments, 1)
+        prose = docstring + comments
+        yield Entry(
+            prose / code, prose, code, path, node.lineno, node.name, docstring, comments
+        )
+
+
+def _changed_files(since: str) -> set[Path]:
+    """Python files touched since *since*, as a git revision."""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{since}..HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {Path(p) for p in out.stdout.split() if p.endswith(".py")}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=["src"],
+        help="directories or files to measure (default: src)",
+    )
+    parser.add_argument(
+        "--min-ratio",
+        type=float,
+        default=3.0,
+        help="report functions at or above this prose-to-code ratio (default: 3)",
+    )
+    parser.add_argument(
+        "--min-prose",
+        type=int,
+        default=8,
+        help="ignore functions with less prose than this, whatever the ratio "
+        "(default: 8) -- a two-line docstring over a one-line body is fine",
+    )
+    parser.add_argument(
+        "--since",
+        metavar="REV",
+        help="restrict to files changed since REV, e.g. the last release tag",
+    )
+    args = parser.parse_args()
+
+    files: list[Path] = []
+    for raw in args.paths:
+        path = Path(raw)
+        files.extend(sorted(path.rglob("*.py")) if path.is_dir() else [path])
+    if args.since:
+        changed = _changed_files(args.since)
+        files = [f for f in files if f in changed]
+        if not files:
+            print(f"No Python files changed since {args.since}.")
+            return
+
+    entries = [e for f in files for e in measure(f)]
+    flagged = [
+        e for e in entries if e.ratio >= args.min_ratio and e.prose >= args.min_prose
+    ]
+    flagged.sort(reverse=True)
+
+    if not flagged:
+        print(
+            f"Nothing at or above {args.min_ratio}x prose-to-code "
+            f"across {len(files)} file(s), {len(entries)} function(s)."
+        )
+        return
+
+    print(f"{'ratio':>7} {'prose':>6} {'code':>5}  location")
+    for e in flagged:
+        print(
+            f"{e.ratio:6.1f}x {e.prose:6} {e.code:5}  "
+            f"{e.path}:{e.lineno} {e.name}() "
+            f"[docstring {e.docstring}, comments {e.comments}]"
+        )
+    total_prose = sum(e.prose for e in entries)
+    total_code = sum(e.code for e in entries)
+    print(
+        f"\n{len(flagged)} of {len(entries)} functions flagged; "
+        f"{total_prose} prose lines to {total_code} code lines overall "
+        f"({total_prose / total_code:.2f}x)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follows the discussion on #769 and gives #770 a mechanism rather than a good intention.

## Why a release step

Rationale prose accumulates per release, not per PR: a fix appends a paragraph
recording what it measured, the next appends another, and nothing compresses what is
already there. `numpy_io._image_data_planes()` reached 44 docstring lines over 6 of
code that way, one paragraph each from #728, #732 and #736.

Nothing catches it mechanically, which is worth stating explicitly because it is easy
to assume otherwise:

- ruff's `select` is `["E4", "E7", "E9", "F"]` plus `PLC0415`, `T10` — no pydocstyle
  (`D`) rules, and `E501` (line length) is not selected either.
- `ruff format` reflows neither comments nor docstrings.
- `mdformat` covers Markdown only; `sphinx-lint` checks reST syntax, not length.

So the release is the natural unit of review, and Step 1b is where it happens.

## Why a tool

Because the eye misjudges this. The worst ratios sit on the smallest helpers, where
nine lines of docstring over a one-line body reads as perfectly reasonable inside a
diff. `tools/prose_density.py` counts docstring plus comment lines against code lines
per function:

```
  ratio  prose  code  location
  19.5x     39     2  src/psd_tools/api/utils.py:155 get_color_channels() [docstring 39, comments 0]
  18.0x     36     2  src/psd_tools/composite/paint.py:46 _clamp01() [docstring 36, comments 0]
  15.0x     30     2  src/psd_tools/api/psd_image.py:628 background_color() [docstring 30, comments 0]
  ...
32 of 1352 functions flagged; 3921 prose lines to 9961 code lines overall (0.39x).
```

**Corrected in 1e8f1d9.** The first version of this PR quoted 40:1 for
`get_color_channels()`, 34 functions flagged and 0.48x overall. Those were the
tool's own bug: it sized docstrings from `ast.get_docstring()`, the cleaned
text, plus a flat two for quotes, which overstated every docstring and -- since
code is the remainder -- understated the divisor with it. Single-expression
functions came out roughly twofold too high. The table above is the corrected
measurement, against merged main.

`--since <tag>` narrows it to files a release touched, which is the form the sweep
wants. `--min-ratio` and `--min-prose` tune the threshold.

That measurement also corrects the framing #770 started with. The concern was raised
about #769's prose, but the densest blocks in the tree predate it by a long way:
its own additions measure 5.5x (`_image_data_planes()`), 4.0x (`_channel_length()`,
`_rle_row_size()`), 3.1x and 1.7x, against a 19.5x top of file. A sweep scoped to one
PR would miss what actually needs compressing.

## What the step protects

The point is not a lower number. The step says to keep what cost real measurement and
what stops a future reader undoing a fix — why a bound is shaped the way it is, why a
guard cannot be tighter, what an experiment ruled out — and to cut history the
changelog already holds, corpus statistics the tests already assert, and the same
explanation repeated at three layers. Trimming is its own commit, comments and
docstrings only; if a line of code moves it stops being a sweep.

Documentation and tooling only. No library code, so nothing to test beyond the tool
running clean under ruff and mypy.

