### PR TITLE
chore: stop calling PIL's deprecated getdata() in the composite tests

### DIFF
--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -884,6 +884,19 @@ def test_composite_pil_force_covers_every_colour_mode(
     assert image.mode == mode
 
 
+def _flattened_data(image: Image.Image) -> Any:
+    """*image*'s pixels as a flat sequence, under whichever name PIL has for it.
+
+    Pillow 12.1 added ``get_flattened_data()`` and deprecated ``getdata()`` for
+    removal in Pillow 14. This project's floor is Pillow 10.3, which has only
+    the old spelling, so both have to work here. They read the same values
+    through the same unpacker and differ only in what they hand back -- a tuple
+    against PIL's internal sequence -- either of which ``np.array()`` accepts.
+    """
+    flatten = getattr(image, "get_flattened_data", None)
+    return flatten() if flatten is not None else image.getdata()
+
+
 def _pixels_as_seen(image: Image.Image) -> np.ndarray:
     """The planes a consumer of *image* reads, rather than PIL's own buffer.
 
@@ -893,10 +906,10 @@ def _pixels_as_seen(image: Image.Image) -> np.ndarray:
     ``Image.fromarray(..., "LAB")`` and back is the identity no matter what the
     unpacker does in between. That is why a NumPy-only assertion could not see
     #759, where the composited image carried both chroma planes 128 off and
-    converted to an unrelated colour. ``getdata()`` goes through the unpacker,
-    which is what ``convert()`` and ``save()`` do too.
+    converted to an unrelated colour. :func:`_flattened_data` goes through the
+    unpacker, which is what ``convert()`` and ``save()`` do too.
     """
-    planes = np.array(image.getdata(), dtype=np.uint8)
+    planes = np.array(_flattened_data(image), dtype=np.uint8)
     return planes.reshape(image.size[1], image.size[0], -1)
 
 


### PR DESCRIPTION
Pillow 12.1 added `Image.get_flattened_data()` and deprecated `getdata()` for
removal in Pillow 14, so every run of the suite emitted:

```
DeprecationWarning: Image.Image.getdata is deprecated and will be removed in
Pillow 14 (2027-10-15). Use get_flattened_data instead.
```

It came from `_pixels_as_seen()` in `tests/psd_tools/composite/test_composite.py`
— the helper that reads composited pixels through PIL's *unpacker* instead of
through `np.asarray()`, which is what makes it able to see #759.

## Why not just rename it

The project floor is `Pillow>=10.3.0` and the new spelling does not exist that
far back. Probed each version directly:

| Pillow | `get_flattened_data` | `getdata()` deprecated |
| --- | --- | --- |
| 10.3.0 (floor) | absent | no |
| 11.3.0 | absent | no |
| 12.0.0 | absent | no |
| 12.1.0 | **present** | **yes** |
| 12.3.0 (current) | present | yes |

So `_flattened_data()` asks the image which name it has. The two go through the
same unpacker and return the same values, differing only in the container — a
tuple against PIL's internal sequence — and `np.array(...)` accepts either.
Raising the floor to 12.1 for a test-only warning would cost users far more than
it buys, and nothing in `src/` calls `getdata()` at all.

## Verification

- The warning is gone; suite warnings drop 14 → 8, and all 2534 tests pass.
- **The helper keeps its teeth.** Swapping `_flattened_data()` for
  `np.asarray()` still fails
  `test_composite_pil_force_pixels_match_the_numpy_path[lab]` — that is the
  #759 regression this lens exists to catch, and it would be worthless if the
  new API happened to read PIL's raw buffer the way `np.asarray()` does. It does
  not: for a LAB image both spellings return `[50 138 72 …]` where `np.asarray()`
  returns `[50 10 200 …]`.
- **The fallback branch is exercised, not just written.** Running the composite
  tests against Pillow 10.3.0 — the declared floor, where `get_flattened_data`
  is confirmed absent — passes 43/43.

Test-only, so no changelog entry per the contributor docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
