### PR TITLE
fix: size the allocation guard against the peak, not the returned array (#767)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [security] Size the ``max_alloc_bytes`` guard against what ``numpy()`` and
+  ``topil()`` peak at rather than the array they return; both hold several
+  intermediates, measured at up to 3.7x the old estimate (#767). Affects you only
+  if you set ``max_alloc_bytes`` or ``$PSD_TOOLS_MAX_ALLOC_BYTES`` -- it admits
+  and rejects different documents in both directions, so re-check a tuned budget.
+
 - [fix] Read and write a 1-bit (Bitmap mode) document at the row stride the
   format uses (#768). A row of ``width`` pixels occupies ``ceil(width / 8)``
   bytes and the depth-1 path floored that, so ``numpy()`` and
@@ -39,10 +45,10 @@ Changelog
   ``_safe_zlib_decompress()`` also now enforces the ceiling it documents,
   refusing a stream that inflates one byte past it rather than handing that byte
   back. The eightfold gap itself is closed at its source by the row-stride fix
-  above (#768), which gives depth 1 the same arithmetic as every other depth: the
-  estimate is ``width * height * channels * 4`` again, and
+  above (#768), which gives depth 1 the same arithmetic as every other depth, and
   :py:func:`psd_tools.compression.decompressed_size_bound` remains available as a
-  public utility.
+  public utility. That arithmetic is superseded on both image-data paths later in
+  this release (#767).
 
 - [fix] Replace a failed channel with exactly the byte count it declares, at
   every depth (#737, #769). The black fill substituted for an undecodable channel was
@@ -439,11 +445,10 @@ Changelog
   over-estimate was not specific to indexed and predates this entry.
 
   The estimate bounds the array that is returned, which is what
-  ``check_pixel_size()`` has always measured. Peak usage during parsing is a
-  small multiple of it for every colour mode; that predates this entry and is
-  unchanged by it. 1-bit documents were under-counted eightfold, which predated
-  this entry as well and is fixed by the row-stride entry above (#768), in this
-  same release.
+  ``check_pixel_size()`` measured as of this entry; peak usage was a small
+  multiple of it, closed later in this release (#767). 1-bit documents were
+  under-counted eightfold, which predated this entry as well and is fixed by the
+  row-stride entry above (#768).
 - [fix] Composite duotone documents at their stored width.
   ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
   pixel data is a single grayscale channel, the one to four ink curves living

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -12,7 +12,7 @@ from psd_tools.api.utils import (
     get_transparency_index,
     has_transparency,
 )
-from psd_tools.constants import ChannelID, ColorMode
+from psd_tools.constants import ChannelID, ColorMode, Compression
 from psd_tools.psd.patterns import Pattern
 
 logger = logging.getLogger(__name__)
@@ -75,13 +75,13 @@ def _image_data_planes(psdimage: "PSDProtocol", flat: bool = False) -> int:
     :func:`_parse_array` trims each row's padding, so a 1-bit document
     allocates one float32 per pixel and the header bounds it exactly.
 
-    This bounds the array that is returned, which is what
-    :func:`~psd_tools.api.utils.check_pixel_size` estimates by construction. It
-    does not model the transient peak: :func:`_parse_array` holds the raw bytes
-    and two float32 arrays at once, and :func:`_remove_background` adds several
-    more, so the true high-water mark is a small multiple of this for every
-    colour mode -- a pre-existing property of this estimate rather than
-    anything a colour mode or a depth causes.
+    This bounds the array that is returned. The transient peak on top of it --
+    :func:`_parse_array` holding two float32 arrays at once,
+    :func:`_remove_background` adding several more -- is
+    :func:`_image_data_peak_bytes`'s subject, and it is what the guard is given
+    (#767). Keep this one about the width of the result: the two are separate
+    because the plane count is a property of the format and the transients are a
+    property of the code, and they go stale for different reasons.
     """
     if flat:
         return 1
@@ -89,6 +89,113 @@ def _image_data_planes(psdimage: "PSDProtocol", flat: bool = False) -> int:
     if psdimage.color_mode == ColorMode.INDEXED and psdimage.depth == 8:
         planes *= EXPECTED_CHANNELS[ColorMode.INDEXED]
     return planes
+
+
+# What :func:`_parse_array` holds *on top of* the array it returns, in bytes per
+# pixel per plane. Each entry is a count of the arrays alive at once in that
+# depth's branch, not a safety factor:
+#
+#   depth 1   ``bits`` and ``1 - bits``, both uint8, while ``.astype`` builds the
+#             float32 result from them.
+#   depth 8   the ``.astype`` result, while ``/ 255.0`` builds the one returned.
+#             The palette adds a third, ``lut[parsed]``, counted separately below
+#             because it is uint8 rather than float32.
+#   depth 16  the same pair, rescaling by 65535 instead.
+#   depth 32  nothing. 32-bit data needs no rescale, so ``.astype`` alone
+#             produces the array that is returned.
+#
+# ``np.frombuffer`` is a view and allocates nothing; so are the ``reshape``,
+# ``transpose`` and ``ravel`` that follow.
+_PARSE_TRANSIENT: dict[int, int] = {1: 2, 8: 4, 16: 4, 32: 0}
+
+# The uint8 array the palette lookup materialises before it is widened, one byte
+# per pixel per plane -- ``lut[parsed]`` is already three planes wide.
+_PALETTE_TRANSIENT: int = 1
+
+# :func:`_remove_background`'s own temporaries, in bytes per pixel: three float32
+# arrays of the three colour planes (3 x 3 x 4) and a boolean mask of the same
+# shape (3 x 1), rounded up from the 39 measured. Flat rather than per-plane
+# because it always works on exactly three colour planes however wide the
+# document is. Measured with every alpha non-zero, which is the worst case for
+# its boolean-indexed copies -- a payload that leaves most of the alpha at zero
+# selects few elements and hides most of this.
+_BACKGROUND_TRANSIENT: int = 40
+
+# Bytes live at the codec's own peak, as a multiple of the decompressed size.
+# ``ImageData.get_data()`` runs after the guard, so this is inside what the guard
+# has to bound. RAW hands back the bytes read at open time -- the same object,
+# when the body is exactly the declared length -- while the other three build
+# their result: RLE joins materialised rows, and prediction adds an
+# ``array.array`` pass and a byte-order pass on top of the inflate. Measured
+# 1.0x / 2.0x / 2.1x / 3.1x, each rounded up.
+_DECOMPRESS_PEAK: dict[Compression, int] = {
+    Compression.RAW: 1,
+    Compression.RLE: 3,
+    Compression.ZIP: 3,
+    Compression.ZIP_WITH_PREDICTION: 4,
+}
+
+
+def _image_data_peak_bytes(psdimage: "PSDProtocol", flat: bool = False) -> int:
+    """Bytes :func:`get_image_data` allocates at its high-water mark.
+
+    :func:`_image_data_planes` sizes the array that comes back;
+    :func:`~psd_tools.api.utils.check_pixel_size` is given this instead, because
+    a budget that only bounds the result is one the peak walks straight through
+    (#767).
+
+    The three phases -- decompressing the channel buffer, parsing it into
+    float32, removing the white background -- run one after another, so the
+    widest of them bounds all three. Summing them instead would reject documents
+    that never hold two phases at once. What *is* live across the last two is the
+    decompressed buffer itself, so that is added to each rather than maxed with
+    them.
+
+    Measured with ``tracemalloc``, which sees numpy's allocations, over every
+    colour mode, depth, channel count and compression method. Two deliberate
+    exclusions:
+
+    - Per-object allocator overhead. This and ``tracemalloc`` both count
+      requested bytes; what the allocator rounds each request up to is neither
+      modelled nor modellable here.
+    - The source buffer is counted even for RAW, where ``get_data()`` usually
+      returns the very bytes object read at open time and allocates nothing.
+      It only usually does: a body longer than the declared length is sliced,
+      and this guard exists for files that are not well formed
+      (GHSA-8q6g-vjhf-jp8m). The cost of counting it is a 2x over-estimate on a
+      32-bit RAW document, where there is no parse transient to dwarf it.
+    """
+    pixels = psdimage.width * psdimage.height
+    if flat:
+        # `np.ones((h, w, 1))` and nothing else -- the image data is never read,
+        # so there is no buffer to decompress and no transient above it.
+        return pixels * 4
+
+    planes = _image_data_planes(psdimage, flat)
+    depth = psdimage.depth
+    returned = pixels * planes * 4
+
+    # Rounded up per row: a 1-bit row of `width` pixels occupies
+    # `ceil(width / 8)` bytes, padding included.
+    source = ((psdimage.width * depth + 7) // 8) * psdimage.height * psdimage.channels
+
+    parse = _PARSE_TRANSIENT[depth]
+    if psdimage.color_mode == ColorMode.INDEXED and depth == 8:
+        parse += _PALETTE_TRANSIENT
+    # `_remove_background()`'s own condition, spelled against the plane count it
+    # actually tests: `data.shape[2] > 3` on an RGB document.
+    background = (
+        _BACKGROUND_TRANSIENT
+        if psdimage.color_mode == ColorMode.RGB and planes > 3
+        else 0
+    )
+    compression = psdimage._record.image_data.compression
+
+    return max(
+        _DECOMPRESS_PEAK[compression] * source,
+        source + returned + pixels * planes * parse,
+        source + returned + pixels * background,
+    )
 
 
 def get_image_data(psdimage: "PSDProtocol", channel: str | None) -> np.ndarray:
@@ -99,14 +206,19 @@ def get_image_data(psdimage: "PSDProtocol", channel: str | None) -> np.ndarray:
         channel == "shape" and not has_transparency(psdimage)
     )
     # The guard is here to reject a file before it allocates, so its estimate
-    # must not fall below the array that follows. See _image_data_planes() for
-    # why the header's own count is not that bound for an indexed document --
-    # and why the wider-of-the-pair shape used in composite() is not either.
+    # must not fall below what follows -- which is more than the array returned,
+    # this path holding two float32 arrays at once while it parses and several
+    # more while it removes the background (#767). _image_data_peak_bytes() is
+    # that bound; the plane count still rides along, naming the shape in the
+    # error message. See _image_data_planes() for why the header's own count is
+    # not the array's width for an indexed document -- and why the
+    # wider-of-the-pair shape used in composite() is not either.
     check_pixel_size(
         psdimage.width,
         psdimage.height,
         _image_data_planes(psdimage, flat),
         max_alloc_bytes=psdimage._max_alloc_bytes,
+        estimated_bytes=_image_data_peak_bytes(psdimage, flat),
     )
 
     if flat:

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -112,14 +112,22 @@ _PARSE_TRANSIENT: dict[int, int] = {1: 2, 8: 4, 16: 4, 32: 0}
 # per pixel per plane -- ``lut[parsed]`` is already three planes wide.
 _PALETTE_TRANSIENT: int = 1
 
-# :func:`_remove_background`'s own temporaries, in bytes per pixel: three float32
-# arrays of the three colour planes (3 x 3 x 4) and a boolean mask of the same
-# shape (3 x 1), rounded up from the 39 measured. Flat rather than per-plane
-# because it always works on exactly three colour planes however wide the
-# document is. Measured with every alpha non-zero, which is the worst case for
-# its boolean-indexed copies -- a payload that leaves most of the alpha at zero
-# selects few elements and hides most of this.
-_BACKGROUND_TRANSIENT: int = 40
+# :func:`_remove_background`'s own temporaries, in bytes per pixel: up to four
+# float32 arrays of the three colour planes (4 x 3 x 4) and a boolean mask of the
+# same shape (3 x 1), rounded up from 51. Flat rather than per-plane because it
+# always works on exactly three colour planes however wide the document is.
+#
+# This is the one term that is not the same everywhere, and it is sized on the
+# widest platform rather than on the one it was developed on. Measured at 39
+# bytes a pixel on macOS/CPython 3.10 -- three arrays, each freed before the next
+# was taken -- and at 48 on Linux and on Windows, at every Python from 3.10 to
+# 3.14 and with or without the composite extra. A guard that holds only where
+# its author ran it is not a guard, so 48 is what this covers.
+#
+# Measured with every alpha non-zero, which is the worst case for its
+# boolean-indexed copies: a payload that leaves most of the alpha at zero selects
+# few elements and hides most of this.
+_BACKGROUND_TRANSIENT: int = 52
 
 # Bytes live at the codec's own peak, as a multiple of the decompressed size.
 # ``ImageData.get_data()`` runs after the guard, so this is inside what the guard
@@ -152,8 +160,11 @@ def _image_data_peak_bytes(psdimage: "PSDProtocol", flat: bool = False) -> int:
     them.
 
     Measured with ``tracemalloc``, which sees numpy's allocations, over every
-    colour mode, depth, channel count and compression method. Two deliberate
-    exclusions:
+    colour mode, depth, channel count and compression method. The fit is exact
+    on the platform it was developed on and an upper bound elsewhere: every term
+    but :data:`_BACKGROUND_TRANSIENT` measures the same everywhere, and that one
+    is sized on the widest platform, so a document admitted here is one whose
+    peak fits on any of them. Two deliberate exclusions:
 
     - Per-object allocator overhead. This and ``tracemalloc`` both count
       requested bytes; what the allocator rounds each request up to is neither

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -13,7 +13,7 @@ from psd_tools.api.utils import (
     get_transparency_index,
     has_transparency,
 )
-from psd_tools.constants import ChannelID, ColorMode, Resource
+from psd_tools.constants import ChannelID, ColorMode, Compression, Resource
 from psd_tools.psd.image_resources import ThumbnailResource, ThumbnailResourceV4
 from psd_tools.psd.patterns import Pattern
 
@@ -78,6 +78,130 @@ def get_pil_depth(pil_mode: str) -> int:
     }.get(pil_mode, 8)
 
 
+# The "I"/"F" image and the second one `.point()` builds from it, four bytes per
+# pixel each, alive together with the "L" they narrow to. Flat rather than
+# per-channel: the loop converts one channel at a time, so only one such pair
+# exists at any moment however many channels the document stores. Measured at
+# 9.0 bytes per pixel in isolation, of which the retained "L" is counted with
+# the other converted channels below.
+_CONVERSION_TRANSIENT: int = 8
+
+# `_remove_white_background()`, in bytes per pixel: the four bands `split()`
+# hands back, the `ImageMath` expression promoting each of three to "I" at four
+# bytes a pixel, the three "L" results, and the `merge()` that reassembles them.
+# Measured at 23.8 in isolation; rounded well up because PIL's buffers are
+# C-side and the instrument that reads them is coarser than the one numpy gets.
+_WHITE_BACKGROUND_TRANSIENT: int = 35
+
+# PIL rounds each image up to its arena's block granularity, so the process grows
+# by a little more than the bytes the images ask for. Every other term here
+# counts requested bytes, as the numpy model does; this one covers the
+# difference, measured at no more than 0.23 bytes per pixel over the whole
+# colour-mode/depth/compression matrix.
+_ALLOCATOR_SLACK: int = 1
+
+# Bytes live at the codec's own peak, as a multiple of the decompressed size.
+# One step wider than the numpy path's table throughout, because this path asks
+# `get_data()` to split the buffer per channel and the split is a second copy.
+_DECOMPRESS_PEAK: dict[Compression, int] = {
+    Compression.RAW: 2,
+    Compression.RLE: 3,
+    Compression.ZIP: 3,
+    Compression.ZIP_WITH_PREDICTION: 4,
+}
+
+
+def _image_data_peak_bytes(
+    psd: "PSDProtocol", channel: int | None, apply_icc: bool
+) -> int:
+    """Bytes :func:`convert_image_data_to_pil` allocates at its high-water mark.
+
+    The counterpart to :func:`~psd_tools.api.numpy_io._image_data_peak_bytes`,
+    and it corrects this path's estimate in *both* directions (#767).
+
+    The old estimate was ``width * height * channels * 4``, four bytes per pixel
+    per stored channel -- a float32 plane, which is what the numpy path returns
+    and what this one never holds. ``_create_image()`` yields "L", "P" or "1",
+    and PIL stores a byte per pixel in all three. It was wrong in both
+    directions and by different amounts: a multi-band 8-bit document was turned
+    away below its budget, while the 16- and 32-bit branches, which build an
+    "I"/"F" image and then a second through ``.point()``, ran straight past it,
+    as did anything whose alpha channel sends it through
+    ``_remove_white_background()``. Correcting it moves both ways -- a little
+    looser on 8-bit RGB and LAB, several times tighter at depth 16 and 32 and on
+    RGBA at any depth.
+
+    Phase-maxed like the numpy model, over the same three-stage shape:
+    decompress, convert each channel, assemble. Every term is gated on the
+    branch that allocates it -- indexed and multichannel documents take
+    ``channels[0]`` and never merge, ``post_process()`` is a no-op without CMYK,
+    a profile or an alpha channel, and the white background is removed only from
+    an RGBA result. Ungated, those terms would make this *tighter* than the
+    estimate it replaces on exactly the 8-bit documents it is meant to stop
+    over-counting.
+
+    PIL's buffers are C-side and invisible to ``tracemalloc``, so unlike the
+    numpy model this is an analytic count of the images the path holds, with each
+    phase measured in isolation rather than fitted to a whole-call figure -- a
+    whole-call RSS delta cannot see a phase that reuses what the phase before it
+    released. The same two exclusions apply as on the numpy side: per-object
+    allocator overhead, and the RAW source buffer being counted even where
+    ``get_data()`` would not re-allocate it.
+    """
+    pixels = psd.width * psd.height
+    depth = psd.depth
+    # Rounded up per row, as the format pads a 1-bit row to a byte boundary.
+    source = ((psd.width * depth + 7) // 8) * psd.height * psd.channels
+    conversion = _CONVERSION_TRANSIENT if depth in (16, 32) else 0
+    decompress = _DECOMPRESS_PEAK[psd._record.image_data.compression] * source
+
+    if channel is not None:
+        # One `_create_image()` and no assembly: nothing is merged, there is no
+        # alpha to put, and `_remove_white_background()` cannot fire on one band.
+        return max(decompress, source + pixels * (1 + conversion))
+
+    mode = get_pil_mode(psd.color_mode)
+    bands = get_pil_channels(mode)
+    alpha = has_transparency(psd)
+    # Indexed and multichannel documents keep `channels[0]` and never merge.
+    merged = (
+        0 if psd.color_mode in (ColorMode.INDEXED, ColorMode.MULTICHANNEL) else bands
+    )
+    icc = apply_icc and Resource.ICC_PROFILE in psd.image_resources
+    # A profile rewrites the image to RGB, so what `putalpha()` and the white
+    # background see afterwards is not the mode the colour mode implies: a CMYK
+    # or grayscale document with a profile *and* an alpha channel comes out RGBA
+    # like any other, and is charged accordingly.
+    final_bands = 3 if icc else bands
+    widened = alpha and (icc or mode in ("RGB", "L"))
+    # `post_process()`'s three widenings, whichever of them this document
+    # reaches. They run in sequence and each frees what it replaced, so the
+    # widest bounds the phase: the CMYK inversion is a second image of the same
+    # mode; `_apply_icc()` holds its input alongside the RGB it writes;
+    # `putalpha()` converts in place and holds the mode it is leaving alongside
+    # the one it is building.
+    post = max(
+        bands if mode == "CMYK" else 0,
+        bands + 3 if icc else 0,
+        2 * final_bands + 1 if widened else 0,
+    )
+    # `_remove_white_background()` only ever sees an RGBA image -- which is to
+    # say a three-band one that `putalpha()` has just widened.
+    white_background = (
+        _WHITE_BACKGROUND_TRANSIENT if widened and final_bands == 3 else 0
+    )
+
+    # One narrow image per stored channel, held in `channels` to the end, and
+    # the decompressed buffer it was built from, held just as long.
+    retained = source + pixels * (psd.channels + _ALLOCATOR_SLACK)
+    return max(
+        decompress,
+        retained + pixels * conversion,
+        retained + pixels * (merged + post),
+        retained + pixels * (merged + 1 + white_background),
+    )
+
+
 def convert_image_data_to_pil(
     psd: "PSDProtocol", channel: int | None, apply_icc: bool
 ) -> Image.Image | None:
@@ -88,22 +212,15 @@ def convert_image_data_to_pil(
 
     # The header's own channel count, with none of the corrections the numpy
     # path needs (:func:`~psd_tools.api.numpy_io._image_data_planes`), because
-    # PIL allocates a plane per stored channel at every depth and mode:
-    # `_create_image()` builds one image per channel from a buffer whose pixel
-    # count is the canvas's, and PIL's "1" mode holds a byte per pixel, so a
-    # 1-bit document allocates a quarter of this estimate.
-    #
-    # What this does not cover is the transient peak in the 16- and 32-bit
-    # branches, which build an "I"/"F" image at four bytes per pixel and then
-    # allocate a second through `.point()` before narrowing to "L" -- roughly
-    # twice the estimate, alive for as long as the conversion. That is a peak
-    # rather than a returned size, which this guard has never modelled on any
-    # path, and it is tracked in #767.
+    # PIL allocates a plane per stored channel at every depth and mode. It sizes
+    # nothing here -- `_image_data_peak_bytes()` does that -- but it still names
+    # the shape the error message reports.
     check_pixel_size(
         psd.width,
         psd.height,
         psd.channels,
         max_alloc_bytes=psd._max_alloc_bytes,
+        estimated_bytes=_image_data_peak_bytes(psd, channel, apply_icc),
     )
 
     if channel is not None and channel >= psd.channels:

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -227,10 +227,19 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
         Open a PSD document.
 
         :param fp: filename or file-like object.
-        :param max_alloc_bytes: optional per-document cap (bytes) on the buffer
-            that :py:meth:`composite`/:py:meth:`numpy`/:py:meth:`topil` allocate;
-            rendering raises :class:`ValueError` if the estimate exceeds it. The
-            estimate comes from the declared geometry. Defaults to the ``$PSD_TOOLS_MAX_ALLOC_BYTES``
+        :param max_alloc_bytes: optional per-document cap (bytes) on what
+            :py:meth:`composite`/:py:meth:`numpy`/:py:meth:`topil` allocate;
+            rendering raises :class:`ValueError` if the estimate exceeds it.
+            :py:meth:`numpy` and :py:meth:`topil` estimate their allocation *at
+            its peak*, intermediates included, so the estimate depends on the
+            colour mode, the depth and the compression method rather than on the
+            declared geometry alone. :py:meth:`composite` bounds the canvas it
+            builds instead, from the geometry: what follows that guard grows with
+            the layer count, which no such estimate can bound. Note that
+            :py:meth:`composite` reaches the other two in the ordinary cases --
+            it returns the preview through :py:meth:`topil` when the document has
+            one, and a document with no layers falls through to :py:meth:`numpy`.
+            Defaults to the ``$PSD_TOOLS_MAX_ALLOC_BYTES``
             env var (or :data:`psd_tools.api.utils.MAX_ALLOC_BYTES`) when ``None``.
         :param encoding: charset encoding of the pascal string within the file,
             default 'macroman'. Some psd files need explicit encoding option.

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -71,7 +71,11 @@ class PSDLargeImageWarning(UserWarning):
 
 
 def check_pixel_size(
-    width: int, height: int, channels: int = 1, max_alloc_bytes: int | None = None
+    width: int,
+    height: int,
+    channels: int = 1,
+    max_alloc_bytes: int | None = None,
+    estimated_bytes: int | None = None,
 ) -> None:
     """Warn and/or raise when canvas dimensions exceed safe thresholds.
 
@@ -85,19 +89,37 @@ def check_pixel_size(
     :data:`WARN_PIXELS` that are still within the per-axis spec limit.
 
     When :data:`MAX_ALLOC_BYTES` is set, also raises :class:`ValueError` if the
-    estimated allocation (``width * height * channels * 4``) exceeds it.
+    estimated allocation exceeds it. That estimate is ``estimated_bytes`` when a
+    caller supplies one, and ``width * height * channels * 4`` otherwise.
+
+    The two spellings answer different questions, and the difference is the
+    point. ``width * height * channels * 4`` sizes the float32 array a path
+    *returns*; a caller that also holds intermediates -- and both image-data
+    paths hold several -- passes what it really peaks at instead, because a
+    budget the peak exceeds is a budget that did not do its job (#767). See
+    :func:`~psd_tools.api.numpy_io._image_data_peak_bytes` and
+    :func:`~psd_tools.api.pil_io._image_data_peak_bytes` for the two models, and
+    :func:`~psd_tools.composite.composite.composite` for the caller that keeps
+    the returned-size spelling deliberately: its peak grows with the layer count,
+    so no expression of this shape bounds it.
 
     :param width: canvas width in pixels.
     :param height: canvas height in pixels.
-    :param channels: number of float32 planes, used only to estimate the
-        allocation (``width * height * channels * 4``) for the
-        :data:`MAX_ALLOC_BYTES` budget. Defaults to 1. Callers may pass a count
-        that differs from the header's channels, because for some colour modes
-        and depths the array is not one plane per stored channel: see
+    :param channels: number of float32 planes. Sizes the default estimate
+        (``width * height * channels * 4``), and names the shape in the error
+        message either way. Defaults to 1. Callers may pass a count that differs
+        from the header's channels, because for some colour modes and depths the
+        array is not one plane per stored channel: see
         :func:`~psd_tools.api.numpy_io._image_data_planes`, which triples an
         indexed document for its palette.
     :param max_alloc_bytes: per-call budget in bytes; overrides the module-level
         :data:`MAX_ALLOC_BYTES` default when not ``None``.
+    :param estimated_bytes: bytes this call is expected to allocate at its peak,
+        replacing the default estimate when given. Callers whose peak is not a
+        multiple of the returned array -- one holding a flat transient, say, that
+        does not scale with the channel count -- cannot express it through
+        ``channels`` alone, which is why this takes a byte count rather than a
+        multiplier.
     """
     if width < 1 or height < 1:
         raise ValueError(f"Image dimensions must be positive, got {width}x{height}.")
@@ -116,10 +138,22 @@ def check_pixel_size(
         )
     budget = max_alloc_bytes if max_alloc_bytes is not None else MAX_ALLOC_BYTES
     if budget is not None:
-        estimated = pixels * max(1, channels) * 4
+        estimated = (
+            estimated_bytes
+            if estimated_bytes is not None
+            else pixels * max(1, channels) * 4
+        )
         if estimated > budget:
+            # Naming which estimate this is matters: with a model the number is
+            # not `width * height * channels * 4` and a reader trying to derive
+            # it from the dimensions would not get there.
+            kind = (
+                "Peak allocation"
+                if estimated_bytes is not None
+                else "Estimated allocation"
+            )
             raise ValueError(
-                f"Estimated allocation {estimated:,} bytes for "
+                f"{kind} {estimated:,} bytes for "
                 f"{width}x{height}x{channels} is over the configured budget "
                 f"({budget:,} bytes). Raise or clear it via "
                 f"PSDImage.open(max_alloc_bytes=...), ${MAX_ALLOC_BYTES_ENV}, or "

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -402,6 +402,12 @@ def composite(
     # with no guard of their own, and a layer record's channel count is an
     # unvalidated uint16, so a malformed file can still allocate past this
     # before `_assert_source_fits` fires.
+    # This keeps the returned-size spelling of the estimate where the two
+    # image-data paths moved to a modelled peak (#767), and not for want of
+    # trying: what follows this guard grows with the layer count, so there is no
+    # expression in `width * height * <constant>` that bounds it. A caller who
+    # needs `max_alloc_bytes` to mean the peak has it on `numpy()` and `topil()`;
+    # here it means the canvas, as it always has.
     _estimate = (
         max(_psd.channels, _channels)
         if _psd is not None and _channels is not None

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from psd_tools.api.layers import AdjustmentLayer, GroupMixin, Layer, PixelLayer
+from psd_tools.api.numpy_io import _image_data_peak_bytes
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.composite import composite
 from psd_tools.composite.composite import Compositor
@@ -579,15 +580,25 @@ def test_composite_flattened_indexed_is_bounded_by_the_numpy_guard() -> None:
     :py:meth:`PSDImage.composite` *method* does not reach either estimate on
     this document -- it short-circuits to ``topil()`` when an unmodified
     document has a preview, which is guarded separately in ``pil_io``.
+
+    The number that binds is the ``numpy()`` guard's, and since #767 that is a
+    model of what the read peaks at rather than the 192-byte array it returns:
+    the palette-expanded result, the packed buffer it was built from and
+    ``_parse_array()``'s own temporaries are all live at once, some 28 bytes a
+    pixel in total. ``composite()``'s own estimate keeps the returned-size
+    spelling and stays at 192, so it is the narrower of the two here and never
+    the one that fires.
     """
     name = "colormodes/4x4_8bit_index_color.psd"
     assert len(PSDImage.open(full_name(name))) == 0  # flattened: early return
-    allocated = PSDImage.open(full_name(name)).numpy().nbytes
-    assert allocated == 4 * 4 * 3 * 4  # one stored channel, three allocated
+    psd = PSDImage.open(full_name(name))
+    assert psd.numpy().nbytes == 4 * 4 * 3 * 4  # one stored channel, three allocated
+    peak = _image_data_peak_bytes(psd)
+    assert peak == 448 > 4 * 4 * 3 * 4  # the peak the guard is handed instead
 
-    composite(PSDImage.open(full_name(name), max_alloc_bytes=allocated))
+    composite(PSDImage.open(full_name(name), max_alloc_bytes=peak))
     with pytest.raises(ValueError, match="4x4x3"):
-        composite(PSDImage.open(full_name(name), max_alloc_bytes=allocated - 1))
+        composite(PSDImage.open(full_name(name), max_alloc_bytes=peak - 1))
 
 
 def test_composite_duotone_is_one_channel_wide() -> None:

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -7,22 +7,27 @@ above MAX_PIXELS_PSD instead of committing the buffer silently.
 """
 
 import base64
+import gc
 import io
 import struct
+import tracemalloc
 import warnings
 import zlib
 
 import pytest
 
-from typing import Any, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 from psd_tools import PSDImage, PSDLargeImageWarning
 from psd_tools import compression as _compression
 from psd_tools.compression import compress
 from psd_tools.api import utils as _utils
 from psd_tools.api.numpy_io import _image_data_planes
-from psd_tools.api.utils import has_transparency
-from psd_tools.constants import ColorMode, Compression
+from psd_tools.api.numpy_io import _image_data_peak_bytes as _numpy_peak_bytes
+from psd_tools.api.pil_io import _WHITE_BACKGROUND_TRANSIENT
+from psd_tools.api.pil_io import _image_data_peak_bytes as _pil_peak_bytes
+from psd_tools.api.utils import check_pixel_size, has_transparency
+from psd_tools.constants import ColorMode, Compression, Resource
 from psd_tools.api.utils import (
     MAX_DIMENSION_PSD,
     MAX_PIXELS_PSD,
@@ -253,25 +258,41 @@ def test_explicit_kwarg_overrides_env_default(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
-# The estimate must match the allocation it guards (#732)
+# The estimate must model the peak it guards (#732, #767)
 # ---------------------------------------------------------------------------
 #
-# `get_image_data()` reads the header's channel count but does not always
-# allocate that many planes, so these pin the estimate against the array that
-# is actually produced rather than against a hard-coded byte count. A budget
-# equal to the real allocation must admit the document and one byte less must
-# reject it: that brackets the estimate from both sides at once, which a test
-# asserting only "raises" would not.
+# `check_pixel_size()` used to be handed `width * height * channels * 4`: the
+# size of the array a path *returns*. #732 fixed the channel count feeding that
+# product, because `get_image_data()` reads the header's count and does not
+# always allocate that many planes. What it could not fix is that the returned
+# array was the wrong quantity to bound. Both image-data paths hold
+# intermediates alongside their result -- `_parse_array()` two float32 arrays at
+# once, `_remove_background()` several more, the decompressed buffer live across
+# all of it -- so the real high-water mark ran up to 3.7x past the budget the
+# caller had set, and on the PIL path the same product also ran the other way,
+# turning away 8-bit documents that would have fitted several times over (#767).
 #
-# Both directions matter. The guard is a security control, so an estimate below
-# the allocation defeats it -- but one above it rejects a file that would have
-# been fine, and a guard that refuses sound documents is its own bug. The
-# estimate is exact for every colour mode, depth and channel count below.
+# So each path now hands the guard a structural model of its own peak:
+# `numpy_io._image_data_peak_bytes()` and `pil_io._image_data_peak_bytes()`.
+# The tests below pin those models from three directions:
 #
-# Note the scope: it bounds the array that is *returned*, which is what
-# `check_pixel_size()` estimates by construction. The transient peak is a small
-# multiple of it for every mode -- `_parse_array()` holds the raw bytes and two
-# float32 arrays at once -- and that is pre-existing, not colour-mode-specific.
+# - The model never falls below what the call really allocates. That is the
+#   security property -- an allocation that walks through the guard is the bug
+#   the guard exists for -- and it is asserted against `tracemalloc`, which sees
+#   numpy's allocations, rather than against any restatement of the model.
+# - The model is not wildly above it either. A guard that refuses sound
+#   documents is its own bug, and an estimate free to drift upwards has nothing
+#   left to say when it does.
+# - The plane count the model is built from still follows the format. The
+#   palette expansion and the depth-1 row arithmetic are facts about the file,
+#   not about the code that reads it, so they are asserted directly on
+#   `_image_data_planes()` and on the array's own `nbytes`. The peak model rides
+#   on top of them, and the two go stale for different reasons.
+#
+# `_assert_budget_brackets_the_model()` below is deliberately thin: it pins
+# *which* number the budget is compared against and nothing more. Left on its
+# own it would be asserting that `check_pixel_size()` spells its comparison
+# `>`, so no test here leans on it alone.
 
 _COLORMODE_FIXTURES = [
     "4x4_8bit_index_color.psd",
@@ -296,6 +317,24 @@ def _colormode(filename: str, max_alloc_bytes: int | None = None) -> PSDImage:
     )
 
 
+def _payload(size: int, depth: int) -> bytes:
+    """``size`` bytes of body that every branch of the model can be measured on.
+
+    The content is load-bearing rather than filler. At depth 32 the buffer is
+    reinterpreted as float32, and a body of arbitrary bytes reads as mostly
+    *negative* floats; `_remove_background()` then finds every alpha at or below
+    zero, its `color[a > 0]` selects almost nothing, and the largest transient
+    in the whole model goes unallocated and unmeasured. ``0x3f000000`` is 0.5f,
+    so every plane -- alpha included -- comes out positive and in range.
+
+    The other depths rescale into ``[0, 1]`` from unsigned integers, where any
+    non-zero byte will do; ``range(1, 256)`` simply skips zero, so that an
+    all-zero alpha plane cannot hide the same transient by the same route.
+    """
+    unit = b"\x3f\x00\x00\x00" if depth == 32 else bytes(range(1, 256))
+    return (unit * (size // len(unit) + 1))[:size]
+
+
 def _forge(
     width: int,
     height: int,
@@ -303,15 +342,30 @@ def _forge(
     depth: int,
     color_mode: int,
     max_alloc_bytes: int | None = None,
+    compression: Compression = Compression.RAW,
+    icc: bool = False,
 ) -> PSDImage:
     """A structurally valid PSD with an arbitrary header/mode combination.
 
     `_build_psd()` above is RGB-only and empty-bodied. These tests need headers
     that no fixture provides -- an indexed document with more than one stored
     channel, an indexed document at a depth where the palette is not applied --
-    and need the image data to actually parse, so the estimate can be compared
-    against a real array.
+    and need the image data to actually parse, so the model can be compared
+    against a real array and a real allocation.
+
+    *compression* matters as much as the header does once the model is about a
+    peak. `Compression.RAW` hands `get_data()` back the same bytes object that
+    was read at open time, so a corpus measured only on raw bodies never
+    exercises the codec's own peak at all.
+
+    *icc* writes an ICC_PROFILE image resource. Only its presence is forged, not
+    a usable profile: `pil_io._image_data_peak_bytes()` asks
+    `Resource.ICC_PROFILE in psd.image_resources` and nothing more, and the one
+    combination that needs this -- a document that is neither RGB nor grayscale,
+    carrying both a profile and transparency -- exists in no shipped fixture.
     """
+    rows = height * channels
+    body = _payload(((width * depth + 7) // 8) * rows, depth)
     buf = io.BytesIO()
     buf.write(
         struct.pack(
@@ -320,24 +374,41 @@ def _forge(
     )
     buf.write(struct.pack(">I", 768))  # colour mode data: a 256x3 palette
     buf.write(bytes(768))
-    buf.write(struct.pack(">I", 0))  # image resources
+    if icc:
+        # One 8BIM block: signature, id 1039, empty pascal name, length, body.
+        resource = (
+            struct.pack(">4sH2xI", b"8BIM", Resource.ICC_PROFILE, 2) + b"\x00\x00"
+        )
+        buf.write(struct.pack(">I", len(resource)))
+        buf.write(resource)
+    else:
+        buf.write(struct.pack(">I", 0))  # image resources
     buf.write(struct.pack(">I", 0))  # layer and mask info
-    buf.write(struct.pack(">H", 0))  # image data: raw, uncompressed
-    buf.write(bytes(width * height * channels * max(1, depth // 8)))
+    buf.write(struct.pack(">H", compression))
+    buf.write(compress(body, compression, width, rows, depth, 1))
     buf.seek(0)
     return PSDImage.open(buf, max_alloc_bytes=max_alloc_bytes)
 
 
-def _assert_estimate_is_exact(open_doc: Any) -> int:
-    """A budget equal to the allocation admits; one byte less rejects.
+def _assert_budget_brackets_the_model(open_doc: Any) -> int:
+    """A budget equal to the model admits; one byte less rejects.
 
-    Returns the allocation, so a caller can additionally pin its width.
+    This says only that the budget is compared against
+    `_image_data_peak_bytes()` and against nothing else -- that the guard reads
+    the model the path built for it, and reads the right one when a branch
+    picks between two. It says nothing whatever about whether the model is
+    *true*; that is the subject of the `tracemalloc` sweep below, and of the
+    `nbytes` and `_image_data_planes()` assertions each caller makes alongside
+    this one. A test whose only assertion were this would be testing that
+    `check_pixel_size()` compares with `>`.
+
+    Returns the model, so a caller can additionally pin its width.
     """
-    allocated = open_doc().numpy().nbytes
-    open_doc(allocated).numpy()
+    model = _numpy_peak_bytes(open_doc())
+    open_doc(model).numpy()
     with pytest.raises(ValueError, match="configured budget"):
-        open_doc(allocated - 1).numpy()
-    return allocated
+        open_doc(model - 1).numpy()
+    return model
 
 
 def test_numpy_guard_estimate_covers_the_palette_expansion() -> None:
@@ -348,12 +419,18 @@ def test_numpy_guard_estimate_covers_the_palette_expansion() -> None:
     own count under-counted it threefold. Indexed is also the mode Photoshop
     writes for a flattened document, so this was the common shape rather than a
     corner.
+
+    The plane count is asserted on `_image_data_planes()` and on the array
+    itself, which is where the expansion lives; the peak model is built from
+    that count and is bracketed separately.
     """
-    allocated = _assert_estimate_is_exact(
+    psd = _colormode("4x4_8bit_index_color.psd")
+    assert psd.channels == 1  # the header says one...
+    assert _image_data_planes(psd) == 3  # ...the array is three planes wide
+    assert psd.numpy().nbytes == 4 * 4 * 3 * 4
+    _assert_budget_brackets_the_model(
         lambda budget=None: _colormode("4x4_8bit_index_color.psd", budget)
     )
-    assert _colormode("4x4_8bit_index_color.psd").channels == 1  # header says 1...
-    assert allocated == 4 * 4 * 3 * 4  # ...the array is 3 planes wide
 
 
 @pytest.mark.parametrize("channels", [1, 2, 4, 8])
@@ -367,10 +444,12 @@ def test_numpy_guard_estimate_scales_the_palette_expansion(channels: int) -> Non
     count and 3, instead of their product, left the estimate a flat third of the
     array for any header declaring three channels or more.
     """
-    allocated = _assert_estimate_is_exact(
+    psd = _forge(4, 4, channels, 8, ColorMode.INDEXED)
+    assert _image_data_planes(psd) == 3 * channels
+    assert psd.numpy().nbytes == 4 * 4 * (3 * channels) * 4
+    _assert_budget_brackets_the_model(
         lambda budget=None: _forge(4, 4, channels, 8, ColorMode.INDEXED, budget)
     )
-    assert allocated == 4 * 4 * (3 * channels) * 4
 
 
 @pytest.mark.parametrize("depth", [16, 32])
@@ -383,10 +462,12 @@ def test_numpy_guard_estimate_does_not_expand_indexed_at_other_depths(
     and it keeps its stored width. Tripling it would reject a file three times
     smaller than the estimate claimed, which is the false-positive direction.
     """
-    allocated = _assert_estimate_is_exact(
+    psd = _forge(4, 4, 1, depth, ColorMode.INDEXED)
+    assert _image_data_planes(psd) == 1  # not tripled
+    assert psd.numpy().nbytes == 4 * 4 * 1 * 4
+    _assert_budget_brackets_the_model(
         lambda budget=None: _forge(4, 4, 1, depth, ColorMode.INDEXED, budget)
     )
-    assert allocated == 4 * 4 * 1 * 4  # not tripled
 
 
 @pytest.mark.parametrize(
@@ -403,45 +484,52 @@ def test_numpy_guard_estimate_does_not_expand_indexed_at_other_depths(
 def test_numpy_guard_estimate_follows_the_header_for_every_other_mode(
     color_mode: int, channels: int
 ) -> None:
-    """Outside the palette expansion, the stored count *is* the allocation.
+    """Outside the palette expansion, the stored count *is* the array's width.
 
     Including where the header disagrees with its colour mode. Such files parse
     fine and produce a narrow array -- a one-channel RGB document returns
     ``(h, w, 1)`` -- so resolving the width from the colour mode instead would
     reject them at up to four times their real size.
     """
-    allocated = _assert_estimate_is_exact(
+    psd = _forge(4, 4, channels, 8, color_mode)
+    assert _image_data_planes(psd) == channels
+    assert psd.numpy().nbytes == 4 * 4 * channels * 4
+    _assert_budget_brackets_the_model(
         lambda budget=None: _forge(4, 4, channels, 8, color_mode, budget)
     )
-    assert allocated == 4 * 4 * channels * 4
 
 
 @pytest.mark.parametrize("channel", [None, "color", "shape", "alpha", "mask"])
 @pytest.mark.parametrize("filename", _COLORMODE_FIXTURES)
-def test_numpy_guard_estimate_never_exceeds_the_allocation(
+def test_numpy_guard_model_covers_every_fixture_and_channel(
     filename: str, channel: Optional[_Channel]
 ) -> None:
-    """No shipped fixture may be rejected at a budget it actually fits inside.
+    """No shipped fixture may be rejected at a budget its own model admits.
 
-    The same invariant as above swept over the real corpus, covering every
-    colour mode and all four depths -- bitmap included, since #737 gave the
-    estimate a depth term; see the depth-1 section below for what that has to
-    get right.
+    The corpus sweep: every colour mode and all four depths -- bitmap included,
+    since #737 gave the estimate a depth term; see the depth-1 section below for
+    what that has to get right.
 
-    Swept over ``channel`` as well, because the estimate has to match whichever
-    branch the argument selects -- see the synthesised paths below, which this
-    parametrisation is what catches.
+    Swept over ``channel`` as well, because the model has to describe whichever
+    branch the argument selects. ``numpy("mask")``, and ``numpy("shape")`` on a
+    document with no transparency, synthesise their answer without reading the
+    image data at all, and are modelled `flat`; the bracket is what catches the
+    guard being handed the other branch's number.
 
-    Note what "the allocation" means for a channel argument. ``numpy("color")``
-    and ``numpy("shape")`` return *views* into the full array -- on
-    ``4x4_8bit_rgba.psd``, ``numpy("color")`` hands back 192 bytes of a 256-byte
-    buffer -- so the returned array's ``nbytes`` is not what was allocated. The
-    guard has to bound the buffer, so that is what is compared against.
+    The independent half is `nbytes`: whatever else the model counts, it may not
+    come out below the buffer the call materialises. Note that this is a floor
+    and no longer an equality -- ``numpy("color")`` and ``numpy("shape")`` return
+    *views* into the full array, so the returned array's own ``nbytes`` is not
+    what was allocated, and the peak sits above the whole buffer besides.
     """
     psd = _colormode(filename)
     flat = channel == "mask" or (channel == "shape" and not has_transparency(psd))
-    allocated = 4 * 4 * 1 * 4 if flat else psd.numpy(None).nbytes
-    _colormode(filename, allocated).numpy(channel)
+    model = _numpy_peak_bytes(psd, flat)
+    buffered = 4 * 4 * 1 * 4 if flat else psd.numpy(None).nbytes
+    assert model >= buffered
+    _colormode(filename, model).numpy(channel)
+    with pytest.raises(ValueError, match="configured budget"):
+        _colormode(filename, model - 1).numpy(channel)
 
 
 @pytest.mark.parametrize("channel", ["mask", "shape"])
@@ -458,14 +546,168 @@ def test_numpy_guard_estimate_matches_the_synthesised_paths(
     that fits several times over -- a quarter of the header's implication on
     CMYK, a third on indexed once the palette expansion is counted.
 
-    Raised by review on this PR. The over-estimate predates it for every
+    Raised by review on #732. The over-estimate predates it for every
     multi-channel mode; sizing indexed by its expanded width would have added a
     third case rather than introducing the problem.
     """
     one_plane = 4 * 4 * 1 * 4
     assert _colormode(filename).numpy(channel).nbytes == one_plane
     assert _image_data_planes(_colormode(filename)) > 1  # the stored width differs
+    assert _numpy_peak_bytes(_colormode(filename), True) == one_plane
     _colormode(filename, one_plane).numpy(channel)
+
+
+@pytest.mark.parametrize("filename", _COLORMODE_FIXTURES)
+def test_the_flat_numpy_paths_are_charged_four_bytes_a_pixel(filename: str) -> None:
+    """And charged for nothing else: they never read the image data.
+
+    ``np.ones((h, w, 1))`` is the whole of what the flat branch allocates. There
+    is no compressed body to inflate, no float32 pair held while a rescale runs
+    and no background to remove, so the model carries no term for any of them --
+    which is the difference between a peak model and a blanket multiplier over
+    the returned size. Swept over the whole corpus because the document's own
+    shape is exactly what this branch is entitled to ignore: a five-channel
+    16-bit CMYK document and a 1-bit bitmap have to be quoted the same number.
+    """
+    psd = _colormode(filename)
+    flat = psd.width * psd.height * 4
+    assert _numpy_peak_bytes(psd, True) == flat
+    # Strictly below the same document's full read, which does carry those
+    # terms -- so the equality above is not a coincidence of size.
+    assert _numpy_peak_bytes(psd, True) < _numpy_peak_bytes(psd, False)
+    # And the guard admits the flat paths at exactly that, rejecting a byte less.
+    _colormode(filename, flat).numpy("mask")
+    with pytest.raises(ValueError, match="configured budget"):
+        _colormode(filename, flat - 1).numpy("mask")
+
+
+# ---------------------------------------------------------------------------
+# The numpy model against a measured peak
+# ---------------------------------------------------------------------------
+#
+# The section above pins what the guard compares against. This one pins that the
+# thing being compared is true, which is the assertion that keeps the model
+# honest as `get_image_data()` moves underneath it. numpy registers its own
+# domain with `tracemalloc`, so every array the path builds is visible here.
+# (PIL's are not -- they are C-side -- which is why the PIL model is asserted
+# structurally further down.)
+
+# `tracemalloc` charges its own bookkeeping to the peak it reports: measured at
+# 5,737 bytes on a 300 px document, 5,737 on a 600 px one and 5,786 on a 1200 px
+# one -- flat across a sixteenfold range in pixel count, so it is an artefact of
+# the instrument rather than an allocation the model should carry. Hence an
+# absolute tolerance rather than a proportional one.
+#
+# It has to stay well *below* the smallest term the sweep is meant to detect, or
+# it silently absorbs one. The narrowest is the ZIP entry in `_DECOMPRESS_PEAK`,
+# worth 0.27 bytes a pixel at depth 32 -- about 40 KB at `_PEAK_SIZE` -- so this
+# is sized against that rather than only against the noise it corrects. At 64 KB
+# and a 256 px canvas, dropping that entry from 3 to 1 left every assertion here
+# passing.
+_TRACE_SLACK = 16 * 1024
+
+# How far above the measured peak the model is allowed to sit. The largest
+# structural over-count is 2.0x, on a depth-32 RAW document: the model charges
+# for the source buffer even where `get_data()` hands back the bytes read at
+# open time (a documented exclusion -- a body longer than the declared length
+# *is* copied, and this guard exists for malformed files), and depth 32 is the
+# one branch with no parse transient to dwarf it. 3 leaves half again on top of
+# that for platform variation in the codecs, while still failing loudly at the
+# shape of mistake worth catching: a term counted twice, or the three phases
+# summed instead of maxed, would land at 3-4x or beyond.
+_MODEL_OVERSHOOT = 3
+
+# 384 px a side. Two constraints meet here. The thinnest model in the sweep is a
+# one-channel bitmap at ~6 bytes a pixel, ~900 KB at this size and so far above
+# `_TRACE_SLACK` that the tolerance is a correction rather than the assertion.
+# And the narrowest per-pixel term, ZIP at depth 32, has to clear that tolerance:
+# 0.27 bytes a pixel is ~40 KB here, comfortably over it, where a 256 px canvas
+# left it under.
+_PEAK_SIZE = 384
+
+# Colour mode, stored channels and depth, chosen to reach every branch of the
+# model rather than to enumerate the format: the palette expansion (indexed at
+# depth 8, at one channel and at three), the background removal (RGB with a
+# fourth plane, whose transient is the largest single term), the depth-1 row
+# padding, the depth-32 branch that needs no rescale and so has no parse
+# transient, and the modes that pass straight through at their stored width.
+_PEAK_DOCUMENTS = [
+    (ColorMode.BITMAP, 1, 1),
+    (ColorMode.GRAYSCALE, 2, 1),
+    (ColorMode.RGB, 4, 1),
+    (ColorMode.GRAYSCALE, 1, 8),
+    (ColorMode.INDEXED, 1, 8),
+    (ColorMode.INDEXED, 3, 8),
+    (ColorMode.RGB, 3, 8),
+    (ColorMode.RGB, 4, 8),
+    (ColorMode.CMYK, 5, 8),
+    (ColorMode.LAB, 3, 8),
+    (ColorMode.MULTICHANNEL, 2, 8),
+    (ColorMode.RGB, 4, 16),
+    (ColorMode.CMYK, 4, 16),
+    (ColorMode.GRAYSCALE, 1, 32),
+    (ColorMode.RGB, 3, 32),
+    (ColorMode.RGB, 4, 32),
+]
+
+
+def _traced_peak(call: Callable[[], Any]) -> int:
+    """Bytes *call* allocates at its high-water mark, per ``tracemalloc``.
+
+    The document is opened *outside* the traced region deliberately. The model
+    counts the compressed body among the bytes the call holds live, but for
+    ``Compression.RAW`` ``get_data()`` usually hands back the very object read at
+    open time and allocates nothing -- tracing the open too would credit the
+    call with that allocation and hide the over-count instead of exposing it.
+    """
+    gc.collect()
+    tracemalloc.start()
+    try:
+        gc.collect()
+        tracemalloc.reset_peak()
+        before, _ = tracemalloc.get_traced_memory()
+        result = call()
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    del result
+    return peak - before
+
+
+@pytest.mark.parametrize("compression", list(Compression))
+@pytest.mark.parametrize("color_mode, channels, depth", _PEAK_DOCUMENTS)
+def test_numpy_peak_model_brackets_the_measured_peak(
+    color_mode: int, channels: int, depth: int, compression: Compression
+) -> None:
+    """The model is above what `numpy()` really allocates, and not far above.
+
+    Swept over the compression methods as well as the header, because three of
+    the four decompress into a buffer they build -- RLE joins materialised rows,
+    prediction adds an ``array.array`` pass and a byte-order pass on top of the
+    inflate -- and only RAW does not. A model fitted on raw bodies alone would
+    have no codec term at all and would still look exact.
+
+    Both directions are asserted for the reason the guard has two failure modes:
+    a model below the peak is a guard that does not guard, and a model far above
+    it is a guard that refuses files it should have passed.
+    """
+    if depth == 1 and compression == Compression.ZIP_WITH_PREDICTION:
+        # `compress()` refuses the combination outright ("Invalid pixel size 1"),
+        # and so it can never reach the reader.
+        pytest.skip("prediction is not defined at depth 1")
+    psd = _forge(
+        _PEAK_SIZE, _PEAK_SIZE, channels, depth, color_mode, compression=compression
+    )
+    model = _numpy_peak_bytes(psd)
+    # Without this the tolerance below could be doing all the work.
+    assert model > 4 * _TRACE_SLACK
+    peak = _traced_peak(psd.numpy)
+    assert peak <= model + _TRACE_SLACK, (
+        f"peak {peak:,} allocated past a model of {model:,}"
+    )
+    assert model <= _MODEL_OVERSHOOT * peak, (
+        f"model {model:,} is more than {_MODEL_OVERSHOOT}x the {peak:,} measured"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -481,10 +723,16 @@ def test_numpy_guard_estimate_matches_the_synthesised_paths(
 # #768 removed both halves of the mismatch. `length` counts packed rows, so an
 # oversized body is truncated (RAW) or refused (ZIP) rather than returned; and
 # `_parse_array()` trims each row's padding bits, so the array is one value per
-# pixel. The estimate is `width * height * channels * 4` again, and what these
-# pin is that it is exact rather than merely safe -- at the widths that are not
-# a multiple of eight above all, which is where the two arithmetics used to
-# part company.
+# pixel.
+#
+# That is still the subject here, and it is a claim about the array rather than
+# about the budget: the width the header declares is the width that is
+# allocated, at the widths that are not a multiple of eight above all, which is
+# where the two arithmetics used to part company. The peak the guard is now
+# given sits above that array -- about six bytes a pixel rather than four, the
+# packed buffer and `_parse_array()`'s two uint8 temporaries riding along with
+# it -- so the array is asserted on `nbytes` and the budget is bracketed
+# against the model separately.
 
 
 def _forge_1bit(
@@ -543,21 +791,26 @@ _DEPTH_1_DOCUMENTS = [
     "compression", [Compression.RAW, Compression.RLE, Compression.ZIP]
 )
 @pytest.mark.parametrize("width, height, channels, color_mode", _DEPTH_1_DOCUMENTS)
-def test_numpy_guard_estimate_is_exact_at_depth_1(
+def test_the_depth_1_array_is_one_float32_per_pixel(
     width: int,
     height: int,
     channels: int,
     color_mode: int,
     compression: Compression,
 ) -> None:
-    """Every depth-1 combination, bracketed on a conforming body.
+    """Every depth-1 combination, on a conforming body.
 
-    Exact, not merely safe, and for ZIP too: #737 had to accept an eightfold
+    Exact, not merely bounded, and for ZIP too: #737 had to accept an eightfold
     over-estimate there, the inflated size being unknowable without inflating,
     but the ceiling it is bounded at is now the packed size and a conforming
-    body reaches it.
+    body reaches it. The budget bracket rides alongside because depth 1 is the
+    one depth whose source term is not a whole number of bytes per pixel, so it
+    is the one most easily got wrong in the model as well as in the array.
     """
-    _assert_estimate_is_exact(
+    psd = _forge_1bit(width, height, channels, color_mode, compression)
+    assert _image_data_planes(psd) == channels
+    assert psd.numpy().nbytes == width * height * channels * 4
+    _assert_budget_brackets_the_model(
         lambda budget=None: _forge_1bit(
             width, height, channels, color_mode, compression, "packed", budget
         )
@@ -576,13 +829,27 @@ def test_a_byte_per_pixel_1bit_body_no_longer_outgrows_its_header(
     estimate to meet it; #768 removes the eight extra planes instead. RAW
     truncates the body to the rows the header declares, and ZIP refuses a stream
     that inflates past them, so either way the array is the one plane the header
-    always said it was, and the old estimate admits it.
+    always said it was.
+
+    The number this used to be checked against, ``64 * 64 * 1 * 4``, is no
+    longer the one the guard holds -- the depth-1 peak is nearer six bytes a
+    pixel than four -- but the claim never was about that constant. It is about
+    which count the constant multiplies: a float32 per *pixel*, not per *bit*.
+    So the array is asserted at a pixel apiece, and the whole modelled peak --
+    packed buffer, result and every transient at once -- is asserted to stay
+    inside the bare eight-plane array the crafted body used to produce.
     """
-    budget = 64 * 64 * 1 * 4
-    psd = _forge_1bit(64, 64, 1, ColorMode.BITMAP, compression, "padded", budget)
+    per_pixel = 64 * 64 * 1 * 4
+    per_bit = 64 * 64 * 8 * 4
+    model = _numpy_peak_bytes(
+        _forge_1bit(64, 64, 1, ColorMode.BITMAP, compression, "padded")
+    )
+    assert model < per_bit
+    psd = _forge_1bit(64, 64, 1, ColorMode.BITMAP, compression, "padded", model)
+    assert _image_data_planes(psd) == 1
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", _compression.PSDDecompressionWarning)
-        assert psd.numpy().nbytes == budget
+        assert psd.numpy().nbytes == per_pixel
 
 
 def test_numpy_guard_estimate_covers_the_shipped_bitmap_fixture() -> None:
@@ -592,53 +859,58 @@ def test_numpy_guard_estimate_covers_the_shipped_bitmap_fixture() -> None:
     four bytes for four rows. Its four-pixel row fills a whole byte, so it used
     to unpack to twice its pixel count -- the 2.0x reading in #737 -- and came
     back ``(4, 4, 2)``, half of it padding. Trimming the padding makes the
-    header's own count exact.
+    header's own count the array's width.
     """
     psd = _colormode("4x4_1bit_bitmap.psd")
     assert psd._record.image_data.compression == Compression.RAW
     assert len(psd._record.image_data.data) == 4  # packed: one byte per row
     assert psd.channels == 1
-    allocated = _assert_estimate_is_exact(
+    assert _image_data_planes(psd) == 1
+    assert psd.numpy().nbytes == 4 * 4 * 1 * 4
+    _assert_budget_brackets_the_model(
         lambda budget=None: _colormode("4x4_1bit_bitmap.psd", budget)
     )
-    assert allocated == 4 * 4 * 1 * 4
 
 
 @pytest.mark.parametrize(
     "filename, width, height",
     [("20x5_1bit_bitmap.psd", 20, 5), ("100x20_1bit_bitmap_rle.psd", 100, 20)],
 )
-def test_numpy_guard_estimate_is_exact_for_a_padded_width(
+def test_the_depth_1_array_is_exact_for_a_padded_width(
     filename: str, width: int, height: int
 ) -> None:
-    """The same bracket on the two Photoshop documents whose width pads.
+    """The same claim on the two Photoshop documents whose width pads.
 
     Forged headers cover the combinations no file has; these two are the real
     thing, RAW and RLE, at a width that is not a multiple of eight. Before #768
     neither could be measured at all -- ``numpy()`` raised on the reshape.
     """
-    allocated = _assert_estimate_is_exact(
-        lambda budget=None: _colormode(filename, budget)
-    )
-    assert allocated == width * height * 1 * 4
+    assert _colormode(filename).numpy().nbytes == width * height * 1 * 4
+    _assert_budget_brackets_the_model(lambda budget=None: _colormode(filename, budget))
 
 
-def test_composite_guard_estimate_is_exact_for_the_bitmap_fixture() -> None:
+def test_composite_guard_model_brackets_the_bitmap_fixture() -> None:
     """The same bracket through ``composite()``, the shipped 1-bit path.
 
     A layerless document composites by reading its own image data, so the
-    depth-1 estimate is what bounds it -- with ``ignore_preview=True``, since
-    the default path returns the flattened preview through
+    depth-1 model is what bounds it -- with ``ignore_preview=True``, since the
+    default path returns the flattened preview through
     :func:`~psd_tools.api.pil_io.convert_image_data_to_pil` and is bounded by
-    the PIL estimate instead.
+    the PIL model instead.
+
+    ``composite()`` keeps the returned-size spelling of its own estimate, its
+    peak growing with the layer count rather than with the canvas, so the number
+    that binds here is the wider of the two: the model `numpy()` was given.
     """
     pytest.importorskip("aggdraw")
     pytest.importorskip("scipy")
     pytest.importorskip("skimage")
-    allocated = _colormode("4x4_1bit_bitmap.psd").numpy(None).nbytes
-    _colormode("4x4_1bit_bitmap.psd", allocated).composite(ignore_preview=True)
+    name = "4x4_1bit_bitmap.psd"
+    model = _numpy_peak_bytes(_colormode(name))
+    assert model > 4 * 4 * 1 * 4  # wider than composite()'s own estimate
+    _colormode(name, model).composite(ignore_preview=True)
     with pytest.raises(ValueError, match="configured budget"):
-        _colormode("4x4_1bit_bitmap.psd", allocated - 1).composite(ignore_preview=True)
+        _colormode(name, model - 1).composite(ignore_preview=True)
 
 
 def test_a_short_1bit_body_still_cannot_be_shaped() -> None:
@@ -694,7 +966,9 @@ def test_16bit_degraded_image_data_keeps_its_declared_width() -> None:
     way.
 
     The estimate is unchanged; what was wrong was the array. Bracketed here
-    rather than merely bounded, because the fill is now exactly ``length``.
+    rather than merely bounded, because the fill is now exactly ``length`` --
+    a degraded read allocates what a sound one would, so the model that was
+    quoted for the sound document has to hold for this one too.
     """
     corrupt = b"\x78\x9c" + b"\xff" * 20  # valid zlib header, garbage deflate
 
@@ -708,7 +982,378 @@ def test_16bit_degraded_image_data_keeps_its_declared_width() -> None:
         array = open_doc().numpy()
     assert array.shape == (4, 4, 3)  # three planes, as the header declares
     assert array.nbytes == 4 * 4 * 3 * 4
+    model = _numpy_peak_bytes(open_doc())
     with pytest.warns(_compression.PSDDecompressionWarning):
-        open_doc(array.nbytes).numpy()
+        open_doc(model).numpy()
     with pytest.raises(ValueError, match="configured budget"):
-        open_doc(array.nbytes - 1).numpy()
+        open_doc(model - 1).numpy()
+
+
+# ---------------------------------------------------------------------------
+# The PIL model, which cannot be measured (#767)
+# ---------------------------------------------------------------------------
+#
+# PIL's buffers are allocated C-side and `tracemalloc` never sees them, so the
+# sweep above has no counterpart here. What can be asserted instead is the
+# model's structure: that it stays above the image the call hands back, and that
+# every term gated on a branch really is gated -- because ungating them is the
+# way this model would silently become the over-estimate it replaced, and #767
+# is as much about that direction as about the other. The old
+# `width * height * channels * 4` was four bytes a pixel per stored channel, a
+# float32 plane; `_create_image()` yields "L", "P" or "1" and PIL stores a byte
+# per pixel in all three, so an 8-bit multi-band document was turned away well
+# below its real footprint.
+#
+# A whole-call RSS delta would see some of this, and it is deliberately not
+# written into the suite: RSS answers with the allocator's arena rather than the
+# program's request, it cannot see a phase that reuses what the phase before it
+# released, and it varies enough between platforms and Pillow builds that gating
+# CI on it would buy noise rather than coverage.
+
+
+@pytest.mark.parametrize("filename", _COLORMODE_FIXTURES)
+def test_pil_peak_model_stays_above_the_image_it_returns(filename: str) -> None:
+    """The floor no model of this path may go under.
+
+    Whatever the branches do in between, the image handed back is still live
+    when the call returns, and every mode this path yields -- "1", "L", "P",
+    "RGB", "CMYK", "LAB" -- stores one byte per pixel per band. So the returned
+    image's own footprint is a lower bound that owes nothing to the model's
+    arithmetic, which is what makes it worth asserting. Strictly above, not
+    merely at: the decompressed buffer is live alongside it in every case.
+    """
+    psd = _colormode(filename)
+    image = psd.topil()
+    assert image is not None
+    returned = image.width * image.height * len(image.getbands())
+    model = _pil_peak_bytes(psd, None, True)
+    assert model > returned
+    _colormode(filename, model).topil()
+    with pytest.raises(ValueError, match="configured budget"):
+        _colormode(filename, model - 1).topil()
+
+
+def test_pil_peak_model_does_not_charge_for_a_merge_that_never_happens() -> None:
+    """Indexed and multichannel documents keep ``channels[0]`` and assemble nothing.
+
+    Every other mode reaches ``Image.merge()``, which builds a second image as
+    wide as the mode's band count while the per-channel images are still held.
+    These two never do -- one puts a palette on the first channel, the other
+    takes it as-is -- so charging them for it would put the model back above the
+    ``width * height * channels * 4`` it replaced on exactly the 8-bit documents
+    that motivated replacing it.
+
+    Three otherwise identical forged headers isolate the term: same dimensions,
+    same stored channel count, same depth, same codec, ICC off. The whole
+    difference between them is the merge, and it comes to the three bands
+    ``Image.merge()`` would have produced, at PIL's byte per pixel each.
+    """
+    rgb = _forge(4, 4, 3, 8, ColorMode.RGB)
+    indexed = _forge(4, 4, 3, 8, ColorMode.INDEXED)
+    multichannel = _forge(4, 4, 3, 8, ColorMode.MULTICHANNEL)
+    merge = 4 * 4 * 3  # three bands, a byte a pixel
+    assert _pil_peak_bytes(indexed, None, False) + merge == _pil_peak_bytes(
+        rgb, None, False
+    )
+    assert _pil_peak_bytes(multichannel, None, False) == _pil_peak_bytes(
+        indexed, None, False
+    )
+
+
+def test_pil_peak_model_does_not_charge_a_single_channel_for_the_assembly() -> None:
+    """``topil(channel)`` builds one image and stops.
+
+    Nothing is merged, there is no alpha to put and ``_remove_white_background()``
+    cannot fire on one band, so the whole assembly phase is gated off. Asserted
+    against the same document read whole, which is the only comparison that
+    makes "does not pay for it" mean anything.
+    """
+    psd = _forge(4, 4, 3, 8, ColorMode.RGB)
+    assert _pil_peak_bytes(psd, 0, False) < _pil_peak_bytes(psd, None, False)
+
+
+def test_pil_peak_model_does_not_charge_for_a_background_it_never_removes() -> None:
+    """``_remove_white_background()`` only ever sees an RGBA image.
+
+    It is the single largest term in this model -- four split bands, three
+    ``ImageMath`` widenings to "I", three "L" results and a merge, some 35 bytes
+    a pixel -- and it fires only when the document declares transparency for its
+    merged preview. A document without it must not be quoted for the phase.
+
+    The two documents are the controlled pair the corpus happens to provide:
+    both RGB, both four stored channels, both 8-bit, differing in whether
+    ``has_transparency()`` holds. ``4x4_8bit_rgba.psd`` stores a fourth channel
+    but declares no merged transparency for it, so ``post_process()`` never
+    calls ``putalpha()``, the image it hands on is "RGB" rather than "RGBA", and
+    ``_remove_white_background()`` returns it untouched. ``fill-opacity.psd``
+    declares it and goes through the phase in full.
+    Compared per pixel because the two are not the same size, and with ICC off
+    so the profile term does not move underneath the comparison.
+    """
+    opaque = _colormode("4x4_8bit_rgba.psd")
+    transparent = PSDImage.open(full_name("transparency/fill-opacity.psd"))
+    assert not has_transparency(opaque) and has_transparency(transparent)
+    for psd in (opaque, transparent):
+        assert (psd.color_mode, psd.channels, psd.depth) == (ColorMode.RGB, 4, 8)
+
+    def per_pixel(psd: PSDImage) -> float:
+        return _pil_peak_bytes(psd, None, False) / (psd.width * psd.height)
+
+    assert per_pixel(transparent) >= _WHITE_BACKGROUND_TRANSIENT
+    assert per_pixel(opaque) < _WHITE_BACKGROUND_TRANSIENT
+
+
+@pytest.mark.parametrize("depth", [16, 32])
+def test_pil_peak_model_charges_the_deep_conversion_pair(depth: int) -> None:
+    """The transient #767 was opened about, pinned directly.
+
+    ``_create_image()`` reads a 16- or 32-bit channel into an "I"/"F" image at
+    four bytes a pixel and then allocates a second through ``.point()`` before
+    narrowing to "L". Both are alive at once, and at depth 8 neither exists --
+    the buffer becomes an "L" and nothing else. The old estimate charged
+    ``channels * 4`` whatever the depth and so could not tell the two cases
+    apart, which is the whole of the issue.
+
+    Held against the same header at depth 8. The excess over that is *not* the
+    term itself, and the assertion deliberately does not claim it is: the model
+    is a maximum over phases, and raising the depth can change which phase binds
+    -- at depth 8 this document is bounded by assembling the merged image, at 16
+    and 32 by the conversion. What the comparison does establish is that the
+    deeper document costs more than its wider source buffer alone accounts for,
+    which is exactly what fails if the pair stops being counted.
+    """
+    pixels = 4 * 4
+    shallow = _pil_peak_bytes(_forge(4, 4, 3, 8, ColorMode.RGB), None, False)
+    deep = _pil_peak_bytes(_forge(4, 4, 3, depth, ColorMode.RGB), None, False)
+    source_growth = pixels * 3 * (depth // 8 - 1)
+    assert deep > shallow + source_growth
+
+
+def test_pil_peak_model_charges_one_conversion_pair_however_many_channels() -> None:
+    """The pair is flat, not per-channel: the loop converts one at a time.
+
+    Three more stored channels buy three more source buffers and three more "L"
+    images -- and not a second "I" pair.
+
+    Multichannel at depth 16 is what makes the comparison controlled. Widening
+    an RGB header from three to six would cross ``has_transparency()`` and
+    switch on the white-background term, so the difference would measure that
+    instead; multichannel's expected count is 64, so both widths stay opaque and
+    the only thing that moves is the channel count. Depth 16 rather than 32
+    because at 32 a six-channel document is bounded by its codec phase, and this
+    is about the conversion phase.
+    """
+    pixels = 4 * 4
+    narrow = _pil_peak_bytes(_forge(4, 4, 3, 16, ColorMode.MULTICHANNEL), None, False)
+    wider = _pil_peak_bytes(_forge(4, 4, 6, 16, ColorMode.MULTICHANNEL), None, False)
+    assert not has_transparency(_forge(4, 4, 6, 16, ColorMode.MULTICHANNEL))
+    assert wider - narrow == pixels * 3 * (2 + 1)
+
+
+def test_pil_peak_model_charges_a_profile_that_widens_to_rgba() -> None:
+    """A profile can send a grayscale document through the background removal.
+
+    ``_apply_icc()`` writes RGB whatever it was given, so a document that is
+    neither RGB nor free of transparency still ends up "RGBA" once
+    ``post_process()`` puts the alpha back -- and then
+    ``_remove_white_background()`` runs in full. Gating that term on the
+    document's own colour mode reads naturally and is wrong: this fixture is
+    grayscale, and ``topil()`` really does return "RGBA" with the profile
+    applied and "LA" without.
+
+    So the model has to ask what the image will *become*, not what the header
+    says it is. Asserted through the public ``apply_icc`` switch, which is the
+    only thing separating the two answers, and per pixel against the term
+    itself rather than as a difference -- the two answers are bounded by
+    different phases, so subtracting them does not leave the term behind.
+    """
+    psd = PSDImage.open(full_name("blend-modes/gray-blend-modes.psd"))
+    assert psd.color_mode == ColorMode.GRAYSCALE and has_transparency(psd)
+    assert Resource.ICC_PROFILE in psd.image_resources
+    with_profile, without_profile = (
+        psd.topil(apply_icc=True),
+        psd.topil(apply_icc=False),
+    )
+    assert with_profile is not None and without_profile is not None
+    assert (with_profile.mode, without_profile.mode) == ("RGBA", "LA")
+
+    pixels = psd.width * psd.height
+    assert _pil_peak_bytes(psd, None, True) >= pixels * _WHITE_BACKGROUND_TRANSIENT
+    assert _pil_peak_bytes(psd, None, False) < pixels * _WHITE_BACKGROUND_TRANSIENT
+
+
+def test_pil_peak_model_charges_a_profile_on_a_mode_that_is_not_rgb() -> None:
+    """The ``icc`` half of the widening gate, which no fixture can reach.
+
+    ``gray-blend-modes.psd`` above proves the profile changes the *width* of
+    what is widened, but not that the profile is what lets the widening happen
+    at all: grayscale is already in ``("RGB", "L")``, so ``putalpha()`` would
+    fire for it either way. The clause exists for the modes that are not --
+    CMYK, LAB, indexed -- where nothing widens unless a profile has first
+    rewritten the image to RGB.
+
+    No shipped document is a non-RGB, non-grayscale mode carrying both a profile
+    and transparency, so the header is forged. Only the profile's *presence* is
+    forged with it: this asserts on the model, which asks whether the resource
+    is there and never decodes it.
+    """
+    psd = _forge(4, 4, 5, 8, ColorMode.CMYK, icc=True)
+    assert has_transparency(psd) and Resource.ICC_PROFILE in psd.image_resources
+    pixels = psd.width * psd.height
+
+    assert _pil_peak_bytes(psd, None, True) >= pixels * _WHITE_BACKGROUND_TRANSIENT
+    # Same document, profile ignored: "CMYK" never becomes "RGBA", so the phase
+    # does not run and must not be quoted for.
+    assert _pil_peak_bytes(psd, None, False) < pixels * _WHITE_BACKGROUND_TRANSIENT
+
+
+@pytest.mark.parametrize(
+    (
+        "color_mode",
+        "channels",
+        "depth",
+        "icc",
+        "channel",
+        "compression",
+        "expected",
+        "binding",
+    ),
+    [
+        # 48 source + 16 * (3 channels + 1 slack) retained, then 16 * (3 merged
+        # + 1 the background removal would be handed).
+        (ColorMode.RGB, 3, 8, False, None, Compression.RAW, 176, "the merged image"),
+        # 64 source + 16 * (4 + 1), then 16 * (4 merged + 4 for the inversion
+        # `post_process()` holds alongside it).
+        (ColorMode.CMYK, 4, 8, False, None, Compression.RAW, 272, "the CMYK inversion"),
+        # Same RGB document with a profile and still no alpha: `_apply_icc()`
+        # holds its input beside the RGB it writes, and nothing widens after.
+        (ColorMode.RGB, 3, 8, True, None, Compression.RAW, 256, "the ICC output"),
+        # Grayscale with alpha: `putalpha()` holds "L" and "LA" together. No
+        # background phase -- one band never becomes RGBA without a profile.
+        (
+            ColorMode.GRAYSCALE,
+            2,
+            8,
+            False,
+            None,
+            Compression.RAW,
+            144,
+            "putalpha widening L to LA",
+        ),
+        # Eight 32-bit channels: 512 bytes of source, and twice that while the
+        # codec runs, is wider than anything the assembly does.
+        (
+            ColorMode.MULTICHANNEL,
+            8,
+            32,
+            False,
+            None,
+            Compression.RAW,
+            1024,
+            "the codec, raw",
+        ),
+        # The same document under each codec that builds its result rather than
+        # handing back the bytes read at open: RLE joins materialised rows, and
+        # prediction adds an `array.array` pass and a byte-order pass on top of
+        # the inflate. Only here, where the codec phase is the widest, do these
+        # multiples show up in a total at all.
+        (
+            ColorMode.MULTICHANNEL,
+            8,
+            32,
+            False,
+            None,
+            Compression.RLE,
+            1536,
+            "the codec, RLE",
+        ),
+        (
+            ColorMode.MULTICHANNEL,
+            8,
+            32,
+            False,
+            None,
+            Compression.ZIP,
+            1536,
+            "the codec, ZIP",
+        ),
+        (
+            ColorMode.MULTICHANNEL,
+            8,
+            32,
+            False,
+            None,
+            Compression.ZIP_WITH_PREDICTION,
+            2048,
+            "the codec, ZIP with prediction",
+        ),
+        # A single channel asked for by index: one conversion pair and one "L",
+        # and none of the assembly. At depth 16 so the pair is what binds.
+        (
+            ColorMode.RGB,
+            3,
+            16,
+            False,
+            0,
+            Compression.RAW,
+            240,
+            "one conversion pair",
+        ),
+    ],
+)
+def test_pil_peak_model_adds_up_to_a_fixed_number(
+    color_mode: int,
+    channels: int,
+    depth: int,
+    icc: bool,
+    channel: int | None,
+    compression: Compression,
+    expected: int,
+    binding: str,
+) -> None:
+    """Whole models against literals, so no constant can quietly vanish.
+
+    The gating tests each hold two models against each other, which pins the
+    differences between them and not the constants they share -- and a test that
+    rebuilt the expected figure from the module's own constants would move
+    whenever they did, which is no test at all. These are written out as plain
+    integers for that reason: changing any term changes a number here, and the
+    change has to be deliberate.
+
+    The rows are not a sample of the format. Each is the narrowest document that
+    makes a different phase the binding one, because a term only shows up in the
+    total when its phase wins the maximum -- which is why they are spread across
+    depths, modes and the ``apply_icc`` switch rather than enumerating headers.
+    ``_ALLOCATOR_SLACK`` in particular has nowhere else to be asserted: it covers
+    what PIL's arena rounds each image up to, real enough to be why the RSS
+    figures sat above a byte count, but invisible to any instrument cheap enough
+    for CI.
+    """
+    psd = _forge(4, 4, channels, depth, color_mode, compression=compression, icc=icc)
+    assert psd._record.image_data.compression == compression
+    assert (Resource.ICC_PROFILE in psd.image_resources) is icc
+    assert _pil_peak_bytes(psd, channel, icc) == expected, (
+        f"the phase that binds here is {binding}"
+    )
+
+
+def test_check_pixel_size_still_defaults_to_the_returned_array() -> None:
+    """Without ``estimated_bytes`` the comparand is ``w * h * channels * 4``.
+
+    :func:`~psd_tools.composite.composite.composite` still calls it that way and
+    deliberately so: what follows *its* guard grows with the layer count, so no
+    expression in ``width * height * <constant>`` bounds it, and the canvas is
+    the only thing the number can honestly describe. The default therefore has
+    to keep working, and the error message has to say which of the two it is
+    reporting -- a reader handed "Peak allocation" cannot rederive it from the
+    dimensions, and one handed "Estimated allocation" should not have to try.
+    """
+    returned = 4 * 4 * 3 * 4
+    check_pixel_size(4, 4, 3, max_alloc_bytes=returned)
+    with pytest.raises(ValueError, match="Estimated allocation 192 bytes"):
+        check_pixel_size(4, 4, 3, max_alloc_bytes=returned - 1)
+    # A model replaces that product outright rather than being added to it: 192
+    # bytes would be over this budget several times over, and it is not consulted.
+    check_pixel_size(4, 4, 3, max_alloc_bytes=8, estimated_bytes=8)
+    with pytest.raises(ValueError, match="Peak allocation 1,000 bytes"):
+        check_pixel_size(4, 4, 3, max_alloc_bytes=999, estimated_bytes=1000)

--- a/tests/psd_tools/test_pixel_size.py
+++ b/tests/psd_tools/test_pixel_size.py
@@ -611,10 +611,14 @@ _TRACE_SLACK = 16 * 1024
 # for the source buffer even where `get_data()` hands back the bytes read at
 # open time (a documented exclusion -- a body longer than the declared length
 # *is* copied, and this guard exists for malformed files), and depth 32 is the
-# one branch with no parse transient to dwarf it. 3 leaves half again on top of
-# that for platform variation in the codecs, while still failing loudly at the
-# shape of mistake worth catching: a term counted twice, or the three phases
-# summed instead of maxed, would land at 3-4x or beyond.
+# one branch with no parse transient to dwarf it.
+#
+# The rest of the headroom is for platform variation, which is real and was
+# found by this test rather than anticipated: `_remove_background()` costs 39
+# bytes a pixel on macOS and 48 on Linux and Windows, so
+# `_BACKGROUND_TRANSIENT` is sized on the latter and overshoots on the former.
+# 3 still fails loudly at the shape of mistake worth catching -- a term counted
+# twice, or the three phases summed instead of maxed, lands at 3-4x or beyond.
 _MODEL_OVERSHOOT = 3
 
 # 384 px a side. Two constraints meet here. The thinnest model in the sweep is a


### PR DESCRIPTION
Closes #767.

`check_pixel_size()` compared `max_alloc_bytes` against `width * height * channels * 4` — the float32 array a path *returns*. Neither image-data path stops there, so a budget the peak walked straight through was reported as respected.

#767 asked the design question rather than assuming the answer: *should the guard model peaks at all, and if so uniformly*, warning that a PIL-only fix leaves numpy's larger multiple in place and that a guessed factor in a guard is a false-positive generator. It also asked for a measurement first, since PIL's buffers are C-side and the 8-bytes-per-pixel figure in the issue was read off the source rather than measured.

## Measured first

| | worst peak / old estimate | where |
|---|---|---|
| `numpy()` | **3.7x** | RGB + alpha, depth 16 |
| `numpy()` | ~2x floor | every other mode, every depth |
| `topil()` | **3.2x** | RGB + alpha, depth 32 |
| `topil()` | **0.21x** | grayscale depth 8 — the estimate *over*-counts |

Three things the issue did not predict:

1. **numpy is the worse path, at every depth.** PIL's 16/32-bit gap is the smaller of the two, so a PIL-only fix would have been the wrong shape — as #767 suspected.
2. **The PIL estimate is also a 2–4x *over*-count at depths 1 and 8.** The `* 4` assumes a float32 plane; `_create_image()` yields `"L"`/`"P"`/`"1"` and PIL stores a byte per pixel in all three. The guard has been turning away sound documents at several times their real cost.
3. **The worst case on both paths is RGB-with-alpha, and on both it is the white-background removal** — not the depth conversion the issue is named for.

### Instruments

`tracemalloc` sees numpy's allocations (numpy registers its own domain) and does **not** see PIL's, which is what makes the numpy model an exact fit and the PIL model an analytic count.

RSS turned out to be a poor instrument and two separate ways of being wrong had to be removed before any number could be trusted:

- `ru_maxrss` is a process high-water mark, so once a file's bytes are resident, later allocations reuse freed space and the delta reads **0** — several 32-bit rows measured as zero while certainly allocating.
- Sampling *current* RSS from a thread fixes that but Pillow's C calls hold the GIL, starving the sampler right through a fast phase: `Image.merge` of three 8.6 MB bands measured **0.002 B/px** against a 34 MB jump in the process. Pillow's arena also caches freed blocks, so a later phase silently reuses what the phase before released.

So PIL is measured **one phase per process**, with the block cache off and the level on return folded in as a floor. That is what produced the terms below, rather than a whole-call figure that cannot see a phase reusing its predecessor's memory.

## The models

Both are phase maxima, not sums: decompress, parse/convert, post-process run one after another, so the widest bounds all three. Summing them would reject documents that never hold two phases at once.

**numpy** (`numpy_io._image_data_peak_bytes`) — an exact fit, to within `tracemalloc`'s own ~5 KB of bookkeeping, over every colour mode × depth × channel count × compression method (with one platform caveat, below):

| depth | held on top of the returned array, per plane | |
|---|---|---|
| 1 | `bits`, `1 - bits` (uint8) during `.astype` | 2 |
| 8 | the `.astype` result during `/ 255.0` (+1 for `lut[parsed]` when the palette applies) | 4 (5) |
| 16 | the same pair, rescaling by 65535 | 4 |
| 32 | nothing — 32-bit data needs no rescale | 0 |

plus 52 B/px flat for `_remove_background` (see the platform note below), and the codec's own peak as a multiple of the decompressed size (RAW 1x, RLE 3x, ZIP 3x, prediction 4x — measured 1.0/2.0/2.1/3.1).

**PIL** (`pil_io._image_data_peak_bytes`) — every term gated on the branch that allocates it, including one that is not obvious from the colour mode: `_apply_icc()` rewrites the image to RGB, so a grayscale or CMYK document that has *both* a profile and an alpha channel comes out RGBA and does go through `_remove_white_background()`. `gray-blend-modes.psd` in the corpus is exactly that — `topil()` returns `RGBA` with a profile applied and `LA` without — so gating on the document's own colour mode would have under-counted a shipped fixture by 4.7x.

Otherwise: indexed and multichannel documents take `channels[0]` and never merge; `post_process()` is a no-op without CMYK, a profile or alpha; the white background is removed only from an RGBA result. **Ungated, those terms would have made this tighter than the estimate it replaces on exactly the 8-bit documents it exists to stop over-counting** — the fix would have been self-defeating.

### Two documented exclusions, in both models

- **Per-object allocator overhead.** Both this and `tracemalloc` count *requested* bytes. On the PIL side one measured byte per pixel (observed ≤0.23) is carried as a named term because RSS is the only instrument available there and it does include the rounding.
- **The RAW source buffer is counted even though `get_data()` usually hands back the very bytes object read at open.** Only *usually*: a body longer than the declared length is sliced, and this guard exists for files that are not well formed. The cost is a 2x over-estimate on a 32-bit RAW document.

## What changes for users

Off by default. For anyone who sets `max_alloc_bytes` or `$PSD_TOOLS_MAX_ALLOC_BYTES`, over the 295-document corpus:

| | min | median | max |
|---|---|---|---|
| `numpy()` | 1.53x | 2.25x | 7.00x |
| `topil()` | **0.82x** | 1.33x | 5.25x |

`topil()` moves in both directions — genuinely looser where the old `* 4` charged a float32 plane for a one-byte-per-pixel image.

`composite()`'s own guard keeps the returned-size estimate: what follows it grows with the layer count, so no estimate of that shape bounds it. It is not insulated, though, and both the docstring and the changelog say so — `composite()` returns the preview through `topil()` when a document has one, and a layerless document falls through to `numpy()`.

## Keeping the model true

The concern #767 raised about factors going stale as the code moves is answered by the `tracemalloc` sweep: numpy's model is asserted against a *measured* peak across the mode × depth × channel × codec matrix, so editing `_parse_array()` or `_remove_background()` without updating the model fails the suite. Two measurement traps are baked into the tests as fixtures rather than left to chance: payloads are built so every alpha is positive (bytes that reinterpret as mostly-negative float32 hide `_remove_background` entirely — which is how the 32-bit gap survived), and all four compression methods are swept (RAW's identity slice hides the buffer term completely).

The measurement-based assertions carry a small absolute tolerance, and it is measured rather than guessed: `tracemalloc`'s own bookkeeping adds **5737 B at 300², 5737 B at 600², 5786 B at 1200²** — flat across a 16x range in pixel count, so it is overhead and not a term the model is missing.

PIL cannot be traced, so its terms are pinned structurally instead: gating tests for the branches that allocate, and whole-model golden values for the constants those comparisons share. The golden rows are chosen so each makes a *different* phase the binding one — a term only reaches the total when its phase wins the maximum, which is why a single document pins almost nothing. No RSS assertion is in the suite; it is too platform-dependent to gate CI on.

**Verified by mutation.** Each of the 27 terms across the two models was changed in turn and the suite re-run. All 27 now fail at least one test. Three did not at first, and fixing them was the point of doing it:

- the **ZIP codec multiple** — the `tracemalloc` tolerance (64 KB over a 256 px canvas) was wide enough to absorb a 0.27 B/px term, so the tolerance was doing the work rather than the assertion. Slack is now 16 KB against 5.7 KB of measured bookkeeping, and the sweep canvas 384 px.
- **PIL's conversion pair** — the transient this issue is *named for* had no test.
- **PIL's ICC widening gate** — the `gray-blend-modes.psd` test does not reach it, because grayscale is already in `("RGB", "L")` and would widen either way. The clause exists for CMYK and LAB, which no shipped document pairs with both a profile and transparency, so that header is forged.

### One term is platform-dependent, and CI is what found it

The first CI run failed 10 cases on Windows (every Python) and on Linux 3.14 — all of them RGB-with-alpha, the only shape that reaches `_remove_background()`. The gap was **proportional to the pixel count, not constant**, so it was an allocation rather than the tolerance.

`_remove_background()` costs **39 B/px on macOS/CPython 3.10 and 48 on Linux and Windows** — identical at every Python from 3.10 to 3.14, with and without the composite extra. It holds four float32 arrays of the three colour planes there where it holds three here. The term is now sized on 48: a guard that holds only where its author ran it is not a guard, and the cost of the other direction is an over-estimate of one term on one platform.

Every other term measures the same everywhere, so the model is an exact fit on one platform and an upper bound on the rest — and the docstring now says that rather than claiming exactness outright. This is also the answer to "would the tests catch it": they did, on the first run, on hardware I do not have.

## Also in this PR

Prose that this change falsifies, corrected in place rather than appended to:

- `PSDImage.open(max_alloc_bytes=...)` — the only autodoc'd description of the guard — said the estimate "comes from the declared geometry". It now depends on colour mode, depth and compression.
- Two passages in the **unreleased** 1.19.0 changelog block asserted the retired contract ("the estimate is `width * height * channels * 4` again"; "the estimate bounds the array that is returned … unchanged by it"). Left alone, 1.19.0 would have shipped a changelog contradicting itself.
- `_image_data_planes()`'s docstring, which explicitly said peaks were *not* modelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
