### PR TITLE
fix: convert a single-channel source, don't broadcast it (#749)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 -------------------
 
 - [fix] Convert a single-channel *source* to the document's colour mode instead
-  of letting the blend arithmetic replicate it across every channel (#749), as
+  of letting the blend arithmetic replicate it across every channel (#749, #776), as
   #722 already did for a backdrop. A grayscale pattern fill on a CMYK document
   rendered a different colour from the same pattern applied as an overlay
   effect. Affects only a one-channel source in a CMYK or Lab document, which

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Convert a single-channel *source* to the document's colour mode instead
+  of letting the blend arithmetic replicate it across every channel (#749), as
+  #722 already did for a backdrop. A grayscale pattern fill on a CMYK document
+  rendered a different colour from the same pattern applied as an overlay
+  effect. Affects only a one-channel source in a CMYK or Lab document, which
+  Photoshop does not write -- it converts a pattern to the document's colour
+  mode on embed -- so no file in the test corpus renders differently.
+
 - [security] Size the ``max_alloc_bytes`` guard against what ``numpy()`` and
   ``topil()`` peak at rather than the array they return; both hold several
   intermediates, measured at up to 3.7x the old estimate (#767). Affects you only

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -54,8 +54,9 @@ def _styled(effects: Iterator[Any]) -> Iterator[_StyledEffect]:
     return cast(Iterator[_StyledEffect], effects)
 
 
-# How a one-channel canvas becomes a given width. Spelled once because it is
-# threaded through most of this module -- see ``widen.make_widen()``.
+# How a one-channel array -- a canvas or a source -- becomes a given width.
+# Spelled once because it is threaded through most of this module -- see
+# ``widen.make_widen()``.
 _Widen = Callable[[np.ndarray, int], np.ndarray]
 
 # What each overlay effect draws. Only the pattern needs the compositor's
@@ -429,7 +430,7 @@ def composite(
     # are resolved here, once, rather than at each point of use. An isolated
     # group starts transparent, so the caller's alpha is dropped before the
     # canvas is built rather than after.
-    # Resolved here and carried through the compositor tree because three of
+    # Resolved here and carried through the compositor tree because four of
     # the sites that need it are inside Compositor, which holds no document.
     # (The cost is not the reason -- make_widen() only reads two attributes,
     # and the expensive transform is built lazily and cached globally.)
@@ -564,13 +565,14 @@ def _uniform_alpha(alpha: float | np.ndarray) -> float | None:
 
 
 def _widen(color: np.ndarray, channels: int) -> np.ndarray:
-    """Replicate a single-channel canvas across ``channels``.
+    """Replicate a single-channel array across ``channels``.
 
-    A grayscale source inside an RGB document arrives one channel wide.
-    Broadcasting would handle it in the blend arithmetic, but the compositor's
-    own canvases have to be a fixed width for their whole lifetime, so a
-    backdrop is widened once at the point it is handed over rather than
-    repeatedly patched mid-composite.
+    A grayscale source inside an RGB document arrives one channel wide. The
+    compositor's own canvases have to be a fixed width for their whole
+    lifetime, so a backdrop is widened once at the point it is handed over
+    rather than repeatedly patched mid-composite; a source is widened at the
+    same point for a different reason, that what a grey means is the
+    document's answer and not the blend arithmetic's (#749).
 
     Replication is right for RGB and wrong for CMYK and Lab, so this is only
     the fallback used when no document is available to ask -- everything that
@@ -741,8 +743,9 @@ class Compositor(object):
 
     ``color``'s channel count becomes ``self.channels`` and is fixed for this
     compositor's lifetime, so a caller handing over a canvas narrower than the
-    document must widen it first. A narrow *source* is fine -- the blend
-    arithmetic broadcasts it -- and must not change the width.
+    document must widen it first. A narrow *source* is fine and must not change
+    the width: ``_fit_source()`` widens it at the door, so the blend arithmetic
+    only ever sees arrays of this compositor's own width.
 
     ``widen`` is how that is done, here and in every sub-compositor this one
     builds. Pass the document's own, from
@@ -778,9 +781,9 @@ class Compositor(object):
         self._viewport = viewport
         self._layer_filter = layer_filter
         self._force = force
-        # How a one-channel canvas becomes this compositor's width. Carried
-        # rather than derived because the three sites that need it below are
-        # inside this class, which holds no document handle (#722).
+        # How a one-channel array becomes this compositor's width. Carried
+        # rather than derived because the four sites that need it below are
+        # inside this class, which holds no document handle (#722, #749).
         self._widen = widen
         self._adjustment_isolated = adjustment_isolated
         # What Knockout.DEEP knocks out to. Inherited by pass-through
@@ -938,7 +941,7 @@ class Compositor(object):
         alpha: np.ndarray,
         mask: float | np.ndarray,
     ) -> None:
-        self._assert_source_fits(color)
+        color = self._fit_source(color)
         # ``color`` is the group already composited over this backdrop, because a
         # pass-through group is rendered by a non-isolated sub-compositor seeded
         # with the backdrop. Re-applying the group therefore means interpolating
@@ -965,14 +968,35 @@ class Compositor(object):
         # back to the group's own color rather than to white.
         self._color = utils.clip(utils.divide(color_t, self._alpha, fill=color))
 
+    def _fit_source(self, color: np.ndarray) -> np.ndarray:
+        """Bring a source to this compositor's width, checking the invariant.
+
+        Both doors a source colour comes through call this, so that what a
+        grey means in this document is answered in one place. A single-channel
+        source is legal to hand over -- a pattern carries its own colour mode, and
+        a fill on a multichannel document resolves to one component because
+        there is nothing to convert it into -- but which colour that one channel
+        *is* depends on the document, and only ``widen`` knows (#749).
+
+        Left to the blend arithmetic it was broadcast instead, which is
+        replication under another name: correct for RGB and, on a CMYK
+        document, an over-inked build that is not the grey it came from. The
+        same grey already converted when it arrived as a backdrop, as a clip
+        base or as a pattern overlay, so it depended on incidental layer
+        structure which of the two answers a document got.
+        """
+        self._assert_source_fits(color)
+        return self._widen(color, self._channels)
+
     def _assert_source_fits(self, color: np.ndarray) -> None:
         """Check the fixed-width invariant where a source meets the canvases.
 
-        The blend arithmetic broadcasts a single-channel source, but a *wider*
-        one would silently widen ``_color`` and leave ``channels`` stale. That
-        is what the deleted ``np.repeat`` fixups used to paper over, so this is
-        the assertion that keeps them deleted: it fires if a caller ever builds
-        a compositor narrower than the sources it will be given.
+        A single-channel source is widened by ``_fit_source()`` above, but a
+        *wider* one would silently widen ``_color`` and leave ``channels``
+        stale. That is what the deleted ``np.repeat`` fixups used to paper
+        over, so this is the assertion that keeps them deleted: it fires if a
+        caller ever builds a compositor narrower than the sources it will be
+        given.
         """
         assert self._color.shape[2] == self._channels, (
             "canvas widened to %d channels, expected %d"
@@ -1019,7 +1043,7 @@ class Compositor(object):
         blend_mode: BlendMode,
         knockout: Knockout = Knockout.NONE,
     ) -> None:
-        self._assert_source_fits(color)
+        color = self._fit_source(color)
         knockout_color, knockout_alpha = self._knockout_backdrop(knockout)
 
         self._shape_g = cast(np.ndarray, utils.union(self._shape_g, shape))

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -33,8 +33,8 @@ logger = logging.getLogger(__name__)
 # color mode data section and were never a channel count (#733). Multichannel
 # is here for a different reason: its channels are spot inks with no colorimetric relation to RGB, so
 # there is no conversion to N of them -- one channel is the honest answer, and
-# what a single channel means once widened to N is #722's question, not this
-# function's.
+# what a single channel means once widened to N is #722's question -- #749's
+# where the single channel is a source, as this one is -- not this function's.
 _SINGLE_CHANNEL_MODES = (
     ColorMode.BITMAP,
     ColorMode.GRAYSCALE,

--- a/src/psd_tools/composite/widen.py
+++ b/src/psd_tools/composite/widen.py
@@ -1,8 +1,10 @@
-"""Widening a single-channel canvas to a document's channel count.
+"""Widening a single-channel array to a document's channel count.
 
 The compositor's canvases keep a fixed width for their whole lifetime, so a
-backdrop or a pattern that arrives one channel wide has to be widened once at
-the point it is handed over. Replicating the value across every channel is
+backdrop that arrives one channel wide has to be widened once at the point it
+is handed over, and a source that arrives one channel wide is widened at the
+same point so that what a grey means is the document's answer rather than the
+blend arithmetic's (#749). Replicating the value across every channel is
 correct for RGB -- a grey ``g`` is ``(g, g, g)`` -- and wrong for everything
 else: ``(g, g, g, g)`` in CMYK is a heavily over-inked colour, and a lightness
 copied into Lab's a/b axes is not neutral (#722).
@@ -153,13 +155,20 @@ def _lab(color: np.ndarray) -> np.ndarray:
 
     Since #752 that makes this deliberately disagree with the *fill* path, which
     does convert: a grey fill descriptor now reaches a Lab canvas at its L*, so
-    grey 0.6 lands at 0.632 where a widened grey 0.6 canvas channel stays at
-    0.6. The asymmetry is intended. A descriptor carries a colour a person
-    picked in some space, and for every class but Lab that space is sRGB-ish, so
-    interpreting it is sound. An arbitrary single-channel canvas handed to a Lab
-    document carries no such claim -- it may be a mask, a spot plane or a
-    caller's scalar -- and interpreting it would invent a colour space it never
-    had.
+    grey 0.6 lands at 0.632 where a widened grey 0.6 array stays at 0.6. The
+    asymmetry is intended, and the line is drawn at the descriptor rather than
+    at the canvas. A descriptor carries a colour a person picked in some space,
+    and for every class but Lab that space is sRGB-ish, so interpreting it is
+    sound. An arbitrary single-channel array carries no such claim -- it may be
+    a mask, a spot plane, a caller's scalar or a grayscale pattern's device
+    grey -- and interpreting it would invent a colour space it never had.
+
+    Since #749 that array can be a *source* and not only a canvas, which is
+    where the split becomes visible inside one document: a grey pattern fill
+    arrives one channel wide and is widened here to L = g, while the same grey
+    written as a ``Gry `` descriptor never reaches this function at all --
+    ``paint._get_gray()`` converts it to its L* and hands over three
+    channels.
     """
     neutral = np.full_like(color, LAB_NEUTRAL_CHROMA)
     return np.concatenate((color, neutral, neutral), axis=2)
@@ -169,7 +178,7 @@ def make_widen(psd: "PSDProtocol | None") -> Callable[[np.ndarray, int], np.ndar
     """Build the widening function for *psd*, resolved once per composite.
 
     Returned as a closure rather than threaded as a document handle because
-    three of the call sites are inside ``Compositor``, which holds no ``psd``.
+    four of the call sites are inside ``Compositor``, which holds no ``psd``.
     It also makes the conversion testable without a document.
     """
     color_mode = None

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -483,8 +483,8 @@ def _layered_multichannel(**kwargs: Any) -> PSDImage:
     on purpose. ``frompil`` converts to the document's ``pil_mode``, which is
     ``"LA"`` for a three-channel multichannel document, so the layer would
     carry a single color channel against a header declaring three -- and a
-    one-channel source broadcasts, so the test would pass without ever
-    exercising the canvas width it is about.
+    one-channel source is widened to whatever the canvas is, so the test would
+    pass without ever exercising the canvas width it is about.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"), **kwargs)
     psd._record.header.color_mode = ColorMode.MULTICHANNEL

--- a/tests/psd_tools/composite/test_primitives.py
+++ b/tests/psd_tools/composite/test_primitives.py
@@ -376,10 +376,12 @@ def test_widen_replicates_a_single_channel() -> None:
 
 @pytest.mark.parametrize("channels", [1, 3])
 def test_a_narrow_source_leaves_the_canvas_width_alone(channels: int) -> None:
-    """The blend arithmetic broadcasts a single-channel source (#710).
+    """A single-channel source is widened to the canvas, never the reverse (#710).
 
-    Applying one is therefore not a reason to reallocate. Consistency check:
-    this held before the fixups were deleted too.
+    The canvas width is the compositor's for its whole lifetime, so applying a
+    narrow source is not a reason to reallocate it -- ``_fit_source()`` brings
+    the source up to it (#749) rather than the arithmetic dragging the canvas
+    down. Consistency check: this held before the fixups were deleted too.
     """
     backdrop = rgb(WHITE) if channels == 3 else gray(1.0)
     compositor = Compositor((0, 0, 2, 2), backdrop, gray(0.0))
@@ -448,7 +450,12 @@ def test_document_backdrop_is_widened_to_the_canvas() -> None:
 
 
 def test_narrow_source_matches_a_pre_widened_one() -> None:
-    """Broadcasting a narrow source is the same as replicating it first."""
+    """Widening a narrow source at the door is the same as widening it before.
+
+    It held under the broadcast this replaced too, for a different reason:
+    replication is what the mode-blind ``_widen`` does, and this compositor has
+    no document to ask for anything else (#749).
+    """
 
     def run(source: np.ndarray) -> np.ndarray:
         compositor = Compositor((0, 0, 2, 2), rgb(RED), gray(1.0))

--- a/tests/psd_tools/composite/test_widen.py
+++ b/tests/psd_tools/composite/test_widen.py
@@ -5,6 +5,10 @@ and wrong for CMYK, where a grey is a profile-dependent CMY build rather than
 ``(g, g, g, g)``, and wrong for Lab, where a lightness copied into a/b is not
 neutral.
 
+The last section covers *sources* rather than backdrops (#749): a source may
+arrive one channel wide, and being broadcast by the blend arithmetic was the
+same replication reached by a different door.
+
 ``cmyk-gray-ramp.psd`` is the ground truth these tests are pinned against. It
 was authored by scripting Photoshop 2026: a grayscale document filled with nine
 8-bit grey patches, converted to CMYK with ``changeMode()`` and saved with its
@@ -25,6 +29,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from psd_tools.api.layers import Layer
 from psd_tools.api.pil_io import post_process
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.composite import composite
@@ -36,7 +41,15 @@ from psd_tools.composite.composite import (
 )
 from psd_tools.composite import widen as widen_module
 from psd_tools.composite.widen import make_widen
-from psd_tools.constants import ColorMode, Resource
+from psd_tools.constants import BlendMode, ColorMode, Resource, Tag
+from psd_tools.psd.descriptor import Descriptor, String
+from psd_tools.psd.patterns import (
+    Pattern,
+    Patterns,
+    VirtualMemoryArray,
+    VirtualMemoryArrayList,
+)
+from psd_tools.terminology import Enum, Key
 
 from ..utils import full_name
 
@@ -325,3 +338,154 @@ def test_scalar_and_single_channel_backdrops_agree(filename: str, value: float) 
         psd, color=canvas, alpha=1.0, layer_filter=lambda layer: False
     )
     assert np.array_equal(scalar_color, canvas_color)
+
+
+# --- Sources, not only backdrops ---------------------------------------------
+#
+# A *source* is allowed to arrive one channel wide -- ``_assert_source_fits()``
+# says so -- and the blend arithmetic used to broadcast it, which is the
+# replication above reached by another door. So one grey got two answers on one
+# document depending on incidental layer structure: converted as a backdrop, as
+# a clip base, as the base colour under a stroke or as a pattern overlay,
+# replicated as a plain fill layer -- or as a stroke's own fill (#749).
+
+# The forged pattern's identifier, arbitrary but shared by the record and the
+# descriptor that names it -- ``_get_pattern()`` matches them exactly.
+FORGED_PATTERN_ID = "4c1b6c4e-7a2f-4d5b-9b3a-000000000749"
+
+
+def _gray_pattern(level: int, size: tuple[int, int] = (4, 4)) -> Pattern:
+    """A flat grayscale pattern, laid out the way Photoshop lays out its own.
+
+    26 channel slots, of which only the first is written: that is what all of
+    the grayscale patterns Photoshop 2026 ships carry, and what
+    ``get_pattern_color_channels()`` reads the colour/alpha boundary off.
+    """
+    height, width = size
+    plane = VirtualMemoryArray()
+    plane.set_data((width, height), bytes([level]) * (width * height), 8)
+    channels = [plane] + [VirtualMemoryArray() for _ in range(25)]
+    return Pattern(
+        image_mode=ColorMode.GRAYSCALE,
+        point=(height, width),
+        name="Forged Gray\x00",
+        pattern_id=FORGED_PATTERN_ID,
+        data=VirtualMemoryArrayList(rectangle=(0, 0, height, width), channels=channels),
+    )
+
+
+def _pattern_fill_desc() -> Descriptor:
+    """The descriptor a pattern fill layer and a pattern overlay both carry."""
+    pattern = Descriptor(classID=b"Ptrn")
+    pattern[Key.ID] = String(FORGED_PATTERN_ID + "\x00")
+    pattern[Key.Name] = String("Forged Gray\x00")
+    desc = Descriptor(classID=b"patternFill")
+    desc[Enum.Pattern] = pattern
+    return desc
+
+
+def _cmyk_gray_pattern_fill(level: int = 128) -> tuple[PSDImage, Layer]:
+    """A CMYK document whose only fill is a *grayscale* pattern.
+
+    Photoshop does not author this: it converts a pattern to the document's
+    colour mode when embedding it, so a pattern applied in a CMYK document is
+    stored ``image_mode=ColorMode.CMYK`` -- verified by scripting Photoshop
+    2026. The mismatch is reachable from files other tools write, and by
+    building the layer through psd-tools, so the pattern is forged into a
+    document that is otherwise Photoshop's own, embedded profile included.
+
+    The gradient block is removed so the fixture cannot rest on
+    ``create_fill()`` happening to check the pattern block first. The layer
+    object stays a ``GradientFill`` either way; nothing here reads its kind.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
+    assert psd.color_mode == ColorMode.CMYK
+    blocks = psd.tagged_blocks
+    assert blocks is not None
+    # Same ignore as ``Patterns.read()``'s own: ``ListElement`` carries an
+    # unbound item type, so every construction of one is untypeable here.
+    blocks.set_data(Tag.PATTERNS1, Patterns([_gray_pattern(level)]))  # type: ignore[list-item]
+    layer = psd[1]
+    del layer.tagged_blocks[Tag.GRADIENT_FILL_SETTING]
+    layer.tagged_blocks.set_data(Tag.PATTERN_FILL_SETTING, _pattern_fill_desc())
+    return psd, layer
+
+
+@pytest.mark.parametrize("render", ["layer", "document"])
+def test_gray_pattern_fill_reaches_the_conversion(render: str) -> None:
+    """The end-to-end path the issue reports, as the fill layer it names.
+
+    Rendered ``[0.502] * 4`` -- the grey in every plate, an over-inked build
+    that is not the grey it came from -- where the same grey as a backdrop, and
+    the same pattern as an *overlay effect* on the same document, had converted
+    since #722.
+    """
+    psd, layer = _cmyk_gray_pattern_fill(128)
+    target = (
+        composite(layer, force=True)
+        if render == "layer"
+        else composite(psd, force=True, layer_filter=lambda other: other is layer)
+    )
+    color = target[0]
+
+    assert color.shape == (psd.height, psd.width, 4)
+    assert np.allclose(color, make_widen(psd)(_grey(128 / 255.0), 4))
+    assert not np.allclose(color, 128 / 255.0, atol=2 / 255)
+
+
+def test_gray_pattern_agrees_between_the_fill_and_the_overlay() -> None:
+    """The first two rows of the issue's table, on one document.
+
+    A pattern fill layer and a pattern overlay effect carry the same
+    descriptor and name the same pattern, so the colour they paint cannot
+    depend on which of the two a person reached for. It did: the overlay
+    widened through ``make_widen`` and the fill was broadcast.
+
+    The overlay is driven through ``_draw_pattern_overlay`` directly rather
+    than through a forged effects block -- it takes the same descriptor the
+    fill layer stores, so what is compared is the two code paths and not two
+    spellings of the pattern. Comparing its raw return against a composited
+    fill is only sound because the fill is opaque over the whole viewport: it
+    is the pattern colour and nothing of the backdrop.
+    """
+    psd, layer = _cmyk_gray_pattern_fill(128)
+    fill = composite(layer, force=True)[0]
+
+    overlay, _ = _draw_pattern_overlay(layer, _pattern_fill_desc(), 4, make_widen(psd))
+
+    assert overlay is not None
+    assert overlay.shape[2] == 4
+    assert np.allclose(fill, overlay)
+
+
+def test_single_channel_source_and_backdrop_agree() -> None:
+    """The distinction the issue is named for, at the compositor itself.
+
+    One grey, handed to the same CMYK document twice: once as the backdrop it
+    composites against, once as a source composited onto it. A source is
+    allowed to arrive narrow and a backdrop is not, but that is a statement
+    about array widths -- it was never meant to be a statement about what
+    colour a grey is.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
+    widen = make_widen(psd)
+    height, width = psd.height, psd.width
+    grey = np.full((height, width, 1), 0.75, dtype=np.float32)
+    ones = np.ones((height, width, 1), dtype=np.float32)
+
+    compositor = Compositor(
+        psd.viewbox,
+        np.zeros((height, width, 4), dtype=np.float32),
+        np.zeros((height, width, 1), dtype=np.float32),
+        widen=widen,
+    )
+    compositor._apply_source(grey, ones, ones, BlendMode.NORMAL)
+    as_source = compositor.finish()[0]
+
+    as_backdrop, _, _ = composite(
+        psd, color=grey, alpha=1.0, layer_filter=lambda layer: False
+    )
+
+    assert np.allclose(as_source, as_backdrop)
+    assert np.allclose(as_source, widen(_grey(0.75), 4))
+    assert not np.allclose(as_source, 0.75, atol=2 / 255)


### PR DESCRIPTION
Fixes #749.

## The decision the issue left open

The issue asks whether a narrow source should be converted at `_apply_source`
or whether the broadcast should be removed altogether. This does both, at one
place: `_apply_source()` and `_apply_passthrough_source()` — the only two doors
an externally-supplied colour comes through — now call

```python
def _fit_source(self, color: np.ndarray) -> np.ndarray:
    self._assert_source_fits(color)
    return self._widen(color, self._channels)
```

so no single-channel source ever reaches the blend arithmetic, and the
affordance the assertion advertises (a source may be one channel wide) is kept.

Widening at the *door* rather than at each producer is the point. A producer
cannot answer the question: a pattern carries its own colour mode, and
`paint._get_color()` deliberately returns one component for a multichannel
document because there is nothing to convert into. It is also what makes the
fix complete without enumeration — the issue's table names the pattern fill
layer, but a stroke's own fill (`_get_stroke`) and a stroke effect's fill
(`draw_stroke_effect`'s white fallback) were broadcast on exactly the same
terms, and a per-producer fix would have had to find all three.

## Evidence

**Corpus-neutral, measured.** Instrumenting `_apply_source` over all 295 files
in `tests/psd_files`, both force modes: the (source width, canvas width) pairs
that actually occur are `(1,1)`, `(3,3)` and `(4,4)` — no source is ever
narrower than its canvas. Composited output is bitwise identical over those 590
renders before and after. `widen()` returns the same object when the width
already matches, so it is allocation-neutral there too.

**The harm, rendered.** Photoshop does not author the mismatch — it converts a
pattern to the document's colour mode when embedding it, verified by scripting
Photoshop 2026 — so the end-to-end test forges a grayscale `Pattern` record and
a `patternFill` descriptor into `colormodes/4x4_8bit_cmyk.psd`. The document and
its embedded Japan Color 2001 Coated profile stay Photoshop's own. Grey 128
rendered `[0.502] × 4` — every plate at 50%, an over-inked build that is not the
grey it came from — and now lands at `[0.431, 0.510, 0.541, 1.0]`, which is what
the same grey already got as a backdrop and as a pattern overlay.

All four new tests fail without the `composite.py` change; the fifth thing worth
pinning (a *wider* source is still rejected) was already covered by
`test_primitives.py::test_a_source_wider_than_the_canvas_is_rejected`.

## Prose the change made stale

- `widen._lab`'s docstring justified declining the L\* transfer by contrasting a
  descriptor's picked colour against "a mask, a spot plane or a caller's
  scalar". A grayscale *pattern* is none of those, and since this change it
  reaches `_lab` too, so the justification is restated: the line is drawn at the
  descriptor, and a grey pattern fill on a Lab document lands at `L = g` where
  the same grey as a `Gry ` descriptor lands at `L = L*(g)` — the descriptor
  never reaching `_lab` at all, being already three channels wide.
- Three "three of the call sites are inside `Compositor`" claims are now four.
- Two test docstrings described the broadcast as the reason they pass.

## Left out on purpose

- `_draw_pattern_overlay` still widens its own fill (`composite.py:88-92`),
  which is now redundant with `_fit_source`. Only its assertion still earns its
  place, and its message is the better of the two. Worth removing separately
  rather than inside a behaviour change.
- A grayscale pattern in a `strokeStyleContent` on a CMYK document has no test.
  It is the same door, pinned by the compositor-level test, and reaching it
  end-to-end needs a vector mask and stroke data forged on top of the pattern —
  a fixture out of proportion to what it would add here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
