### PR TITLE
test: point the widen-inheritance guard at the site it was not covering

### DIFF
--- a/tests/psd_tools/composite/test_widen.py
+++ b/tests/psd_tools/composite/test_widen.py
@@ -213,35 +213,67 @@ def test_widened_grey_survives_the_icc_round_trip() -> None:
         assert max(abs(c - level) for c in rendered) <= 3
 
 
+# Every function that constructs a ``Compositor``, and so has to pass ``widen``
+# on. Named rather than counted so that the fixtures below are checked to still
+# reach each one: a guard that renders a document which no longer builds, say, a
+# stroke sub-compositor keeps passing while covering nothing.
+_WIDEN_CALLERS = frozenset(
+    {"composite", "_get_group", "_get_object", "_apply_clip_layers"}
+)
+
+# Between them these reach all four. Neither does alone: the clipping fixture
+# has no stroked shape, and the stroke fixture has no group.
+_WIDEN_FIXTURES = ["clipping-mask.psd", "effects/stroke-composite.psd"]
+
+
 def test_every_sub_compositor_inherits_the_conversion(monkeypatch) -> None:
     """A sub-compositor that forgets ``widen`` reverts its subtree to replication.
 
     ``_get_group()`` did exactly that, and because the group compositor is the
     parent of the clip and stroke ones, losing it there took the whole subtree
-    with it -- the three sites that do pass it on were only right at the
-    document's top level. No fixture caught it: no CMYK or Lab fixture has
-    groups, so the corpus renders identically either way.
+    with it -- the sites that did pass it on were only right at the document's
+    top level. No fixture caught it: no CMYK or Lab fixture has groups, so the
+    corpus renders identically either way. Nor would one: in RGB replication
+    *is* the conversion, so a lost ``widen`` is invisible in every document the
+    corpus actually contains.
+
+    Which makes what the spy is pointed at the whole substance of the test, and
+    ``clipping-mask.psd`` alone was pointing it away from one site. It builds a
+    top-level, two group and one clip compositor, and no stroke one -- so the
+    ``Compositor(...)`` in ``_get_object()`` that seeds a stroke was covered by
+    nothing, though losing ``widen`` there reverts every stroked shape in a CMYK
+    or Lab document (#749, #776). ``effects/stroke-composite.psd`` builds eight
+    of them.
 
     Pinned on the identity of the callable rather than on any rendered value,
     so a new ``Compositor(...)`` that omits the argument fails here regardless
-    of which document it is exercised with.
+    of which document it is exercised with -- and on the caller's name, so a
+    site that stops being reached fails here too rather than going quiet.
     """
-    seen: list[bool] = []
+    seen: list[tuple[str, bool]] = []
     original = Compositor.__init__
 
     def spy(self, *args, **kwargs):
         original(self, *args, **kwargs)
-        seen.append(self._widen is _widen)
+        # Frame 1 is whatever called ``Compositor(...)``: the constructor is
+        # reached through ``type.__call__``, which adds no Python frame.
+        seen.append((sys._getframe(1).f_code.co_name, self._widen is _widen))
 
     monkeypatch.setattr(Compositor, "__init__", spy)
 
-    psd = PSDImage.open(full_name("clipping-mask.psd"))
-    composite(psd, force=True)
+    for filename in _WIDEN_FIXTURES:
+        composite(PSDImage.open(full_name(filename)), force=True)
 
-    assert seen, "no compositor was constructed"
-    assert not any(seen), "%d of %d compositors fell back to the mode-blind _widen" % (
-        sum(seen),
-        len(seen),
+    fell_back = [caller for caller, is_default in seen if is_default]
+    assert not fell_back, (
+        "%d of %d compositors fell back to the mode-blind "
+        "_widen, from %s" % (len(fell_back), len(seen), sorted(set(fell_back)))
+    )
+
+    missing = _WIDEN_CALLERS - {caller for caller, _ in seen}
+    assert not missing, (
+        "%s built no compositor for these fixtures, so nothing checks that it "
+        "passes widen on" % sorted(missing)
     )
 
 


### PR DESCRIPTION
Follow-up to #776, from reviewing what actually covers the stroke path after
#749. Test-only, no behaviour change, no changelog entry.

## The hole

`test_every_sub_compositor_inherits_the_conversion` exists to catch a
`Compositor(...)` that forgets `widen=`, which reverts its whole subtree to
mode-blind replication — the mistake `_get_group()` made during #722.

It rendered `clipping-mask.psd`. Measured, that builds:

| fixture | `composite` | `_get_group` | `_apply_clip_layers` | `_get_object` (stroke) |
| --- | --- | --- | --- | --- |
| `clipping-mask.psd` | 1 | 2 | 1 | **0** |
| `effects/stroke-composite.psd` | 1 | 0 | 4 | **8** |

So the fourth site — the `Compositor(...)` in `_get_object()` that seeds a
stroke (`composite.py:1288`) — was covered by nothing, even though losing
`widen` there reverts every stroked shape in a CMYK or Lab document.

Nothing else would have caught it either. Every stroke fill in the corpus
already matches its canvas width (88 RGB, 4 grayscale, 4 Lab — no narrow ones),
and in RGB replication *is* the conversion, so the rendered output is identical
whether the argument is there or not. A corpus diff is blind to this by
construction; only the spy can see it.

## The change

Render both fixtures, which between them reach all four sites, and record
*which function* built each compositor rather than only whether it fell back.

Verified in both directions:

- Dropping `widen=self._widen` from the stroke construction now fails with
  `8 of 17 compositors fell back to the mode-blind _widen, from ['_get_object']`.
  It passed before.
- Reverting to the single fixture fails the new coverage assertion with
  `['_get_object'] built no compositor for these fixtures, so nothing checks
  that it passes widen on`.

That second assertion is the part that keeps this from rotting: without it the
guard degrades silently — a fixture that stops building a stroke sub-compositor
takes the coverage with it and the test keeps passing, which is exactly how this
hole went unnoticed.

Test runtime is unchanged at 0.13s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
