### PR TITLE
fix: blend a multichannel document by its colour mode, not its width

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -524,6 +524,18 @@ Changelog
   with Knockout at fill opacity 100% -- where it has no visible effect by
   design -- are unaffected.
 
+- [fix] Fall back to ``normal`` for the six non-separable blend modes on a
+  multichannel document at whatever its plate count is, rather than at every
+  count but three and four (#746). Three spot plates were blended as if they
+  were R, G and B, and four had the fourth plate read as CMYK black generation;
+  both were silently wrong output rather than an error. Affects only
+  multichannel documents that carry layers, a shape Photoshop neither writes --
+  converting to Multichannel flattens -- nor preserves on opening, so no file in
+  the test corpus renders differently. The six functions in
+  ``psd_tools.composite.blend`` now take the document's colour mode as an
+  optional third argument, supplied by the new ``get_blend_func()`` lookup;
+  ``BLEND_FUNC`` is unchanged.
+
 1.18.0 (2026-08-07)
 -------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,17 +4,27 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
-- [fix] Fall back to ``normal`` for the six non-separable blend modes on a
-  multichannel document at whatever its plate count is, rather than at every
-  count but three and four (#746). Three spot plates were blended as if they
-  were R, G and B, and four had the fourth plate read as CMYK black generation;
-  both were silently wrong output rather than an error. Affects only
-  multichannel documents that carry layers, a shape Photoshop neither writes --
-  converting to Multichannel flattens -- nor preserves on opening, so no file in
-  the test corpus renders differently. The six functions in
-  ``psd_tools.composite.blend`` now take the document's colour mode as an
-  optional third argument, supplied by the new ``get_blend_func()`` lookup;
-  ``BLEND_FUNC`` is unchanged.
+- [fix] Degrade the six non-separable blend modes -- ``Hue``, ``Saturation``,
+  ``Color``, ``Luminosity``, ``Darker Color`` and ``Lighter Color`` -- on every
+  document Photoshop does not offer them on, instead of crashing or reading the
+  channels as something they are not (#735, #746). The first four raised
+  ``IndexError`` or ``ValueError`` on every single-channel document -- grayscale
+  and duotone -- and on anything wider than CMYK, indexing channels 1 and 2 of
+  an array that has only channel 0; ``Darker Color`` and ``Lighter Color`` did
+  not raise but returned the backdrop unchanged whatever the source was. A
+  multichannel document showed neither symptom and was misread instead: three
+  spot plates blended as if they were R, G and B, and four with the fourth plate
+  taken for CMYK black generation. All six now fall back to ``Normal`` with a
+  debug log, as ``Dissolve`` already does; RGB and CMYK are unaffected, and Lab
+  keeps its as-if-RGB treatment, Photoshop offering all six there. Affects
+  grayscale and duotone documents, which are ordinary files, and multichannel
+  documents carrying layers, which Photoshop neither writes -- converting to
+  Multichannel flattens -- nor preserves on opening, so no file in the test
+  corpus renders differently.
+
+  The six functions in ``psd_tools.composite.blend`` take the document's colour
+  mode as an optional third argument, supplied by the new ``get_blend_func()``
+  lookup; ``BLEND_FUNC`` is unchanged.
 
 - [fix] Convert a single-channel *source* to the document's colour mode instead
   of letting the blend arithmetic replicate it across every channel (#749,
@@ -305,19 +315,6 @@ Changelog
   ``psd_tools.color_convert`` is unchanged -- it is public API with a documented
   ink-space contract -- and the ``background_color`` docstring, which repeated
   the wrong spelling, is corrected (#747).
-
-- [fix] Degrade the non-separable blend modes on documents whose colour array
-  is neither three nor four channels wide instead of crashing. ``Hue``, ``Saturation``, ``Color``
-  and ``Luminosity`` raised ``IndexError`` or ``ValueError`` on every
-  single-channel document -- grayscale and duotone -- because they index
-  channels 1 and 2 of an array that has only channel 0, while ``Darker Color``
-  and ``Lighter Color`` did not raise but returned the backdrop unchanged
-  whatever the source was. A document wider than CMYK was broken too, there
-  raising for all six. Photoshop offers none of these six modes on such a
-  document, so there is no result to reproduce and they now fall back to
-  ``Normal`` with a debug log, as ``Dissolve`` already does. RGB and CMYK are
-  unaffected, and Lab is three channels wide so it keeps its existing
-  as-if-RGB treatment -- Photoshop does offer all six modes there (#735).
 
 - [fix] Let a per-channel colour be set on a multichannel document.
   :py:attr:`~psd_tools.api.psd_image.PSDImage.background_color` validated the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,18 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Fall back to ``normal`` for the six non-separable blend modes on a
+  multichannel document at whatever its plate count is, rather than at every
+  count but three and four (#746). Three spot plates were blended as if they
+  were R, G and B, and four had the fourth plate read as CMYK black generation;
+  both were silently wrong output rather than an error. Affects only
+  multichannel documents that carry layers, a shape Photoshop neither writes --
+  converting to Multichannel flattens -- nor preserves on opening, so no file in
+  the test corpus renders differently. The six functions in
+  ``psd_tools.composite.blend`` now take the document's colour mode as an
+  optional third argument, supplied by the new ``get_blend_func()`` lookup;
+  ``BLEND_FUNC`` is unchanged.
+
 - [fix] Convert a single-channel *source* to the document's colour mode instead
   of letting the blend arithmetic replicate it across every channel (#749,
   #776, #777), as #722 already did for a backdrop. A grayscale pattern fill on a
@@ -523,18 +535,6 @@ Changelog
   opacity below 100% now render differently. Documents without Knockout, or
   with Knockout at fill opacity 100% -- where it has no visible effect by
   design -- are unaffected.
-
-- [fix] Fall back to ``normal`` for the six non-separable blend modes on a
-  multichannel document at whatever its plate count is, rather than at every
-  count but three and four (#746). Three spot plates were blended as if they
-  were R, G and B, and four had the fourth plate read as CMYK black generation;
-  both were silently wrong output rather than an error. Affects only
-  multichannel documents that carry layers, a shape Photoshop neither writes --
-  converting to Multichannel flattens -- nor preserves on opening, so no file in
-  the test corpus renders differently. The six functions in
-  ``psd_tools.composite.blend`` now take the document's colour mode as an
-  optional third argument, supplied by the new ``get_blend_func()`` lookup;
-  ``BLEND_FUNC`` is unchanged.
 
 1.18.0 (2026-08-07)
 -------------------

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -72,10 +72,11 @@ enums to their corresponding functions for easy lookup during compositing.
 
 import functools
 import logging
+from typing import Callable
 
 import numpy as np
 
-from psd_tools.constants import BlendMode
+from psd_tools.constants import BlendMode, ColorMode
 from psd_tools.terminology import Enum
 
 logger = logging.getLogger(__name__)
@@ -249,6 +250,15 @@ def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return B
 
 
+# The wrappers :py:func:`non_separable` builds, which are the only blend
+# functions that take a colour mode. Populated by the decorator rather than
+# listed here, so a seventh non-separable mode cannot be added without
+# :py:func:`get_blend_func` learning about it. Binding the mode over the whole
+# of ``BLEND_FUNC`` instead is not an option: ``color_dodge`` and
+# ``color_burn`` already have a third parameter of their own.
+_MODE_AWARE: set[Callable] = set()
+
+
 # Non-separable blending must be in RGB. CMYK should be first converted to RGB,
 # blended, then CMY components should be retrieved from RGB results. K
 # component is K of Cb for hue, saturation, and color blending, and K of Cs for
@@ -258,18 +268,38 @@ def non_separable(k: str = "s"):
 
     The wrapped functions are RGB-only by construction: the helpers below index
     channels 0, 1 and 2 by name. A three-channel source reaches them unchanged
-    and a four-channel one round-trips through RGB. Any other width falls back
-    to :py:func:`normal` rather than raising or inventing a result.
+    and a four-channel CMYK one round-trips through RGB. Anything else falls
+    back to :py:func:`normal` rather than raising or inventing a result.
 
-    The fallback is keyed on the width rather than on the colour mode, so it
-    covers every mode that is not three or four channels wide: the one-channel
-    ones -- grayscale and duotone, and bitmap and indexed alike -- and
-    multichannel at whatever its spot plates come to. Photoshop offers none of
-    the six on any of them. Scripted against Photoshop 2026, a grayscale
-    document rejects every one with *The command "Set" is not currently
-    available* and they are greyed out in the UI, and bitmap mode does not admit
-    layers at all. So there is no result to reproduce, and widening the array to
-    three channels would produce output Photoshop never does (#735).
+    What "anything else" is takes both the colour mode and the width to decide,
+    and :py:func:`get_blend_func` is what supplies the mode:
+
+    - **Multichannel** falls back at every plate count, and is checked first
+      for that reason. Its channels are spot inks, so a hue or a luminosity read off
+      them is meaningless whether there are three of them or thirty; keying on
+      the width alone had four plates claimed as CMYK -- the fourth ink blended
+      as black generation -- and three blended as if they were R, G and B
+      (#746).
+    - **One channel** falls back on the width: grayscale, duotone and bitmap
+      are each one channel wide, and Photoshop offers none of the six on any of
+      them. Two channels, and five or more, likewise.
+    - **CMYK** round-trips through RGB. **RGB** blends directly, and so does
+      indexed, whose canvas is three channels wide once its palette has been
+      applied.
+
+    Photoshop offers none of the six on any of the modes that fall back.
+    Scripted against Photoshop 2026, a grayscale document rejects every one with
+    *The command "Set" is not currently available* and they are greyed out in
+    the UI; bitmap mode does not admit layers at all; and a multichannel
+    document does not either -- converting to Multichannel flattens, so the
+    blend mode cannot be set on one in the first place. So there is no result to
+    reproduce, and widening or reinterpreting the array would produce output
+    Photoshop never does (#735, #746).
+
+    With no mode to ask -- a bare :py:class:`~psd_tools.composite.Compositor`,
+    or one of these functions called directly -- the width decides alone, as it
+    did before #746: four channels round-trip as CMYK, which is the only mode a
+    four-channel array can belong to on a real document.
 
     Lab is three channels wide and so is blended as if it were RGB. That is this
     module's pre-existing treatment of Lab, not something the fallback decides,
@@ -281,15 +311,33 @@ def non_separable(k: str = "s"):
 
     def decorator(func):
         @functools.wraps(func)
-        def _blend_fn(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
+        def _blend_fn(
+            Cb: np.ndarray, Cs: np.ndarray, color_mode: ColorMode | None = None
+        ) -> np.ndarray:
+            if color_mode == ColorMode.MULTICHANNEL:
+                # Ahead of the width tests, and with a message of its own: for
+                # three or four plates the width is the wrong diagnosis, and
+                # those are exactly the two counts that used to blend rather
+                # than fall back.
+                logger.debug(
+                    "%s blend is not defined on a multichannel document; "
+                    "falling back to normal",
+                    func.__name__,
+                )
+                return normal(Cb, Cs)
             if Cs.shape[2] == 4:
+                # Four channels means CMYK. Multichannel is the only other mode
+                # whose canvas can be that wide and it has returned above, so
+                # reading the fourth channel as K is sound here without asking
+                # the mode again. ``tests/psd_tools/composite/test_blend.py``
+                # pins that premise on ``api.utils.EXPECTED_CHANNELS``.
                 K = Cs[:, :, 3:4] if k == "s" else Cb[:, :, 3:4]
                 Cb, Cs = _cmyk2rgb(Cb), _cmyk2rgb(Cs)
                 return np.concatenate((_rgb2cmy(func(Cb, Cs), K), K), axis=2)
             if Cs.shape[2] != 3:
-                # Keyed on the source: the compositor allows a one-channel
-                # source against a wider canvas, so this is not always the
-                # document's own width.
+                # The document's own width: ``Compositor._fit_source()`` widens
+                # a one-channel source at the door, so every array that reaches
+                # here is exactly the canvas width (#749).
                 logger.debug(
                     "%s blend is not defined for a %d-channel source; "
                     "falling back to normal",
@@ -299,6 +347,7 @@ def non_separable(k: str = "s"):
                 return normal(Cb, Cs)
             return func(Cb, Cs)
 
+        _MODE_AWARE.add(_blend_fn)
         return _blend_fn
 
     return decorator
@@ -603,3 +652,29 @@ BLEND_FUNC = {
     b"lighterColor": lighter_color,
     Enum.Dissolve: dissolve,
 }
+
+
+def get_blend_func(
+    blend_mode: BlendMode | bytes, color_mode: ColorMode | None = None
+) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    """Look up *blend_mode*, with the document's colour mode already bound in.
+
+    :py:data:`BLEND_FUNC` answers by blend mode alone, which is all a separable
+    mode needs. The six non-separable ones also need to know what the channels
+    of their operands *are* -- three spot plates are not R, G and B, and a
+    fourth is not black generation -- so the mode is bound to those here rather
+    than plumbed through every blend signature (#746).
+
+    The result takes ``(Cb, Cs)`` either way, so the compositor calls it without
+    caring which kind it got. Pass no *color_mode* and the width decides alone,
+    exactly as it did before; :py:data:`BLEND_FUNC` itself is unchanged and
+    stays the mode-blind table.
+
+    Unknown keys answer :py:func:`normal`, as the ``.get`` calls this replaces
+    did. ``PASS_THROUGH`` is one of them and reaches here for real: a group that
+    isolates its adjustments is composited as an ordinary source.
+    """
+    func = BLEND_FUNC.get(blend_mode, normal)
+    if color_mode is None or func not in _MODE_AWARE:
+        return func
+    return functools.partial(func, color_mode=color_mode)

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -67,7 +67,9 @@ Example usage::
     # Result: [0.35, 0.18, 0.16]
 
 The ``BLEND_FUNC`` dictionary maps :py:class:`~psd_tools.constants.BlendMode`
-enums to their corresponding functions for easy lookup during compositing.
+enums to their corresponding functions. The compositor looks a mode up through
+:py:func:`get_blend_func`, which answers from that table and binds the
+document's colour mode where the function needs it.
 """
 
 import functools
@@ -252,10 +254,11 @@ def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 # The wrappers :py:func:`non_separable` builds, which are the only blend
 # functions that take a colour mode. Populated by the decorator rather than
-# listed here, so a seventh non-separable mode cannot be added without
-# :py:func:`get_blend_func` learning about it. Binding the mode over the whole
-# of ``BLEND_FUNC`` instead is not an option: ``color_dodge`` and
-# ``color_burn`` already have a third parameter of their own.
+# listed here, so that a seventh mode added *through the decorator* needs no
+# edit here; one written by hand would still have to register itself, as it
+# would have to reimplement the fallbacks. Binding the mode over the whole of
+# ``BLEND_FUNC`` instead is not an option: ``color_dodge`` and ``color_burn``
+# already have a third parameter of their own.
 _MODE_AWARE: set[Callable] = set()
 
 
@@ -284,8 +287,10 @@ def non_separable(k: str = "s"):
       are each one channel wide, and Photoshop offers none of the six on any of
       them. Two channels, and five or more, likewise.
     - **CMYK** round-trips through RGB. **RGB** blends directly, and so does
-      indexed, whose canvas is three channels wide once its palette has been
-      applied.
+      indexed, whose canvas :py:data:`~psd_tools.api.utils.EXPECTED_CHANNELS`
+      fixes at three channels. (Whether an indexed *layer* arrives as palette
+      colours or as raw indices is a separate question this does not settle;
+      the palette is applied on the image-data path only.)
 
     Photoshop offers none of the six on any of the modes that fall back.
     Scripted against Photoshop 2026, a grayscale document rejects every one with
@@ -298,15 +303,25 @@ def non_separable(k: str = "s"):
 
     With no mode to ask -- a bare :py:class:`~psd_tools.composite.Compositor`,
     or one of these functions called directly -- the width decides alone, as it
-    did before #746: four channels round-trip as CMYK, which is the only mode a
-    four-channel array can belong to on a real document.
+    did before #746, and four channels round-trip as CMYK. That is a guess, and
+    on a four-plate multichannel array it is the wrong one; it is the same guess
+    the whole module made before #746, kept because a caller who supplies no
+    document is not asking to be told which mode it has.
 
     Lab is three channels wide and so is blended as if it were RGB. That is this
     module's pre-existing treatment of Lab, not something the fallback decides,
     and it is the right side to leave Lab on: Photoshop does offer all six modes
     on a Lab document.
 
-    .. note: This implementation is still inaccurate.
+    .. note::
+
+       This implementation is still inaccurate. The CMYK round trip in
+       particular reads its operands as ink where the compositor's canvas holds
+       what is left of it, so ``_cmyk2rgb`` inverts them: the six modes
+       collapse to a constant on a CMYK document, and blending an operand with
+       itself is not the identity it must be. That is the same inversion #747
+       fixed in ``composite/paint.py`` and is untouched here; #746 settled only
+       which modes reach the round trip, not what it computes.
     """
 
     def decorator(func):
@@ -326,18 +341,22 @@ def non_separable(k: str = "s"):
                 )
                 return normal(Cb, Cs)
             if Cs.shape[2] == 4:
-                # Four channels means CMYK. Multichannel is the only other mode
-                # whose canvas can be that wide and it has returned above, so
-                # reading the fourth channel as K is sound here without asking
-                # the mode again. ``tests/psd_tools/composite/test_blend.py``
-                # pins that premise on ``api.utils.EXPECTED_CHANNELS``.
+                # Four channels means CMYK, when a mode was supplied at all:
+                # multichannel is the only other mode whose canvas can be that
+                # wide, and it returned above.
+                # ``tests/psd_tools/composite/test_blend.py`` pins that premise
+                # on ``api.utils.EXPECTED_CHANNELS``. With no mode supplied this
+                # is the guess the docstring describes, not a deduction -- and
+                # what it computes is wrong either way, see the note above.
                 K = Cs[:, :, 3:4] if k == "s" else Cb[:, :, 3:4]
                 Cb, Cs = _cmyk2rgb(Cb), _cmyk2rgb(Cs)
                 return np.concatenate((_rgb2cmy(func(Cb, Cs), K), K), axis=2)
             if Cs.shape[2] != 3:
-                # The document's own width: ``Compositor._fit_source()`` widens
-                # a one-channel source at the door, so every array that reaches
-                # here is exactly the canvas width (#749).
+                # The canvas width, and inside the compositor the
+                # document's: ``Compositor._fit_source()`` widens a one-channel
+                # source at the door, so every array reaching here from there is
+                # exactly that wide (#749). A direct caller can hand over any
+                # width, which is why this is a fallback and not an assertion.
                 logger.debug(
                     "%s blend is not defined for a %d-channel source; "
                     "falling back to normal",

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -674,7 +674,7 @@ BLEND_FUNC = {
 
 
 def get_blend_func(
-    blend_mode: BlendMode | bytes, color_mode: ColorMode | None = None
+    blend_mode: bytes, color_mode: ColorMode | None = None
 ) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
     """Look up *blend_mode*, with the document's colour mode already bound in.
 
@@ -688,6 +688,12 @@ def get_blend_func(
     caring which kind it got. Pass no *color_mode* and the width decides alone,
     exactly as it did before; :py:data:`BLEND_FUNC` itself is unchanged and
     stays the mode-blind table.
+
+    *blend_mode* is ``bytes`` and not :py:class:`~psd_tools.constants.BlendMode`
+    because :py:data:`BLEND_FUNC` is keyed by two families -- enum members for a
+    layer's own mode, raw descriptor keys such as ``b"lighterColor"`` for a
+    stroke's or an effect's -- and ``BlendMode`` subclasses ``bytes``, so the
+    supertype admits both without a union of a type and its own supertype.
 
     Unknown keys answer :py:func:`normal`, as the ``.get`` calls this replaces
     did. ``PASS_THROUGH`` is one of them and reaches here for real: a group that

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -47,7 +47,7 @@ class _StyledEffect(Protocol):
     def opacity(self) -> float: ...
 
     @property
-    def blend_mode(self) -> BlendMode: ...
+    def blend_mode(self) -> bytes: ...
 
 
 def _styled(effects: Iterator[Any]) -> Iterator[_StyledEffect]:
@@ -1064,7 +1064,11 @@ class Compositor(object):
         color: np.ndarray,
         shape: np.ndarray,
         alpha: np.ndarray,
-        blend_mode: BlendMode,
+        # Not ``BlendMode``: a stroke's and an effect's blend mode is a raw
+        # descriptor key, and only a layer's is an enum member. ``BlendMode``
+        # subclasses ``bytes``, so this admits both rather than widening to a
+        # union of a type and its own supertype.
+        blend_mode: bytes,
         knockout: Knockout = Knockout.NONE,
     ) -> None:
         color = self._fit_source(color)

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -15,7 +15,7 @@ from psd_tools.api.psd_image import PSDImage
 from psd_tools.api.utils import check_pixel_size, get_color_channels
 from psd_tools.composite import paint, utils, vector
 from psd_tools.composite.adjustments import ADJUSTMENT_FUNC
-from psd_tools.composite.blend import BLEND_FUNC, normal
+from psd_tools.composite.blend import get_blend_func
 from psd_tools.composite.effects import draw_stroke_effect
 from psd_tools.composite.widen import make_widen
 from psd_tools.constants import (
@@ -463,6 +463,7 @@ def composite(
         force,
         document_backdrop=lambda: _document_backdrop(_psd, viewport),
         widen=_widen_fn,
+        color_mode=None if _psd is None else _psd.color_mode,
     )
     target_group = group if isinstance(group, GroupMixin) and not as_layer else [group]
     for layer in target_group:  # type: ignore
@@ -762,13 +763,21 @@ class Compositor(object):
     is only correct when there is no document to ask (#722). A sub-compositor
     that does not pass it on returns its whole subtree to that fallback.
 
+    ``color_mode`` is the document's, and travels the same way for the same
+    reason: the six non-separable blend modes need to know what their operands'
+    channels are and not merely how many, since a multichannel document's spot
+    plates are neither RGB nor CMYK (#746). A sub-compositor that does not pass
+    it on returns its whole subtree to deciding by width alone.
+
     Example::
 
         widen = make_widen(psd)
         color, alpha = _normalize_backdrop(
             1.0, 0.0, height, width, channels, widen=widen
         )
-        compositor = Compositor(group.bbox, color, alpha, widen=widen)
+        compositor = Compositor(
+            group.bbox, color, alpha, widen=widen, color_mode=psd.color_mode
+        )
         for layer in group:
             compositor.apply(layer)
         color, shape, alpha = compositor.finish()
@@ -785,6 +794,7 @@ class Compositor(object):
         document_backdrop: Callable[[], tuple[np.ndarray, np.ndarray] | None]
         | None = None,
         widen: _Widen = _widen,
+        color_mode: ColorMode | None = None,
     ):
         self._viewport = viewport
         self._layer_filter = layer_filter
@@ -793,6 +803,12 @@ class Compositor(object):
         # rather than derived because the four sites that need it below are
         # inside this class, which holds no document handle (#722, #749).
         self._widen = widen
+        # The document's colour mode, for the blend functions that need to know
+        # what their operands' channels are and not just how many there are.
+        # Carried for the same reason as ``widen``: ``_apply_source()`` holds no
+        # document handle either. None means "no document to ask", and leaves
+        # the width to decide alone (#746).
+        self._color_mode = color_mode
         self._adjustment_isolated = adjustment_isolated
         # What Knockout.DEEP knocks out to. Inherited by pass-through
         # sub-compositors and reset at every isolation boundary, so deep
@@ -1067,7 +1083,7 @@ class Compositor(object):
         alpha_b = knockout_alpha if knockout else alpha_previous
         color_b = knockout_color if knockout else self._color
 
-        blend_fn = BLEND_FUNC.get(blend_mode, normal)
+        blend_fn = get_blend_func(blend_mode, self._color_mode)
         color_t = (shape - alpha) * alpha_b * color_b + alpha * (
             (1.0 - alpha_b) * color + alpha_b * blend_fn(color_b, color)
         )
@@ -1104,7 +1120,10 @@ class Compositor(object):
         shape = shape_mask * shape_const
         opacity = shape * opacity_const
 
-        blend_fn = BLEND_FUNC.get(layer.blend_mode, normal)
+        # Passed for uniformity with _apply_source() rather than for effect:
+        # the guard above has already returned for every mode whose blending
+        # the colour mode changes, multichannel included.
+        blend_fn = get_blend_func(layer.blend_mode, self._color_mode)
         blended = blend_fn(backdrop_color, transformed_color)
 
         if self._adjustment_isolated:
@@ -1237,6 +1256,7 @@ class Compositor(object):
             adjustment_isolated=self._adjustment_isolated or isolate_adjustments,
             document_backdrop=document_backdrop,
             widen=self._widen,
+            color_mode=self._color_mode,
         )
 
         for sublayer in cast(GroupMixin, layer):
@@ -1298,6 +1318,7 @@ class Compositor(object):
                 self._widen(color, self.channels),
                 alpha,
                 widen=self._widen,
+                color_mode=self._color_mode,
             )
             compositor._apply_source(color_s, shape_s, alpha_s, layer.stroke.blend_mode)
             color, _, _ = compositor.finish()
@@ -1315,6 +1336,7 @@ class Compositor(object):
             layer_filter=self._layer_filter,
             force=self._force,
             widen=self._widen,
+            color_mode=self._color_mode,
         )
         for clip_layer in layer.clip_layers:
             compositor.apply(clip_layer, clip_compositing=True)

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -1120,9 +1120,13 @@ class Compositor(object):
         shape = shape_mask * shape_const
         opacity = shape * opacity_const
 
-        # Passed for uniformity with _apply_source() rather than for effect:
-        # the guard above has already returned for every mode whose blending
-        # the colour mode changes, multichannel included.
+        # Passed for uniformity with _apply_source() rather than for effect.
+        # The guard above returns for every mode whose blending the colour mode
+        # changes, multichannel included -- though it reads the *layer's*
+        # document where this binds the compositor's, which are the same
+        # document on every path the library builds. Where they could differ, a
+        # compositor built by hand, the canvas is this one's and so is the mode
+        # that describes it.
         blend_fn = get_blend_func(layer.blend_mode, self._color_mode)
         blended = blend_fn(backdrop_color, transformed_color)
 

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -7,17 +7,22 @@ from PIL import Image
 
 from psd_tools import PSDImage
 from psd_tools.api.layers import GroupMixin, PixelLayer
+from psd_tools.api.utils import EXPECTED_CHANNELS, color_channels
 from psd_tools.composite.blend import (
     BLEND_FUNC,
     color,
+    color_dodge,
     darker_color,
+    get_blend_func,
     hue,
     lighter_color,
     luminosity,
+    multiply,
     normal,
     saturation,
 )
-from psd_tools.constants import BlendMode
+from psd_tools.constants import BlendMode, ColorMode
+from psd_tools.terminology import Enum
 from .test_composite import check_composite_quality
 
 logger = logging.getLogger(__name__)
@@ -250,25 +255,51 @@ def test_non_separable_falls_back_to_normal_off_rgb(
     assert np.array_equal(result, normal(Cb, Cs))
 
 
-@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
-@pytest.mark.parametrize("channels", [3, 4])
-def test_non_separable_still_blends_rgb_and_cmyk(
-    func: Callable, channels: int, caplog: pytest.LogCaptureFixture
-) -> None:
-    """The fallback must not swallow the widths that do have ground truth.
+def _mixed_pair(channels: int) -> tuple[np.ndarray, np.ndarray]:
+    """A backdrop and a source that no single operand can be mistaken for.
 
     The source is brighter than the backdrop in one pixel and darker in the
     other. A spatially constant pair would not do: ``darker_color`` and
     ``lighter_color`` return one whole operand, so on constant input one of the
-    two always coincides with ``normal`` and the comparison could not tell a
-    real blend from the fallback.
+    two always coincides with ``normal`` and a comparison could not tell a real
+    blend from the fallback.
     """
     Cb = np.full((1, 2, channels), 0.4, dtype=np.float32)
     Cs = np.full((1, 2, channels), 0.6, dtype=np.float32)
     Cs[0, 0, 0] = 0.9
     Cs[0, 1, :] = 0.1
+    return Cb, Cs
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+@pytest.mark.parametrize(
+    ("color_mode", "channels"),
+    [
+        (None, 3),
+        (None, 4),
+        (ColorMode.RGB, 3),
+        (ColorMode.INDEXED, 3),
+        (ColorMode.LAB, 3),
+        (ColorMode.CMYK, 4),
+    ],
+)
+def test_non_separable_still_blends_the_modes_with_ground_truth(
+    func: Callable,
+    color_mode: ColorMode | None,
+    channels: int,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The fallbacks must not swallow the cases that do have ground truth.
+
+    Photoshop offers all six modes on an RGB, indexed, Lab and CMYK document,
+    so all four keep blending -- the three-channel ones directly and CMYK
+    through the RGB round trip. So does an array with no mode attached, which
+    is what a bare ``Compositor`` or a direct call hands over: there the width
+    decides alone, as it did before #746.
+    """
+    Cb, Cs = _mixed_pair(channels)
     with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
-        result = func(Cb.copy(), Cs.copy())
+        result = func(Cb.copy(), Cs.copy(), color_mode)
     assert result.shape == (1, 2, channels)
     assert not np.array_equal(result, normal(Cb, Cs))
     assert "falling back to normal" not in caplog.text
@@ -281,3 +312,96 @@ def test_non_separable_fallback_is_logged(caplog: pytest.LogCaptureFixture) -> N
     with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
         luminosity(Cb, Cs)
     assert "luminosity blend is not defined for a 1-channel source" in caplog.text
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+@pytest.mark.parametrize("channels", [1, 2, 3, 4, 5])
+def test_non_separable_falls_back_on_a_multichannel_document(
+    func: Callable, channels: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A spot plate is not a colour component, at any plate count (#746).
+
+    #745 keyed the fallback on the width, which left two plate counts blending:
+    four were claimed as CMYK and the fourth ink blended as black generation,
+    and three went into the RGB helpers as if the plates were R, G and B. Both
+    were silently wrong rather than an error, and three is the count the only
+    multichannel fixture in the corpus has.
+
+    The assertion on the message is what makes this discriminate. At one, two
+    and five channels the width fallback #745 added returns ``normal`` too, so
+    the equality alone would pass there with this fix reverted; and for three
+    and four the width is the wrong diagnosis to log.
+    """
+    Cb, Cs = _mixed_pair(channels)
+    with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
+        result = func(Cb.copy(), Cs.copy(), ColorMode.MULTICHANNEL)
+    assert result.shape == (1, 2, channels)
+    assert np.array_equal(result, normal(Cb, Cs))
+    assert (
+        "%s blend is not defined on a multichannel document" % func.__name__
+        in caplog.text
+    )
+
+
+def test_only_cmyk_is_four_channels_wide() -> None:
+    """The premise the ``Cs.shape[2] == 4`` branch reads as CMYK (#746).
+
+    Multichannel returns before that branch, so what makes its remaining
+    reading of a four-channel array sound is that no other mode can produce
+    one: :py:data:`EXPECTED_CHANNELS` fixes every mode but multichannel, whose
+    entry is the format maximum and whose count the header supplies. Pinned
+    here so that a change to the table -- indexed expanding to four
+    post-palette, say -- fails as a test rather than as an unrelated mode
+    blended as ink.
+    """
+    assert {m for m in ColorMode if EXPECTED_CHANNELS[m] == 4} == {ColorMode.CMYK}
+    assert EXPECTED_CHANNELS[ColorMode.MULTICHANNEL] == 64
+    assert color_channels(ColorMode.MULTICHANNEL, 4) == 4
+
+
+def test_get_blend_func_binds_the_mode_only_to_the_non_separable_six() -> None:
+    """Which functions take a colour mode is a correctness question (#746).
+
+    ``color_dodge`` and ``color_burn`` already have a third parameter of their
+    own -- the ``s`` factor -- so binding the mode across the whole table would
+    hand them a ``ColorMode`` as that factor. The six wrappers register
+    themselves as the decorator builds them; everything else must come back
+    untouched, and identically, so that a caller can still compare identity.
+    """
+    assert get_blend_func(BlendMode.MULTIPLY, ColorMode.MULTICHANNEL) is multiply
+    assert get_blend_func(BlendMode.COLOR_DODGE, ColorMode.CMYK) is color_dodge
+    assert get_blend_func(BlendMode.HUE) is hue
+    assert get_blend_func(BlendMode.HUE, ColorMode.MULTICHANNEL) is not hue
+
+
+def test_get_blend_func_defaults_unknown_keys_to_normal() -> None:
+    """The ``.get(..., normal)`` default this replaced is load-bearing (#746).
+
+    ``PASS_THROUGH`` has no entry in ``BLEND_FUNC`` and reaches the lookup for
+    real: a group that isolates its adjustments is composited as an ordinary
+    source, so ``_apply_source()`` is called with it. Answering ``None`` there
+    would raise rather than composite.
+    """
+    assert BLEND_FUNC.get(BlendMode.PASS_THROUGH) is None
+    assert get_blend_func(BlendMode.PASS_THROUGH) is normal
+    assert get_blend_func(BlendMode.PASS_THROUGH, ColorMode.MULTICHANNEL) is normal
+    assert get_blend_func(b"nosuchblendmode", ColorMode.CMYK) is normal
+
+
+@pytest.mark.parametrize(
+    "key",
+    [Enum.Hue, Enum.Saturation, Enum.Color, Enum.Luminosity]
+    + [b"darkerColor", b"lighterColor"],
+)
+def test_get_blend_func_degrades_the_descriptor_keys_too(key: bytes) -> None:
+    """Effects and strokes look their blend mode up by descriptor key (#746).
+
+    ``BLEND_FUNC`` carries the six twice over, once per key family, and a typo
+    in the descriptor half shipped undetected once already -- see
+    ``test_lighter_color_descriptor_key`` above. So the family a layer's own
+    blend mode does *not* come through is pinned here rather than assumed to
+    follow.
+    """
+    Cb, Cs = _mixed_pair(4)
+    blend_fn = get_blend_func(key, ColorMode.MULTICHANNEL)
+    assert np.array_equal(blend_fn(Cb.copy(), Cs.copy()), normal(Cb, Cs))

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -247,6 +247,11 @@ def test_non_separable_falls_back_to_normal_off_rgb(
 
     ``normal`` is the fallback because Photoshop refuses to set any of these
     six modes on such a document, so there is no result to reproduce.
+
+    Since #746 the width is no longer the whole rule: a multichannel document
+    returns before this branch when its mode is known, at three and four plates
+    as well as at the widths here. These cases carry no mode, so they still
+    reach the width fallback and pin it as #735 left it.
     """
     Cb = np.full((2, 2, channels), 0.4, dtype=np.float32)
     Cs = np.full((2, 2, channels), 0.6, dtype=np.float32)
@@ -291,11 +296,21 @@ def test_non_separable_still_blends_the_modes_with_ground_truth(
 ) -> None:
     """The fallbacks must not swallow the cases that do have ground truth.
 
-    Photoshop offers all six modes on an RGB, indexed, Lab and CMYK document,
-    so all four keep blending -- the three-channel ones directly and CMYK
-    through the RGB round trip. So does an array with no mode attached, which
-    is what a bare ``Compositor`` or a direct call hands over: there the width
-    decides alone, as it did before #746.
+    Photoshop offers all six on an RGB, a Lab and a CMYK document, so those
+    three keep blending -- the three-channel ones directly, CMYK through the
+    RGB round trip. So does an array with no mode attached, which is what a
+    bare ``Compositor`` or a direct call hands over: there the width decides
+    alone, as it did before #746.
+
+    Indexed rides along on width rather than on ground truth. Photoshop
+    flattens on conversion to Indexed Color, the same argument that keeps
+    multichannel out, so there is no layer to set a blend mode on; what the row
+    pins is that the mode-keyed branch singles out multichannel and leaves
+    every other three-channel canvas on the RGB path.
+
+    What none of these rows claims is that the CMYK result is *right*: the
+    round trip inverts its operands, as ``non_separable``'s note records. They
+    pin which path a mode takes, not what the path computes.
     """
     Cb, Cs = _mixed_pair(channels)
     with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
@@ -357,6 +372,20 @@ def test_only_cmyk_is_four_channels_wide() -> None:
     assert {m for m in ColorMode if EXPECTED_CHANNELS[m] == 4} == {ColorMode.CMYK}
     assert EXPECTED_CHANNELS[ColorMode.MULTICHANNEL] == 64
     assert color_channels(ColorMode.MULTICHANNEL, 4) == 4
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+def test_non_separable_defaults_to_deciding_by_width(func: Callable) -> None:
+    """Called with two arguments, these behave as they did before #746.
+
+    Every other case passes a mode explicitly, including the ``None`` rows, so
+    without this the *default* would be untested -- and a default of, say,
+    ``ColorMode.MULTICHANNEL`` would degrade every direct caller to ``normal``
+    while the whole suite stayed green.
+    """
+    Cb, Cs = _mixed_pair(4)
+    assert np.array_equal(func(Cb.copy(), Cs.copy()), func(Cb.copy(), Cs.copy(), None))
+    assert not np.array_equal(func(Cb.copy(), Cs.copy()), normal(Cb, Cs))
 
 
 def test_get_blend_func_binds_the_mode_only_to_the_non_separable_six() -> None:

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -460,7 +460,9 @@ def test_composite_layerless_multichannel_over_a_backdrop() -> None:
     assert color.shape == (psd.height, psd.width, psd.numpy("color").shape[2])
 
 
-def _layered_multichannel(**kwargs: Any) -> PSDImage:
+def _layered_multichannel(
+    filename: str = "colormodes/4x4_8bit_rgb.psd", **kwargs: Any
+) -> PSDImage:
     """A multichannel document *with* layers, which no fixture provides.
 
     Photoshop neither produces nor preserves this shape: converting to
@@ -477,7 +479,10 @@ def _layered_multichannel(**kwargs: Any) -> PSDImage:
     Retagging the RGB fixture's color mode in place is the whole of
     it: that fixture's three document channels and its layers' three color
     channels already agree, as they would in a multichannel file with three
-    spot channels, so nothing else about the document has to change.
+    spot channels, so nothing else about the document has to change. The CMYK
+    fixture retags on the same terms and gives four plates instead of three --
+    the count that used to be claimed as CMYK (#746) -- since its header and
+    its layers agree at four the same way.
 
     Built this way rather than with ``PSDImage.new`` + ``PixelLayer.frompil``
     on purpose. ``frompil`` converts to the document's ``pil_mode``, which is
@@ -486,7 +491,7 @@ def _layered_multichannel(**kwargs: Any) -> PSDImage:
     one-channel source is widened to whatever the canvas is, so the test would
     pass without ever exercising the canvas width it is about.
     """
-    psd = PSDImage.open(full_name("colormodes/4x4_8bit_rgb.psd"), **kwargs)
+    psd = PSDImage.open(full_name(filename), **kwargs)
     psd._record.header.color_mode = ColorMode.MULTICHANNEL
     return psd
 
@@ -656,17 +661,17 @@ def test_composite_duotone_with_a_channelwise_blend_mode(blend_mode: BlendMode) 
     assert color.shape == (psd.height, psd.width, 1)
 
 
-@pytest.mark.parametrize(
-    "blend_mode",
-    [
-        BlendMode.HUE,
-        BlendMode.SATURATION,
-        BlendMode.COLOR,
-        BlendMode.LUMINOSITY,
-        BlendMode.DARKER_COLOR,
-        BlendMode.LIGHTER_COLOR,
-    ],
-)
+NON_SEPARABLE_MODES = [
+    BlendMode.HUE,
+    BlendMode.SATURATION,
+    BlendMode.COLOR,
+    BlendMode.LUMINOSITY,
+    BlendMode.DARKER_COLOR,
+    BlendMode.LIGHTER_COLOR,
+]
+
+
+@pytest.mark.parametrize("blend_mode", NON_SEPARABLE_MODES)
 @pytest.mark.parametrize(
     "filename",
     [
@@ -706,17 +711,7 @@ def test_composite_single_channel_with_a_non_separable_blend_mode(
     assert np.array_equal(color, composite(reference)[0])
 
 
-@pytest.mark.parametrize(
-    "blend_mode",
-    [
-        BlendMode.HUE,
-        BlendMode.SATURATION,
-        BlendMode.COLOR,
-        BlendMode.LUMINOSITY,
-        BlendMode.DARKER_COLOR,
-        BlendMode.LIGHTER_COLOR,
-    ],
-)
+@pytest.mark.parametrize("blend_mode", NON_SEPARABLE_MODES)
 def test_composite_single_channel_non_separable_over_an_opaque_backdrop(
     blend_mode: BlendMode,
 ) -> None:
@@ -743,6 +738,78 @@ def test_composite_single_channel_non_separable_over_an_opaque_backdrop(
     assert (alpha == 1.0).all(), "the backdrop must be opaque for this to bite"
     assert color.shape == (4, 4, 1)
     assert np.allclose(color, 192 / 255.0, atol=1 / 255.0)
+
+
+@pytest.mark.parametrize("blend_mode", NON_SEPARABLE_MODES)
+@pytest.mark.parametrize(
+    ("filename", "plates"),
+    [
+        ("colormodes/4x4_8bit_rgb.psd", 3),
+        ("colormodes/4x4_8bit_cmyk.psd", 4),
+    ],
+)
+def test_composite_multichannel_with_a_non_separable_blend_mode(
+    filename: str, plates: int, blend_mode: BlendMode
+) -> None:
+    """A spot plate is neither a colour component nor an ink (#746).
+
+    #735 keyed the degradation on the width, which left the two plate counts
+    that collide with RGB and CMYK still blending: three plates went into the
+    RGB helpers as if they were R, G and B, and four were round-tripped as CMYK
+    with the fourth ink read as black generation. Measured here before the fix,
+    against the same document at ``Normal``, every one of the twelve cases
+    differed -- by up to 0.7 at three plates and 1.0 at four.
+
+    The backdrop has to be passed in opaque. Where these fixtures' layers paint
+    the document's own alpha is zero, and ``_apply_source``'s
+    ``(1 - alpha_b) * color + alpha_b * blend(...)`` then collapses to the
+    source, so the blend result never reaches the output and returning it or
+    returning the backdrop look identical -- the same trap
+    ``test_composite_single_channel_non_separable_over_an_opaque_backdrop``
+    exists for.
+
+    Left at ``force=False`` deliberately. Forcing routes the second layer
+    through ``paint.draw_gradient_fill()``, a different path from the one under
+    test, and on that path ``Luminosity`` already coincided with ``Normal``
+    before the fix -- so that parametrization would have asserted nothing.
+    """
+    psd = _layered_multichannel(filename)
+    assert psd.color_mode == ColorMode.MULTICHANNEL
+    assert psd.channels == plates
+    for layer in psd:
+        layer.blend_mode = blend_mode
+
+    color, alpha, _ = composite(psd, color=0.5, alpha=1.0)
+    assert (alpha == 1.0).all(), "the backdrop must be opaque for this to bite"
+    assert color.shape == (psd.height, psd.width, plates)
+
+    reference = _layered_multichannel(filename)
+    for layer in reference:
+        layer.blend_mode = BlendMode.NORMAL
+    assert np.array_equal(color, composite(reference, color=0.5, alpha=1.0)[0])
+
+
+@pytest.mark.parametrize("blend_mode", NON_SEPARABLE_MODES)
+def test_composite_cmyk_still_blends_where_multichannel_no_longer_does(
+    blend_mode: BlendMode,
+) -> None:
+    """The colour mode is doing the work above, not the channel count (#746).
+
+    The same fixture, the same four channels, the same backdrop -- left tagged
+    CMYK. A fix that fell back on the width of the array rather than on what
+    its channels mean would pass the test above and fail this one, taking the
+    CMYK round trip down with it.
+    """
+    psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
+    assert psd.color_mode == ColorMode.CMYK
+    for layer in psd:
+        layer.blend_mode = blend_mode
+    color, _, _ = composite(psd, color=0.5, alpha=1.0)
+
+    reference = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
+    for layer in reference:
+        layer.blend_mode = BlendMode.NORMAL
+    assert not np.array_equal(color, composite(reference, color=0.5, alpha=1.0)[0])
 
 
 def test_composite_pil_duotone_force_keeps_the_luminance_plane_intact() -> None:

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -770,8 +770,9 @@ def test_composite_multichannel_with_a_non_separable_blend_mode(
 
     Left at ``force=False`` deliberately. Forcing routes the second layer
     through ``paint.draw_gradient_fill()``, a different path from the one under
-    test, and on that path ``Luminosity`` already coincided with ``Normal``
-    before the fix -- so that parametrization would have asserted nothing.
+    test, and shrinks the pre-fix evidence to nothing worth asserting on: at
+    four plates ``Luminosity`` separated from ``Normal`` by 2.4e-07 there,
+    float noise rather than a visible misblend, against 1.0 here.
     """
     psd = _layered_multichannel(filename)
     assert psd.color_mode == ColorMode.MULTICHANNEL
@@ -790,7 +791,7 @@ def test_composite_multichannel_with_a_non_separable_blend_mode(
 
 
 @pytest.mark.parametrize("blend_mode", NON_SEPARABLE_MODES)
-def test_composite_cmyk_still_blends_where_multichannel_no_longer_does(
+def test_composite_cmyk_still_takes_the_round_trip_multichannel_no_longer_does(
     blend_mode: BlendMode,
 ) -> None:
     """The colour mode is doing the work above, not the channel count (#746).
@@ -799,6 +800,13 @@ def test_composite_cmyk_still_blends_where_multichannel_no_longer_does(
     CMYK. A fix that fell back on the width of the array rather than on what
     its channels mean would pass the test above and fail this one, taking the
     CMYK round trip down with it.
+
+    Which path CMYK takes is all this pins. It is deliberately not evidence
+    that the path is *correct*: ``_cmyk2rgb`` reads its operands as ink where
+    the canvas holds what is left of it, so the six collapse to a constant on a
+    CMYK document -- which is why they differ from ``Normal`` so emphatically
+    here. See the note on ``blend.non_separable``; that inversion is #747's
+    family and is untouched by #746.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
     assert psd.color_mode == ColorMode.CMYK

--- a/tests/psd_tools/composite/test_widen.py
+++ b/tests/psd_tools/composite/test_widen.py
@@ -209,10 +209,11 @@ def test_widened_grey_survives_the_icc_round_trip() -> None:
         assert max(abs(c - level) for c in rendered) <= 3
 
 
-# Every function that constructs a ``Compositor``, and so has to pass ``widen``
-# on. Named rather than counted so that the fixtures below are checked to still
-# reach each one: a guard that renders a document which no longer builds, say, a
-# stroke sub-compositor keeps passing while covering nothing.
+# Every function that constructs a ``Compositor``, and so has to pass the
+# document's facts on. Named rather than counted so that the fixtures below are
+# checked to still reach each one: a guard that renders a document which no
+# longer builds, say, a stroke sub-compositor keeps passing while covering
+# nothing.
 _WIDEN_CALLERS = frozenset(
     {"composite", "_get_group", "_get_object", "_apply_clip_layers"}
 )
@@ -222,7 +223,7 @@ _WIDEN_CALLERS = frozenset(
 _WIDEN_FIXTURES = ["clipping-mask.psd", "effects/stroke-composite.psd"]
 
 
-def test_every_sub_compositor_inherits_the_conversion(monkeypatch) -> None:
+def test_every_sub_compositor_inherits_the_document_facts(monkeypatch) -> None:
     """A sub-compositor that forgets ``widen`` reverts its subtree to replication.
 
     ``_get_group()`` did exactly that, and because the group compositor is the
@@ -241,35 +242,56 @@ def test_every_sub_compositor_inherits_the_conversion(monkeypatch) -> None:
     or Lab document (#749, #776). ``effects/stroke-composite.psd`` builds eight
     of them.
 
+    ``color_mode`` is checked in the same pass, being the second fact carried
+    down the same tree for the same reason: a compositor that does not know its
+    document's colour mode blends the non-separable modes by the width of the
+    array alone, which is what read a multichannel document's fourth spot plate
+    as black generation (#746). One spy rather than two, so that the two facts
+    cannot drift apart -- the failure mode here is a *new* construction site
+    passing one argument and forgetting the other.
+
     Pinned on the identity of the callable rather than on any rendered value,
     so a new ``Compositor(...)`` that omits the argument fails here regardless
     of which document it is exercised with -- and on the caller's name, so a
     site that stops being reached fails here too rather than going quiet.
     """
-    seen: list[tuple[str, bool]] = []
+    seen: list[tuple[str, bool, bool]] = []
     original = Compositor.__init__
 
     def spy(self, *args, **kwargs):
         original(self, *args, **kwargs)
         # Frame 1 is whatever called ``Compositor(...)``: the constructor is
         # reached through ``type.__call__``, which adds no Python frame.
-        seen.append((sys._getframe(1).f_code.co_name, self._widen is _widen))
+        seen.append(
+            (
+                sys._getframe(1).f_code.co_name,
+                self._widen is _widen,
+                self._color_mode is None,
+            )
+        )
 
     monkeypatch.setattr(Compositor, "__init__", spy)
 
     for filename in _WIDEN_FIXTURES:
         composite(PSDImage.open(full_name(filename)), force=True)
 
-    fell_back = [caller for caller, is_default in seen if is_default]
+    fell_back = [caller for caller, is_default, _ in seen if is_default]
     assert not fell_back, (
         "%d of %d compositors fell back to the mode-blind "
         "_widen, from %s" % (len(fell_back), len(seen), sorted(set(fell_back)))
     )
 
-    missing = _WIDEN_CALLERS - {caller for caller, _ in seen}
+    modeless = [caller for caller, _, no_mode in seen if no_mode]
+    assert not modeless, "%d of %d compositors were given no colour mode, from %s" % (
+        len(modeless),
+        len(seen),
+        sorted(set(modeless)),
+    )
+
+    missing = _WIDEN_CALLERS - {caller for caller, _, _ in seen}
     assert not missing, (
         "%s built no compositor for these fixtures, so nothing checks that it "
-        "passes widen on" % sorted(missing)
+        "passes the document's facts on" % sorted(missing)
     )
 
 
@@ -281,7 +303,7 @@ def test_the_conversion_is_resolved_once_per_composite(monkeypatch) -> None:
     again each time. Three comments assert this in prose; nothing else asserts
     it in code.
 
-    ``test_every_sub_compositor_inherits_the_conversion`` above does not cover
+    ``test_every_sub_compositor_inherits_the_document_facts`` above does not cover
     it: that spy compares each compositor's ``_widen`` against the mode-blind
     fallback, so a site building a fresh ``make_widen(psd)`` of its own would
     satisfy it. The compositor count is asserted here for the same reason --

--- a/tests/psd_tools/composite/test_widen.py
+++ b/tests/psd_tools/composite/test_widen.py
@@ -214,17 +214,17 @@ def test_widened_grey_survives_the_icc_round_trip() -> None:
 # checked to still reach each one: a guard that renders a document which no
 # longer builds, say, a stroke sub-compositor keeps passing while covering
 # nothing.
-_WIDEN_CALLERS = frozenset(
+_COMPOSITOR_CALLERS = frozenset(
     {"composite", "_get_group", "_get_object", "_apply_clip_layers"}
 )
 
 # Between them these reach all four. Neither does alone: the clipping fixture
 # has no stroked shape, and the stroke fixture has no group.
-_WIDEN_FIXTURES = ["clipping-mask.psd", "effects/stroke-composite.psd"]
+_COMPOSITOR_FIXTURES = ["clipping-mask.psd", "effects/stroke-composite.psd"]
 
 
 def test_every_sub_compositor_inherits_the_document_facts(monkeypatch) -> None:
-    """A sub-compositor that forgets ``widen`` reverts its subtree to replication.
+    """A sub-compositor that forgets ``widen`` or ``color_mode`` loses its subtree.
 
     ``_get_group()`` did exactly that, and because the group compositor is the
     parent of the clip and stroke ones, losing it there took the whole subtree
@@ -257,6 +257,7 @@ def test_every_sub_compositor_inherits_the_document_facts(monkeypatch) -> None:
     """
     seen: list[tuple[str, bool, bool]] = []
     original = Compositor.__init__
+    expected_mode = None
 
     def spy(self, *args, **kwargs):
         original(self, *args, **kwargs)
@@ -266,14 +267,19 @@ def test_every_sub_compositor_inherits_the_document_facts(monkeypatch) -> None:
             (
                 sys._getframe(1).f_code.co_name,
                 self._widen is _widen,
-                self._color_mode is None,
+                # Against the document's own mode rather than merely against
+                # None, so that a site hardcoding a mode of its own fails here
+                # too.
+                self._color_mode != expected_mode,
             )
         )
 
     monkeypatch.setattr(Compositor, "__init__", spy)
 
-    for filename in _WIDEN_FIXTURES:
-        composite(PSDImage.open(full_name(filename)), force=True)
+    for filename in _COMPOSITOR_FIXTURES:
+        psd = PSDImage.open(full_name(filename))
+        expected_mode = psd.color_mode
+        composite(psd, force=True)
 
     fell_back = [caller for caller, is_default, _ in seen if is_default]
     assert not fell_back, (
@@ -281,14 +287,13 @@ def test_every_sub_compositor_inherits_the_document_facts(monkeypatch) -> None:
         "_widen, from %s" % (len(fell_back), len(seen), sorted(set(fell_back)))
     )
 
-    modeless = [caller for caller, _, no_mode in seen if no_mode]
-    assert not modeless, "%d of %d compositors were given no colour mode, from %s" % (
-        len(modeless),
-        len(seen),
-        sorted(set(modeless)),
+    wrong_mode = [caller for caller, _, mismatched in seen if mismatched]
+    assert not wrong_mode, (
+        "%d of %d compositors did not carry the document's colour mode, from %s"
+        % (len(wrong_mode), len(seen), sorted(set(wrong_mode)))
     )
 
-    missing = _WIDEN_CALLERS - {caller for caller, _, _ in seen}
+    missing = _COMPOSITOR_CALLERS - {caller for caller, _, _ in seen}
     assert not missing, (
         "%s built no compositor for these fixtures, so nothing checks that it "
         "passes the document's facts on" % sorted(missing)


### PR DESCRIPTION
Closes #746.

## The bug

The six non-separable blend modes decided everything by the width of their
operands. #745 gave every width but three and four a fallback to `normal`, which
left a multichannel document's two colliding plate counts still blending:

| spot plates | before | after |
| --- | --- | --- |
| 1, 2, 5+ | `normal` (#735) | `normal` |
| **3** | **blended as if the plates were R, G and B** | `normal` |
| **4** | **fourth plate read as CMYK black generation** | `normal` |

The issue filed the 4-plate row. The 3-plate row is the issue's own table being
wrong — it lists 3 as already falling back, and it does not: width 3 goes
straight into the RGB helpers. Measured over an opaque backdrop, all six modes
differed from `Normal` by up to 0.7 at three plates and 1.0 at four. Three plates
is also the shape the only multichannel fixture in the corpus has, so this is the
more reachable of the two. Both rows are fixed here under one rule, at the user's
direction.

## The fix

A spot plate has no hue or luminosity to read at any count, so `MULTICHANNEL`
falls back ahead of the width tests, with a log message that names the mode — for
three and four plates the width is the wrong diagnosis to report.

The mode reaches the blend functions through a new `get_blend_func()`, which
binds it to the six wrappers `non_separable()` builds and returns everything else
untouched. Binding across `BLEND_FUNC` wholesale is not an option: `color_dodge`
and `color_burn` already have a third parameter of their own. `BLEND_FUNC` itself
is unchanged and stays the mode-blind table.

`Compositor` carries `color_mode` the way it already carries `widen`, threaded at
all four construction sites, since `_apply_source()` holds no document handle.

Once multichannel returns first, `Cs.shape[2] == 4` implies CMYK — `EXPECTED_CHANNELS`
fixes every other mode at 1 or 3, and `_assert_source_fits` rejects a wider
source. A guard on that was written and then removed: it was unreachable, and the
premise it defended is pinned directly instead by
`test_only_cmyk_is_four_channels_wide`.

## Tests

- `test_blend.py`: all six at widths 1–5 with `MULTICHANNEL` return exactly
  `normal` **and** log the mode message — at 1, 2 and 5 the #735 width fallback
  returns `normal` too, so the equality alone would not discriminate; the
  mode/width pairs that do blend (RGB, indexed, Lab, CMYK, and no mode at all);
  the two-argument default; `get_blend_func`'s binding, its `normal` default for
  `PASS_THROUGH` and unknown keys, and the descriptor-key family effects and
  strokes use.
- `test_composite.py`: end-to-end at both plate counts over an opaque backdrop,
  pinned against the same document at `Normal`. The backdrop must be passed in
  opaque or `_apply_source`'s `(1 - alpha_b) * color + alpha_b * blend(...)`
  collapses to the source and the blend result never reaches the output.
- `test_widen.py`: the sub-compositor threading guard now checks `widen` and
  `color_mode` in one spy, against the document's own mode rather than against
  `None`, so a site that hardcodes a mode fails it too.

Verification: full suite 2731 passed, 3 skipped, 27 xfailed, 2 xpassed. All 590
corpus renders (295 fixtures × force on/off) byte-identical to `main`. Each part
of the fix fails at least one test when reverted on its own.

## Adjacent, not fixed here

**The CMYK round trip this routes to is itself inverted** — filed as #781.
`_cmyk2rgb` reads its operands as ink where the canvas holds what is left of it,
so all six modes collapse to a constant on a CMYK document and `color(Cb, Cb)` is
not the identity. That is #747's family, pre-existing, and orthogonal: #746
settles which modes reach the round trip, not what it computes. The second commit
here exists to stop this PR's own prose and tests from reading as though that
path were correct — `test_composite_cmyk_still_takes_the_round_trip_...` pins
routing, not arithmetic, and says so.

Also corrected, being prose the diff sits on top of: the "keyed on the source"
comment (false since #749 — `_fit_source` widens at the door), the claim that
indexed documents are one channel wide at the blend (`EXPECTED_CHANNELS` fixes
them at three), and a `.. note:` that never rendered for want of a second colon.
#735's changelog entry described the width-only rule this replaces; since both
land in 1.19.0 and cover one behaviour, they are merged into a single entry here
citing both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
