### PR TITLE
fix: blend CMYK on the CMY complement, as Photoshop does

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,26 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Blend the six non-separable modes on a CMYK document the way Photoshop
+  does -- on the CMY complement, with K carried across -- instead of through a
+  round trip that collapsed every one of them to a constant (#781). ``Hue``,
+  ``Saturation``, ``Color``, ``Luminosity``, ``Darker Color`` and ``Lighter
+  Color`` returned full CMY whatever their operands, so blending a colour with
+  itself did not return that colour: the conversion read the canvas as ink where
+  it holds what is left of it, the same inversion #747 fixed for fills. Two
+  narrower faults went with it -- K was taken from the source for all four
+  component modes where Photoshop takes the backdrop's for three of them, and
+  ``Darker``/``Lighter Color`` dropped the chosen operand's K and left K out of
+  the comparison that chooses. Measured against Photoshop 2026 over six CMYK
+  colour pairs, all six now land within one 8-bit step, and
+  ``blend-modes/cmyk-blend-modes.psd`` falls from 0.026612 to 0.000179 mean
+  squared error against its own merged preview -- it was xfailed as "Fix me!"
+  and now passes.
+
+  **Rendering change**: a CMYK document using any of these six modes renders
+  differently. RGB, Lab, grayscale and multichannel documents are unaffected;
+  one fixture in the corpus moves, and it moves toward Photoshop.
+
 - [fix] Degrade the six non-separable blend modes -- ``Hue``, ``Saturation``,
   ``Color``, ``Luminosity``, ``Darker Color`` and ``Lighter Color`` -- on every
   document Photoshop does not offer them on, instead of crashing or reading the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,8 @@ Changelog
   component modes where Photoshop takes the backdrop's for three of them, and
   ``Darker``/``Lighter Color`` dropped the chosen operand's K and left K out of
   the comparison that chooses. Measured against Photoshop 2026 over six CMYK
-  colour pairs, all six now land within one 8-bit step, and
+  colour pairs, all six now land within 1.2/255 -- 8-bit quantization alone is
+  1/255 -- and
   ``blend-modes/cmyk-blend-modes.psd`` falls from 0.026612 to 0.000179 mean
   squared error against its own merged preview -- it was xfailed as "Fix me!"
   and now passes.

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -45,11 +45,16 @@ Blend mode categories:
 - ``saturation``: Preserves luminosity and hue, replaces saturation
 - ``color``: Preserves luminosity, replaces hue and saturation
 - ``luminosity``: Preserves hue and saturation, replaces luminosity
+- ``darker_color``, ``lighter_color``: Return whichever operand is darker or
+  lighter, whole -- listed under Darken and Lighten above, but non-separable
+  like the four here, and wrapped by the same guards
 
 Implementation details:
 
 - Separable blend modes process each color channel independently
-- Non-separable modes convert to HSL color space first
+- Non-separable modes read all three channels together, through the ``_lum``
+  and ``_sat`` helpers below; on CMYK they use the CMY complement and carry K
+  across untouched (#781)
 - All functions expect normalized float32 arrays (0.0-1.0 range)
 - Division by zero is protected with small epsilon values
 
@@ -74,7 +79,7 @@ document's colour mode where the function needs it.
 
 import functools
 import logging
-from typing import Callable
+from typing import Callable, Literal
 
 import numpy as np
 
@@ -262,35 +267,79 @@ def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 _MODE_AWARE: set[Callable] = set()
 
 
-# Non-separable blending must be in RGB. CMYK should be first converted to RGB,
-# blended, then CMY components should be retrieved from RGB results. K
-# component is K of Cb for hue, saturation, and color blending, and K of Cs for
-# luminosity.
-def non_separable(k: str = "s"):
-    """Wrap non-separable blending function for CMYK handling.
+# Non-separable blending happens on the CMY complement, which is what the
+# canvas already holds (#747: "the transform yields ink; the canvas counts what
+# is left"). There is no conversion to RGB and back: Photoshop blends those
+# three channels directly and carries K across from one operand -- K of Cb for
+# hue, saturation and color, K of Cs for luminosity. Scripted against Photoshop
+# 2026 over six CMYK colour pairs, that reproduces all four modes to within one
+# 8-bit step; converting through RGB first, by any formula tried, does not
+# (#781).
+def _guarded(func, apply):
+    """Wrap *apply* in the two fallbacks every non-separable mode shares.
 
-    The wrapped functions are RGB-only by construction: the helpers below index
-    channels 0, 1 and 2 by name. A three-channel source reaches them unchanged
-    and a four-channel CMYK one round-trips through RGB. Anything else falls
-    back to :py:func:`normal` rather than raising or inventing a result.
+    ``func`` is only ever the undecorated function, for its name in the log and
+    for :py:func:`functools.wraps`; ``apply`` is what actually blends.
+    """
 
-    What "anything else" is takes both the colour mode and the width to decide,
-    and :py:func:`get_blend_func` is what supplies the mode:
+    @functools.wraps(func)
+    def _blend_fn(
+        Cb: np.ndarray, Cs: np.ndarray, color_mode: ColorMode | None = None
+    ) -> np.ndarray:
+        if color_mode == ColorMode.MULTICHANNEL:
+            # Ahead of the width test, and with a message of its own: for three
+            # or four plates the width is the wrong diagnosis, and those are
+            # exactly the two counts that used to blend rather than fall back.
+            logger.debug(
+                "%s blend is not defined on a multichannel document; "
+                "falling back to normal",
+                func.__name__,
+            )
+            return normal(Cb, Cs)
+        if Cs.shape[2] not in (3, 4):
+            # The canvas width, and inside the compositor the document's:
+            # ``Compositor._fit_source()`` widens a one-channel source at the
+            # door, so every array reaching here from there is exactly that wide
+            # (#749). A direct caller can hand over any width, which is why this
+            # is a fallback and not an assertion.
+            logger.debug(
+                "%s blend is not defined for a %d-channel source; "
+                "falling back to normal",
+                func.__name__,
+                Cs.shape[2],
+            )
+            return normal(Cb, Cs)
+        return apply(Cb, Cs)
 
-    - **Multichannel** falls back at every plate count, and is checked first
-      for that reason. Its channels are spot inks, so a hue or a luminosity read off
-      them is meaningless whether there are three of them or thirty; keying on
-      the width alone had four plates claimed as CMYK -- the fourth ink blended
-      as black generation -- and three blended as if they were R, G and B
-      (#746).
-    - **One channel** falls back on the width: grayscale, duotone and bitmap
-      are each one channel wide, and Photoshop offers none of the six on any of
+    _MODE_AWARE.add(_blend_fn)
+    return _blend_fn
+
+
+def non_separable(k: Literal["b", "s"]):
+    """Wrap a component blend -- Hue, Saturation, Color or Luminosity.
+
+    The wrapped functions are three-channel by construction: the helpers below
+    index channels 0, 1 and 2 by name. RGB reaches them unchanged. CMYK hands
+    them its first three channels -- the CMY complement -- and gets K back from
+    whichever operand *k* names, ``"b"`` for the backdrop or ``"s"`` for the
+    source. There is no default: taking K from the wrong operand is invisible in
+    every RGB document and wrong in every CMYK one, which is how it went
+    unnoticed until #781.
+
+    Any other width falls back to :py:func:`normal` rather than raising or
+    inventing a result, and so does a multichannel document at any plate count:
+
+    - **Multichannel** falls back, and is checked first for that reason. Its
+      channels are spot inks, so a hue or a luminosity read off them is
+      meaningless whether there are three of them or thirty; keying on the width
+      alone had four plates claimed as CMYK and three blended as if they were R,
+      G and B (#746).
+    - **One channel** falls back on the width: grayscale, duotone and bitmap are
+      each one channel wide, and Photoshop offers none of the six on any of
       them. Two channels, and five or more, likewise.
-    - **CMYK** round-trips through RGB. **RGB** blends directly, and so does
-      indexed, whose canvas :py:data:`~psd_tools.api.utils.EXPECTED_CHANNELS`
-      fixes at three channels. (Whether an indexed *layer* arrives as palette
-      colours or as raw indices is a separate question this does not settle;
-      the palette is applied on the image-data path only.)
+    - **CMYK** blends its CMY complement. **RGB** blends directly, and so does
+      indexed, whose canvas
+      :py:data:`~psd_tools.api.utils.EXPECTED_CHANNELS` fixes at three.
 
     Photoshop offers none of the six on any of the modes that fall back.
     Scripted against Photoshop 2026, a grayscale document rejects every one with
@@ -303,7 +352,7 @@ def non_separable(k: str = "s"):
 
     With no mode to ask -- a bare :py:class:`~psd_tools.composite.Compositor`,
     or one of these functions called directly -- the width decides alone, as it
-    did before #746, and four channels round-trip as CMYK. That is a guess, and
+    did before #746, and four channels are taken for CMYK. That is a guess, and
     on a four-plate multichannel array it is the wrong one; it is the same guess
     the whole module made before #746, kept because a caller who supplies no
     document is not asking to be told which mode it has.
@@ -312,89 +361,62 @@ def non_separable(k: str = "s"):
     module's pre-existing treatment of Lab, not something the fallback decides,
     and it is the right side to leave Lab on: Photoshop does offer all six modes
     on a Lab document.
-
-    .. note::
-
-       This implementation is still inaccurate. The CMYK round trip in
-       particular reads its operands as ink where the compositor's canvas holds
-       what is left of it, so ``_cmyk2rgb`` inverts them: the six modes
-       collapse to a constant on a CMYK document, and blending an operand with
-       itself is not the identity it must be. That is the same inversion #747
-       fixed in ``composite/paint.py`` and is untouched here; #746 settled only
-       which modes reach the round trip, not what it computes.
     """
 
     def decorator(func):
-        @functools.wraps(func)
-        def _blend_fn(
-            Cb: np.ndarray, Cs: np.ndarray, color_mode: ColorMode | None = None
-        ) -> np.ndarray:
-            if color_mode == ColorMode.MULTICHANNEL:
-                # Ahead of the width tests, and with a message of its own: for
-                # three or four plates the width is the wrong diagnosis, and
-                # those are exactly the two counts that used to blend rather
-                # than fall back.
-                logger.debug(
-                    "%s blend is not defined on a multichannel document; "
-                    "falling back to normal",
-                    func.__name__,
-                )
-                return normal(Cb, Cs)
+        def apply(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
             if Cs.shape[2] == 4:
-                # Four channels means CMYK, when a mode was supplied at all:
-                # multichannel is the only other mode whose canvas can be that
-                # wide, and it returned above.
-                # ``tests/psd_tools/composite/test_blend.py`` pins that premise
-                # on ``api.utils.EXPECTED_CHANNELS``. With no mode supplied this
-                # is the guess the docstring describes, not a deduction -- and
-                # what it computes is wrong either way, see the note above.
-                K = Cs[:, :, 3:4] if k == "s" else Cb[:, :, 3:4]
-                Cb, Cs = _cmyk2rgb(Cb), _cmyk2rgb(Cs)
-                return np.concatenate((_rgb2cmy(func(Cb, Cs), K), K), axis=2)
-            if Cs.shape[2] != 3:
-                # The canvas width, and inside the compositor the
-                # document's: ``Compositor._fit_source()`` widens a one-channel
-                # source at the door, so every array reaching here from there is
-                # exactly that wide (#749). A direct caller can hand over any
-                # width, which is why this is a fallback and not an assertion.
-                logger.debug(
-                    "%s blend is not defined for a %d-channel source; "
-                    "falling back to normal",
-                    func.__name__,
-                    Cs.shape[2],
-                )
-                return normal(Cb, Cs)
+                K = Cb[:, :, 3:4] if k == "b" else Cs[:, :, 3:4]
+                return np.concatenate((func(Cb[:, :, :3], Cs[:, :, :3]), K), axis=2)
             return func(Cb, Cs)
 
-        _MODE_AWARE.add(_blend_fn)
-        return _blend_fn
+        return _guarded(func, apply)
 
     return decorator
 
 
-def _cmyk2rgb(C: np.ndarray) -> np.ndarray:
-    return np.stack([(1.0 - C[:, :, i]) * (1.0 - C[:, :, 3]) for i in range(3)], axis=2)
+def non_separable_selection(func):
+    """Wrap Darker Color or Lighter Color, which choose between whole pixels.
+
+    These two differ from the four component modes in taking the array whole
+    rather than by its first three channels: they return one operand or the
+    other unchanged, and on CMYK that has to include its K. Photoshop agrees --
+    over six colour pairs its Darker Color is one of the two inputs exactly, K
+    and all -- and forcing K from a fixed operand instead, as #781 found, gave a
+    colour neither input had (#781).
+
+    They also compare a different quantity: :py:func:`_lightness`, which folds K
+    in, where the component modes blend the CMY complement with no K term at
+    all. Both halves of that asymmetry are Photoshop's, not a simplification.
+    """
+    return _guarded(func, func)
 
 
-def _rgb2cmy(C: np.ndarray, K: np.ndarray) -> np.ndarray:
-    K = np.repeat(K, 3, axis=2)
-    color = np.zeros((C.shape[0], C.shape[1], 3), dtype=np.float32)
-    index = K < 1.0
-    color[index] = (1.0 - C[index] - K[index]) / (1.0 - K[index] + _FLOAT_EPSILON)
-    return color
+def _lightness(C: np.ndarray) -> np.ndarray:
+    """How light a colour is, for the two modes that choose between pixels.
+
+    On CMYK the K plate darkens every ink, so it belongs in the comparison:
+    this is ``_lum(CMY) * K``, which is algebraically ``_lum(CMY * K)`` -- the
+    luminance of the naive CMYK-to-RGB conversion. The four component modes
+    deliberately use no K term at all; both halves of that asymmetry are what
+    Photoshop does (#781).
+    """
+    if C.shape[2] == 4:
+        return _lum(C[:, :, :3] * C[:, :, 3:4])
+    return _lum(C)
 
 
-@non_separable()
+@non_separable("b")
 def hue(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(_set_sat(Cs, _sat(Cb)), _lum(Cb))
 
 
-@non_separable()
+@non_separable("b")
 def saturation(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(_set_sat(Cb, _sat(Cs)), _lum(Cb))
 
 
-@non_separable()
+@non_separable("b")
 def color(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(Cs, _lum(Cb))
 
@@ -404,17 +426,17 @@ def luminosity(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     return _set_lum(Cb, _lum(Cs))
 
 
-@non_separable()
+@non_separable_selection
 def darker_color(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
-    index = np.repeat(_lum(Cs) < _lum(Cb), 3, axis=2)
+    index = np.repeat(_lightness(Cs) < _lightness(Cb), Cb.shape[2], axis=2)
     B = Cb.copy()
     B[index] = Cs[index]
     return B
 
 
-@non_separable()
+@non_separable_selection
 def lighter_color(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
-    index = np.repeat(_lum(Cs) > _lum(Cb), 3, axis=2)
+    index = np.repeat(_lightness(Cs) > _lightness(Cb), Cb.shape[2], axis=2)
     B = Cb.copy()
     B[index] = Cs[index]
     return B

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -52,9 +52,12 @@ Blend mode categories:
 Implementation details:
 
 - Separable blend modes process each color channel independently
-- Non-separable modes read all three channels together, through the ``_lum``
-  and ``_sat`` helpers below; on CMYK they use the CMY complement and carry K
-  across untouched (#781)
+- The four component modes read three channels together, through the ``_lum``
+  and ``_sat`` helpers below; on CMYK they blend the CMY complement and carry K
+  across from one operand (#781)
+- ``darker_color`` and ``lighter_color`` return one operand or the other whole.
+  On CMYK that includes its K, and K also weighs in the comparison that chooses
+  -- see ``_lightness`` (#781)
 - All functions expect normalized float32 arrays (0.0-1.0 range)
 - Division by zero is protected with small epsilon values
 
@@ -267,19 +270,18 @@ def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 _MODE_AWARE: set[Callable] = set()
 
 
-# Non-separable blending happens on the CMY complement, which is what the
-# canvas already holds (#747: "the transform yields ink; the canvas counts what
-# is left"). There is no conversion to RGB and back: Photoshop blends those
-# three channels directly and carries K across from one operand -- K of Cb for
-# hue, saturation and color, K of Cs for luminosity. Scripted against Photoshop
-# 2026 over six CMYK colour pairs, that reproduces all four modes to within one
-# 8-bit step; converting through RGB first, by any formula tried, does not
-# (#781).
+# The one place the two fallbacks are applied, so that both decorators below
+# get them and cannot drift apart. What they are and why is documented on
+# :py:func:`non_separable`.
 def _guarded(func, apply):
     """Wrap *apply* in the two fallbacks every non-separable mode shares.
 
     ``func`` is only ever the undecorated function, for its name in the log and
-    for :py:func:`functools.wraps`; ``apply`` is what actually blends.
+    for :py:func:`functools.wraps`; ``apply`` is what actually blends. Both
+    operands must be the same width for either decorator's arithmetic to mean
+    anything, so a mismatch takes the fallback rather than reaching it: K would
+    otherwise be an empty slice off a three-channel backdrop, and the mode would
+    quietly return one channel fewer than it was given.
     """
 
     @functools.wraps(func)
@@ -296,17 +298,18 @@ def _guarded(func, apply):
                 func.__name__,
             )
             return normal(Cb, Cs)
-        if Cs.shape[2] not in (3, 4):
+        if Cs.shape[2] not in (3, 4) or Cb.shape[2] != Cs.shape[2]:
             # The canvas width, and inside the compositor the document's:
             # ``Compositor._fit_source()`` widens a one-channel source at the
             # door, so every array reaching here from there is exactly that wide
             # (#749). A direct caller can hand over any width, which is why this
             # is a fallback and not an assertion.
             logger.debug(
-                "%s blend is not defined for a %d-channel source; "
-                "falling back to normal",
+                "%s blend is not defined for a %d-channel source against a "
+                "%d-channel backdrop; falling back to normal",
                 func.__name__,
                 Cs.shape[2],
+                Cb.shape[2],
             )
             return normal(Cb, Cs)
         return apply(Cb, Cs)
@@ -315,6 +318,13 @@ def _guarded(func, apply):
     return _blend_fn
 
 
+# Non-separable blending happens on the CMY complement, which is what the
+# canvas already holds (#747: "the transform yields ink; the canvas counts what
+# is left"). There is no conversion to RGB and back: Photoshop blends those
+# three channels directly and carries K across from one operand -- K of Cb for
+# hue, saturation and color, K of Cs for luminosity. Scripted against Photoshop
+# 2026 over six CMYK colour pairs, that reproduces all four modes to within
+# 1.2/255; converting through RGB first, by any formula tried, does not (#781).
 def non_separable(k: Literal["b", "s"]):
     """Wrap a component blend -- Hue, Saturation, Color or Luminosity.
 
@@ -388,6 +398,10 @@ def non_separable_selection(func):
     They also compare a different quantity: :py:func:`_lightness`, which folds K
     in, where the component modes blend the CMY complement with no K term at
     all. Both halves of that asymmetry are Photoshop's, not a simplification.
+
+    The multichannel and width fallbacks are the same ones
+    :py:func:`non_separable` documents; both decorators get them from
+    :py:func:`_guarded`.
     """
     return _guarded(func, func)
 

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -21,6 +21,7 @@ from psd_tools.composite.blend import (
     normal,
     saturation,
 )
+import psd_tools.composite.blend as blend_module
 from psd_tools.constants import BlendMode, ColorMode
 from psd_tools.terminology import Enum
 from .test_composite import check_composite_quality
@@ -69,6 +70,11 @@ def test_lighter_color_descriptor_key() -> None:
         # Total test
         ("blend-modes/rgb-blend-modes.psd",),
         ("blend-modes/gray-blend-modes.psd",),
+        # Was xfailed as "# Fix me!" until #781: the six non-separable modes
+        # went through a CMYK round trip that read the canvas as ink where it
+        # holds what is left of it, and the whole document's error sat at
+        # 0.026612 against this 0.01 threshold. It is 0.000179 now.
+        ("blend-modes/cmyk-blend-modes.psd",),
     ],
 )
 def test_blend_quality(filename: str) -> None:
@@ -79,7 +85,6 @@ def test_blend_quality(filename: str) -> None:
     ("filename",),
     [
         ("blend-modes/dissolve.psd",),
-        ("blend-modes/cmyk-blend-modes.psd",),  # Fix me!
     ],
 )
 @pytest.mark.xfail
@@ -297,10 +302,10 @@ def test_non_separable_still_blends_the_modes_with_ground_truth(
     """The fallbacks must not swallow the cases that do have ground truth.
 
     Photoshop offers all six on an RGB, a Lab and a CMYK document, so those
-    three keep blending -- the three-channel ones directly, CMYK through the
-    RGB round trip. So does an array with no mode attached, which is what a
-    bare ``Compositor`` or a direct call hands over: there the width decides
-    alone, as it did before #746.
+    three keep blending -- the three-channel ones directly, CMYK on its CMY
+    complement with K carried across. So does an array with no mode attached,
+    which is what a bare ``Compositor`` or a direct call hands over: there the
+    width decides alone, as it did before #746.
 
     Indexed rides along on width rather than on ground truth. Photoshop
     flattens on conversion to Indexed Color, the same argument that keeps
@@ -308,9 +313,10 @@ def test_non_separable_still_blends_the_modes_with_ground_truth(
     pins is that the mode-keyed branch singles out multichannel and leaves
     every other three-channel canvas on the RGB path.
 
-    What none of these rows claims is that the CMYK result is *right*: the
-    round trip inverts its operands, as ``non_separable``'s note records. They
-    pin which path a mode takes, not what the path computes.
+    What the CMYK row is worth is settled separately, by
+    ``test_non_separable_matches_photoshop_on_cmyk`` below: since #781 the
+    result is Photoshop's to within one 8-bit step, where this row only asks
+    that some blending happened at all.
     """
     Cb, Cs = _mixed_pair(channels)
     with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
@@ -386,6 +392,151 @@ def test_non_separable_defaults_to_deciding_by_width(func: Callable) -> None:
     Cb, Cs = _mixed_pair(4)
     assert np.array_equal(func(Cb.copy(), Cs.copy()), func(Cb.copy(), Cs.copy(), None))
     assert not np.array_equal(func(Cb.copy(), Cs.copy()), normal(Cb, Cs))
+
+
+# Photoshop 2026's own answers, U.S. Web Coated (SWOP) v2, in ink percent:
+# ``(backdrop, source, {mode: result})``. Authored by scripting Photoshop --
+# fill a Background, add a layer, set ``blendMode``, flatten, and read the pixel
+# back through ``doc.colorSamplers`` -- so these are its render and not a
+# derivation. The pairs are off the neutral axis and differ in every channel;
+# pair 3's near-neutral backdrop and pair 5's paper white are the two that
+# discriminate hardest (see the test below).
+PHOTOSHOP_CMYK: list[tuple[list[float], list[float], dict[str, list[float]]]] = [
+    (
+        [80, 20, 10, 5],
+        [10, 70, 60, 20],
+        {
+            "hue": [0, 53.73, 45.1, 5.1],
+            "saturation": [73.73, 22.35, 13.73, 5.1],
+            "color": [0, 53.73, 45.1, 5.1],
+            "luminosity": [93.73, 33.73, 23.53, 20],
+            "darker_color": [9.8, 69.8, 60, 20],
+            "lighter_color": [80, 20, 9.8, 5.1],
+        },
+    ),
+    (
+        [10, 70, 60, 20],
+        [80, 20, 10, 5],
+        {
+            "hue": [87.45, 36.08, 27.45, 20],
+            "saturation": [2.75, 72.94, 61.57, 20],
+            "color": [93.73, 33.73, 23.53, 20],
+            "luminosity": [0, 53.73, 45.1, 5.1],
+            "darker_color": [9.8, 69.8, 60, 20],
+            "lighter_color": [80, 20, 9.8, 5.1],
+        },
+    ),
+    (
+        [5, 5, 90, 0],
+        [70, 60, 0, 10],
+        {
+            "hue": [17.65, 14.9, 0, 0],
+            "saturation": [6.67, 6.67, 76.47, 0],
+            "color": [17.65, 14.9, 0, 0],
+            "luminosity": [50.98, 50.98, 99.61, 9.8],
+            "darker_color": [69.8, 60, 0, 9.8],
+            "lighter_color": [5.1, 5.1, 89.8, 0],
+        },
+    ),
+    (
+        [40, 40, 40, 40],
+        [0, 90, 30, 0],
+        {
+            "hue": [40, 40, 40, 40],
+            "saturation": [40, 40, 40, 40],
+            "color": [0, 63.53, 21.18, 40],
+            "luminosity": [56.08, 56.08, 56.08, 0],
+            "darker_color": [40, 40, 40, 40],
+            "lighter_color": [0, 89.8, 29.8, 0],
+        },
+    ),
+    (
+        [95, 0, 30, 60],
+        [20, 15, 85, 2],
+        {
+            "hue": [27.06, 21.18, 99.61, 60],
+            "saturation": [78.43, 8.24, 30.2, 60],
+            "color": [27.45, 22.35, 92.55, 60],
+            "luminosity": [72.16, 0, 22.75, 1.96],
+            "darker_color": [94.9, 0, 29.8, 60],
+            "lighter_color": [20, 14.9, 85.1, 1.96],
+        },
+    ),
+    (
+        [0, 0, 0, 0],
+        [50, 40, 30, 10],
+        {
+            "hue": [0, 0, 0, 0],
+            "saturation": [0, 0, 0, 0],
+            "color": [0, 0, 0, 0],
+            "luminosity": [41.96, 41.96, 41.96, 9.8],
+            "darker_color": [49.8, 40, 29.8, 9.8],
+            "lighter_color": [0, 0, 0, 0],
+        },
+    ),
+]
+
+# One 8-bit step is 1/255, and Photoshop reports through an 8-bit sampler, so
+# the floor here is quantization and not model error: the worst of the 36 is
+# 1.20/255 and thirteen of them sit at exactly one step. Two steps leaves the
+# assertion loose enough to be stable and tight enough to fail loudly -- every
+# defect #781 fixed moves at least one of these rows by 25 to 148 steps.
+_ONE_STEP = 1.0 / 255.0
+
+
+def _cmyk_canvas(ink: list[float]) -> np.ndarray:
+    """Ink percent as the compositor holds it: a canvas counts what is left."""
+    return (1.0 - np.array(ink, dtype=np.float32) / 100.0).reshape(1, 1, 4)
+
+
+@pytest.mark.parametrize("mode", [f.__name__ for f in NON_SEPARABLE])
+@pytest.mark.parametrize("pair", range(len(PHOTOSHOP_CMYK)), ids=lambda i: "pair%d" % i)
+def test_non_separable_matches_photoshop_on_cmyk(pair: int, mode: str) -> None:
+    """The whole of what #781 fixed, against Photoshop's own render.
+
+    Three separate defects lived in the four-channel branch, and the corpus
+    fixture ``blend-modes/cmyk-blend-modes.psd`` catches only the first even
+    though it exercises all six modes:
+
+    1. The round trip. ``_cmyk2rgb`` computed ``(1 - C) * (1 - K)``, reading the
+       canvas as ink where it holds what is left of it, so all six collapsed to
+       a constant and ``color(Cb, Cb)`` was not ``Cb``. There is no round trip
+       now: Photoshop blends the CMY complement directly, which is what the
+       canvas already holds, and no formula that converts to RGB first came
+       within 6/255 of these numbers.
+    2. Which operand supplies K -- the backdrop's for hue, saturation and
+       color, the source's for luminosity. The code took the source's for all
+       four. Reverting that alone still passes the fixture, and moves pair 4 by
+       148/255 here.
+    3. Darker and Lighter Color return an operand *whole*, K included, and
+       weigh K when deciding which is darker. Reverting either half still passes
+       the fixture; dropping K from the comparison changes no pixel in it at
+       all, while pair 3 -- a near-neutral backdrop against a saturated source
+       -- moves by 128/255.
+
+    So this table is not redundant with the fixture; for two of the three it is
+    the only thing standing.
+    """
+    backdrop, source, expected = PHOTOSHOP_CMYK[pair]
+    blend_fn = getattr(blend_module, mode)
+    result = blend_fn(_cmyk_canvas(backdrop), _cmyk_canvas(source), ColorMode.CMYK)
+    ink = (1.0 - result.ravel()) * 100.0
+    assert ink == pytest.approx(expected[mode], abs=2 * _ONE_STEP * 100.0)
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+def test_non_separable_is_the_identity_on_equal_cmyk_operands(func: Callable) -> None:
+    """Blending a colour with itself must return it (#781).
+
+    The plainest statement of what the inverted round trip broke: it answered
+    full CMY for every input, so even this could not hold. ``hue`` and
+    ``saturation`` come back one ulp out because ``_set_sat`` rebuilds the
+    channels from a sorted comparison rather than passing them through; the
+    other four are exact.
+    """
+    Cb = _cmyk_canvas([37, 12, 68, 21])
+    result = func(Cb.copy(), Cb.copy(), ColorMode.CMYK)
+    assert result == pytest.approx(Cb, abs=1e-6)
 
 
 def test_get_blend_func_binds_the_mode_only_to_the_non_separable_six() -> None:

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -394,7 +394,10 @@ def test_non_separable_defaults_to_deciding_by_width(func: Callable) -> None:
     assert not np.array_equal(func(Cb.copy(), Cs.copy()), normal(Cb, Cs))
 
 
-# Photoshop 2026's own answers, U.S. Web Coated (SWOP) v2, in ink percent:
+# Photoshop 2026's own answers, in ink percent, authored in its default CMYK
+# working space -- U.S. Web Coated (SWOP) v2. The space is provenance, not a
+# parameter: nothing in the model these pin consults a profile, so a document
+# saved in another working space blends by the same arithmetic. Format:
 # ``(backdrop, source, {mode: result})``. Authored by scripting Photoshop --
 # fill a Background, add a layer, set ``blendMode``, flatten, and read the pixel
 # back through ``doc.colorSamplers`` -- so these are its render and not a
@@ -477,8 +480,8 @@ PHOTOSHOP_CMYK: list[tuple[list[float], list[float], dict[str, list[float]]]] = 
 ]
 
 # One 8-bit step is 1/255, and Photoshop reports through an 8-bit sampler, so
-# the floor here is quantization and not model error: the worst of the 36 is
-# 1.20/255 and thirteen of them sit at exactly one step. Two steps leaves the
+# the floor here is quantization and not model error: the worst of the 36 rows
+# is 1.20 steps and none exceeds one and a quarter. Two steps leaves the
 # assertion loose enough to be stable and tight enough to fail loudly -- every
 # defect #781 fixed moves at least one of these rows by 25 to 148 steps.
 _ONE_STEP = 1.0 / 255.0
@@ -512,7 +515,7 @@ def test_non_separable_matches_photoshop_on_cmyk(pair: int, mode: str) -> None:
        weigh K when deciding which is darker. Reverting either half still passes
        the fixture; dropping K from the comparison changes no pixel in it at
        all, while pair 3 -- a near-neutral backdrop against a saturated source
-       -- moves by 128/255.
+       -- moves by 127.5/255.
 
     So this table is not redundant with the fixture; for two of the three it is
     the only thing standing.
@@ -533,10 +536,39 @@ def test_non_separable_is_the_identity_on_equal_cmyk_operands(func: Callable) ->
     ``saturation`` come back one ulp out because ``_set_sat`` rebuilds the
     channels from a sorted comparison rather than passing them through; the
     other four are exact.
+
+    Weak for ``darker_color`` and ``lighter_color``, deliberately kept for
+    symmetry: equal operands make their mask all-false, so they return the
+    backdrop whatever ``_lightness`` computes and whichever operand K would come
+    from. Those two are pinned by the Photoshop table above, not here.
     """
     Cb = _cmyk_canvas([37, 12, 68, 21])
     result = func(Cb.copy(), Cb.copy(), ColorMode.CMYK)
     assert result == pytest.approx(Cb, abs=1e-6)
+
+
+@pytest.mark.parametrize("func", NON_SEPARABLE, ids=lambda f: f.__name__)
+def test_non_separable_falls_back_when_the_operands_disagree_in_width(
+    func: Callable, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Operands of different widths degrade rather than half-blend (#781).
+
+    Unreachable through the compositor -- ``_fit_source()`` brings every source
+    to the canvas width, and the backdrop *is* the canvas -- so this pins a
+    direct caller's blast radius. It is worth pinning because #781 made the
+    failure quieter before making it louder: taking K from the backdrop means a
+    three-channel backdrop under a four-channel source slices ``Cb[:, :, 3:4]``
+    to *nothing*, and ``concatenate`` then returns three channels where four
+    were asked for -- a silent short array rather than the ``IndexError`` the
+    same input used to raise.
+    """
+    Cb = np.full((2, 2, 3), 0.4, dtype=np.float32)
+    Cs = np.full((2, 2, 4), 0.6, dtype=np.float32)
+    with caplog.at_level(logging.DEBUG, logger="psd_tools.composite.blend"):
+        result = func(Cb.copy(), Cs.copy(), ColorMode.CMYK)
+    assert result.shape == (2, 2, 4), "must not silently narrow the result"
+    assert np.array_equal(result, normal(Cb, Cs))
+    assert "4-channel source against a 3-channel backdrop" in caplog.text
 
 
 def test_get_blend_func_binds_the_mode_only_to_the_non_separable_six() -> None:

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -791,22 +791,21 @@ def test_composite_multichannel_with_a_non_separable_blend_mode(
 
 
 @pytest.mark.parametrize("blend_mode", NON_SEPARABLE_MODES)
-def test_composite_cmyk_still_takes_the_round_trip_multichannel_no_longer_does(
+def test_composite_cmyk_still_blends_where_multichannel_no_longer_does(
     blend_mode: BlendMode,
 ) -> None:
     """The colour mode is doing the work above, not the channel count (#746).
 
     The same fixture, the same four channels, the same backdrop -- left tagged
-    CMYK. A fix that fell back on the width of the array rather than on what
-    its channels mean would pass the test above and fail this one, taking the
-    CMYK round trip down with it.
+    CMYK. A fix that fell back on the width of the array rather than on what its
+    channels mean would pass the test above and fail this one, taking CMYK
+    blending down with it.
 
-    Which path CMYK takes is all this pins. It is deliberately not evidence
-    that the path is *correct*: ``_cmyk2rgb`` reads its operands as ink where
-    the canvas holds what is left of it, so the six collapse to a constant on a
-    CMYK document -- which is why they differ from ``Normal`` so emphatically
-    here. See the note on ``blend.non_separable``; that inversion is #747's
-    family and is untouched by #746.
+    That CMYK still blends is all this pins; what it blends *to* is pinned
+    against Photoshop by ``test_blend.test_non_separable_matches_photoshop_on_cmyk``.
+    Until #781 the distinction mattered a great deal -- the four-channel branch
+    collapsed every mode to a constant, so this test passed on output that was
+    wrong in every pixel.
     """
     psd = PSDImage.open(full_name("colormodes/4x4_8bit_cmyk.psd"))
     assert psd.color_mode == ColorMode.CMYK


### PR DESCRIPTION
Closes #781. Follows #782, which settled which modes reach the CMYK branch; this
settles what the branch computes.

## The bug

The six non-separable modes converted CMYK to RGB, blended, and converted back.
`_cmyk2rgb` computed `(1 - C) * (1 - K)`, reading the canvas as **ink** where it
holds what is *left* of it (`widen.py`: *"the transform yields ink; the canvas
counts what is left"*, #747). So every mode returned full CMY whatever its
operands:

```
>>> color(Cb, Cb)                 # blending a colour with itself
array([0., 0., 0., 1.])           # ... is not that colour
>>> darker_color(Cb, Cs) == lighter_color(Cb, Cs)
True                              # ... though they select opposite operands
```

Unlike #735 and #746 this needed no hand-built file: Photoshop offers all six on
an ordinary CMYK document.

## Inverting the formula is not the fix

Scripted Photoshop 2026 over six CMYK colour pairs — 36 ground-truth samples,
read back through `doc.colorSamplers` — and it blends the **CMY complement
directly**, which is what the canvas already holds, carrying K across from one
operand. Max error over the 36:

| model | max error |
| --- | --- |
| today | collapses to a constant |
| the formula inverted properly (`C*K`, `/K`) | 6–83/255 |
| an ICC round trip through sRGB | 135–253/255 |
| **the CMY complement, blended directly** | **1.2/255** (quantization alone is 1.0) |

So `_cmyk2rgb` and `_rgb2cmy` are **deleted** rather than repaired, and the
four-channel branch is one `concatenate`.

## Two more faults were hiding behind the first

Both invisible while everything collapsed to a constant:

- **K came from the wrong operand.** The comment above the decorator was right —
  backdrop for hue/saturation/color, source for luminosity — and the code
  contradicted it: `k` defaulted to `"s"` and five of six sites took the
  default. `k` is **required** now; a silent default is what hid this.
- **Darker/Lighter Color must return an operand whole**, K included, and weigh K
  in the comparison that chooses. They forced K from a fixed operand and
  compared the CMY complement alone, which picks the wrong operand outright when
  a neutral backdrop meets a saturated source.

Photoshop agrees exactly on both, across all six pairs.

## Results

`blend-modes/cmyk-blend-modes.psd` — 164 layers, all six modes, Photoshop's own
merged preview — has sat in `test_blend_quality_xfail` marked `# Fix me!`:

```
0.026612  ->  0.000179     (threshold 0.01)
```

It moves into the passing list; the xfail is deleted. Across 590 corpus renders
(295 fixtures × force on/off) it is the **only** file whose output changes, and
RGB is bit-identical by construction, not merely by measurement — at three
channels the new code is the same call, `_lightness` reduces to `_lum`, and the
mask repeat is unchanged.

## Tests

The plan review earned its keep here: **the fixture discriminates almost
nothing.** Reverting the K-source still passes it (0.000217); reverting the
whole-pixel selection still passes it (0.000192); dropping K from the comparison
changes **not one pixel** in it. So the 36-row Photoshop table is not redundant
with the fixture — for two of the three defects it is the only thing standing.
Piecewise revert now costs 18, 2 and 3 failures respectively.

Tolerance is two 8-bit steps on the 0–100 ink scale (`2 * 100/255` = 0.784),
against a measured worst of 1.20 steps; the three reverts overshoot it by 25–148
steps. The working space is authoring provenance only — nothing in the model
consults a profile.

Also pinned: the identity `color(Cb, Cb) == Cb`, and a width-mismatch fallback
(below).

## The second commit

Review of the first found that taking K from the backdrop made an *existing*
failure quieter: a three-channel backdrop under a four-channel source slices
`Cb[:, :, 3:4]` to nothing, so `concatenate` returned three channels where four
were asked for — a silent short array where the same input used to raise
`IndexError`. `_guarded` now degrades on a width mismatch and logs both widths.
Unreachable through `Compositor` (`_fit_source` brings every source to the canvas
width), so it is a direct caller's blast radius only.

It also corrects three numbers of mine, all overstated the same way — "within one
8-bit step" for a measured 1.20, a step count that held only under a quarter-step
band, and 128 for 127.5 — and prose that described the four component modes as if
it covered the two selection ones.

Verification: 2780 passed, 3 skipped, 26 xfailed, 2 xpassed (both pre-existing on
`main`); ruff, mypy, sphinx clean.

## Not fixed here

#189 (separable CMYK blending accuracy) is untouched and remains open. The
`_lightness` helper is the luminance of the naive CMYK→RGB conversion, so that
conversion survives in the one place it belongs — deciding which of two colours
is darker — while the component modes deliberately use no K term at all. Both
halves of that asymmetry are Photoshop's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
