### PR TITLE
fix: correct soft light, vivid light and hard mix against Photoshop

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,8 +9,8 @@ Changelog
   reported it. Rendering changes for RGB, Grayscale and CMYK alike wherever
   those three are used; ``Vivid Light`` was the largest error in the suite and
   had been xfailed as a known discrepancy. The other 17 separable modes already
-  matched Photoshop to within 8-bit quantization on CMYK and are now pinned
-  there against its own render (#189, #784).
+  matched Photoshop on CMYK to within 1.4/255 and are now pinned there against
+  its own render (#189, #784).
 
 - [fix] Blend the six non-separable modes on a CMYK document the way Photoshop
   does -- on the CMY complement, with K carried across -- instead of through a

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [fix] Correct ``Soft Light``, ``Vivid Light`` and ``Hard Mix``, which
+  disagreed with Photoshop in every colour mode -- not only in CMYK, where #189
+  reported it. Rendering changes for RGB, Grayscale and CMYK alike wherever
+  those three are used; ``Vivid Light`` was the largest error in the suite and
+  had been xfailed as a known discrepancy. The other 17 separable modes already
+  matched Photoshop to within 8-bit quantization on CMYK and are now pinned
+  there against its own render (#189, #PRNUM).
+
 - [fix] Blend the six non-separable modes on a CMYK document the way Photoshop
   does -- on the CMY complement, with K carried across -- instead of through a
   round trip that collapsed every one of them to a constant (#781). ``Hue``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Changelog
   those three are used; ``Vivid Light`` was the largest error in the suite and
   had been xfailed as a known discrepancy. The other 17 separable modes already
   matched Photoshop to within 8-bit quantization on CMYK and are now pinned
-  there against its own render (#189, #PRNUM).
+  there against its own render (#189, #784).
 
 - [fix] Blend the six non-separable modes on a CMYK document the way Photoshop
   does -- on the CMY complement, with K carried across -- instead of through a

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -162,7 +162,10 @@ def hard_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 
 def soft_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
-    index = Cs <= 0.25
+    # D is a function of the backdrop alone. Keying its piecewise on Cs instead
+    # left every Cb <= 0.25 pixel on the sqrt arm, up to 12.6 steps of 1/255
+    # away from Photoshop (#189).
+    index = Cb <= 0.25
     index_not = ~index
     D = np.zeros_like(Cb, dtype=np.float32)
     D[index] = ((16 * Cb[index] - 12) * Cb[index] + 4) * Cb[index]
@@ -187,11 +190,19 @@ def vivid_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     the contrast.
     """
 
-    Cs2 = Cs * 2
-    index = Cs > 0.5
-    B = color_burn(Cb, Cs2)
-    D = color_dodge(Cb, Cs2 - 1)
-    B[index] = D[index]
+    # Deliberately not color_burn/color_dodge: those carry the spec's backdrop
+    # special cases -- Cb == 1 burns to 1, Cb == 0 dodges to 0 -- and Photoshop
+    # does not apply them here. Inside Vivid Light the *source* extreme wins,
+    # so Cs == 0 burns to 0 and Cs == 1 dodges to 1 whatever the backdrop. Plain
+    # Color Burn and Color Dodge do keep the backdrop cases, so the two really
+    # do differ; both readings are pinned against Photoshop's own render (#189).
+    burn = Cs <= 0.5
+    dodge = ~burn
+    B = np.zeros_like(Cb, dtype=np.float32)
+    B[burn] = 1 - np.minimum(1, (1 - Cb[burn]) / (2 * Cs[burn] + _FLOAT_EPSILON))
+    B[dodge] = np.minimum(1, Cb[dodge] / (2 * (1 - Cs[dodge]) + _FLOAT_EPSILON))
+    B[Cs == 0] = 0
+    B[Cs == 1] = 1
     return B
 
 
@@ -239,14 +250,22 @@ def subtract(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 def hard_mix(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Adds the red, green and blue channel values of the blend color to the RGB
-    values of the base color. If the resulting sum for a channel is 255 or
-    greater, it receives a value of 255; if less than 255, a value of 0.
+    values of the base color. If the resulting sum for a channel is above 255 it
+    receives a value of 255, and below 255 a value of 0; on exactly 255 the
+    backdrop decides, as the comment below sets out.
     Therefore, all blended pixels have red, green, and blue channel values of
     either 0 or 255. This changes all pixels to primary additive colors (red,
     green, or blue), white, or black.
     """
+    # Photoshop breaks the exact tie toward the backdrop: where Cb + Cs == 1 the
+    # result is 1 only where Cb > 0.5. That tie is a real case and not float
+    # noise -- two complementary 8-bit values sum to exactly 1.0 in float32 for
+    # all 256 of them -- so it is testable rather than something to fudge past.
+    # The 0.999999 factor this replaces decided every tie the other way and got
+    # 9 of 145 measured boundary samples wrong (#189).
+    total = Cb + Cs
     B = np.zeros_like(Cb, dtype=np.float32)
-    B[(Cb + 0.999999 * Cs) >= 1] = 1  # There seems a weird numerical issue.
+    B[(total > 1) | ((total == 1) & (Cb > 0.5))] = 1
     return B
 
 

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -31,7 +31,7 @@ Blend mode categories:
 - ``overlay``: Combination of multiply and screen
 - ``soft_light``: Soft version of overlay
 - ``hard_light``: Hard version of overlay
-- ``vivid_light``: Combination of color dodge and burn
+- ``vivid_light``: Burns or dodges to shift contrast
 - ``linear_light``: Combination of linear dodge and burn
 - ``pin_light``: Replaces colors based on brightness
 - ``hard_mix``: Posterizes to primary colors
@@ -251,18 +251,21 @@ def hard_mix(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Adds the red, green and blue channel values of the blend color to the RGB
     values of the base color. If the resulting sum for a channel is above 255 it
-    receives a value of 255, and below 255 a value of 0; on exactly 255 the
-    backdrop decides, as the comment below sets out.
+    receives a value of 255, and below 255 a value of 0; on exactly 255 it is
+    255 only where the base is above half, as the comment below sets out.
     Therefore, all blended pixels have red, green, and blue channel values of
     either 0 or 255. This changes all pixels to primary additive colors (red,
     green, or blue), white, or black.
     """
-    # Photoshop breaks the exact tie toward the backdrop: where Cb + Cs == 1 the
-    # result is 1 only where Cb > 0.5. That tie is a real case and not float
-    # noise -- two complementary 8-bit values sum to exactly 1.0 in float32 for
-    # all 256 of them -- so it is testable rather than something to fudge past.
-    # The 0.999999 factor this replaces decided every tie the other way and got
-    # 9 of 145 measured boundary samples wrong (#189).
+    # Where Cb + Cs == 1 exactly, Photoshop answers 1 only where Cb > 0.5. On
+    # that line Cb > 0.5, Cb > Cs and Cs < 0.5 are one and the same predicate,
+    # so which of the three Photoshop actually tests is not observable; all
+    # reproduce the 145 measured boundary samples. The tie is a real case and
+    # not float noise -- complementary values sum to exactly 1.0 in float32 at
+    # 8- and 16-bit alike -- though only a backdrop that reaches here unrounded
+    # can land on it. The 0.999999 factor this replaces did worse than lose the
+    # tie: it read as ``total >= 1 + 1e-6 * Cs``, so it mis-answered a whole
+    # band above the threshold, and got 9 of the 145 wrong (#189).
     total = Cb + Cs
     B = np.zeros_like(Cb, dtype=np.float32)
     B[(total > 1) | ((total == 1) & (Cb > 0.5))] = 1

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -483,7 +483,9 @@ PHOTOSHOP_CMYK: list[tuple[list[float], list[float], dict[str, list[float]]]] = 
 # the floor here is quantization and not model error: the worst of the 36 rows
 # is 1.20 steps and none exceeds one and a quarter. Two steps leaves the
 # assertion loose enough to be stable and tight enough to fail loudly -- every
-# defect #781 fixed moves at least one of these rows by 25 to 148 steps.
+# defect #781 fixed moves at least one of these rows by 25 to 148 steps. The
+# separable table further down shares this tolerance on the same reasoning; its
+# own worst row is 1.13 steps, and the defects #189 fixed move rows by 6 to 255.
 _ONE_STEP = 1.0 / 255.0
 
 
@@ -621,7 +623,7 @@ def test_get_blend_func_degrades_the_descriptor_keys_too(key: bytes) -> None:
 
 # The separable half of the same experiment that produced ``PHOTOSHOP_CMYK``
 # above, and the answer to #189: 17 of the 20 modes here already agreed with
-# Photoshop to within quantization, so the compositor's CMYK convention -- the
+# Photoshop to within 1.4/255, so the compositor's CMYK convention -- the
 # canvas counts what is left of the ink, and the separable formulas apply to
 # that complement -- was never the problem the issue supposed. Three modes were
 # wrong, and wrong in every colour mode rather than only in CMYK:
@@ -631,7 +633,11 @@ def test_get_blend_func_degrades_the_descriptor_keys_too(key: bytes) -> None:
 # ``vivid_light`` corners (Cb == 1 with Cs == 0, and Cb == 0 with Cs == 1) and
 # pair 3 carries the ``hard_mix`` tie from both sides (Cb + Cs == 1 with Cb
 # above and below a half) together with two backdrops under a quarter, where
-# ``soft_light``'s D actually differs. Format: ``(backdrop, source, {mode:
+# ``soft_light``'s D actually differs. Pair 2 does one more job: its
+# ``color_burn`` and ``color_dodge`` rows sit on those same two corners and
+# pin that the plain modes *do* keep the backdrop special cases Vivid Light
+# does not, which is the surprising half of that fix and the reason it is not
+# simply a bug in one of the two. Format: ``(backdrop, source, {mode:
 # result})``, ink percent, authored the same way -- Photoshop's own render.
 PHOTOSHOP_CMYK_SEPARABLE: list[
     tuple[list[float], list[float], dict[str, list[float]]]
@@ -778,10 +784,46 @@ def _cmyk_canvas_8bit(ink: list[float]) -> np.ndarray:
     than the 0.5 that a direct conversion yields -- close enough to read as a
     tie that is not one, and to assert the wrong branch. Snapping first makes
     the readable round numbers in the table above mean exactly what Photoshop
-    held; it reproduces all 40 stored operands there.
+    held: every operand in the table round-trips to the byte Photoshop reported.
+    That is checked rather than guaranteed -- inks such as 10, 50 and 70 land on
+    a .5 boundary in exact arithmetic, and it is float64 representation error
+    and ``np.round``'s half-to-even rule that put them on Photoshop's side. A
+    new pair that lands on such a boundary needs the same check, which
+    ``test_the_table_operands_round_trip_to_photoshops_bytes`` below applies.
     """
     value = np.round((1.0 - np.array(ink, dtype=np.float64) / 100.0) * 255.0)
     return (value / 255.0).astype(np.float32).reshape(1, 1, 4)
+
+
+def test_the_separable_table_covers_every_pair_alike() -> None:
+    """The parametrize below reads its mode list from pair 0 alone.
+
+    A key missing from a later pair would be a ``KeyError`` at run time and an
+    extra one would go silently untested, so the table is made to answer for
+    itself here.
+    """
+    keys = [set(res) for _, _, res in PHOTOSHOP_CMYK_SEPARABLE]
+    assert all(k == keys[0] for k in keys)
+    assert len(keys[0]) == 20
+
+
+def test_the_table_operands_round_trip_to_photoshops_bytes() -> None:
+    """``_cmyk_canvas_8bit``'s premise, pinned rather than assumed.
+
+    The table reads in round nominal ink because that is legible, and relies on
+    the snap landing on the byte Photoshop stored. ``normal`` returns the source
+    untouched, so its row is Photoshop's own report of that operand and gives
+    the check for free on one side; the backdrops are covered by the fact that
+    every pair's backdrop appears as some pair's source, or as its own
+    ``darken``/``lighten`` row.
+    """
+    for backdrop, source, expected in PHOTOSHOP_CMYK_SEPARABLE:
+        stored = list((1.0 - _cmyk_canvas_8bit(source).reshape(4)) * 100.0)
+        # Photoshop's sampler reports ink to two decimals, so 9.803921... comes
+        # back as 9.8. One 8-bit step is 100/255 == 0.392 of a percent, so this
+        # tolerates that report rounding and still catches a whole byte.
+        assert stored == pytest.approx(expected["normal"], abs=0.01)
+        assert _cmyk_canvas_8bit(backdrop).dtype == np.float32
 
 
 @pytest.mark.parametrize(
@@ -798,6 +840,13 @@ def test_separable_matches_photoshop_on_cmyk(pair: int, mode: str) -> None:
     across the whole canvas: it sat at 0.000179 against a 0.01 threshold while
     three modes were wrong, and two of the three defects moved it by less than
     a thousandth. Reverting any one of the three fails a row here instead.
+
+    A CMYK table settles a fix advertised for every colour mode because these
+    twenty are not mode-aware: none is in ``_MODE_AWARE``, so ``get_blend_func``
+    hands back the bare function and one object serves RGB, Grayscale, Lab and
+    CMYK alike, as the ``get_blend_func`` binding test above pins. So fixing the
+    arithmetic on CMYK fixes it everywhere, which is why #189's report against
+    CMYK alone never located a CMYK fault.
     """
     backdrop, source, expected = PHOTOSHOP_CMYK_SEPARABLE[pair]
     blend_fn = getattr(blend_module, mode)

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -51,10 +51,10 @@ def test_lighter_color_descriptor_key() -> None:
         ("blend-modes/linear-burn.psd",),
         ("blend-modes/hard-light.psd",),
         ("blend-modes/soft-light.psd",),
-        pytest.param(
-            "blend-modes/vivid-light.psd",
-            marks=pytest.mark.xfail(reason="vivid light algorithm discrepency"),
-        ),
+        # Was xfailed as a "vivid light algorithm discrepency" until #189: the
+        # mode delegated to the guarded color_burn/color_dodge, whose backdrop
+        # special cases Photoshop does not apply here. 0.020755 -> 0.000001.
+        ("blend-modes/vivid-light.psd",),
         ("blend-modes/linear-light.psd",),
         ("blend-modes/pin-light.psd",),
         ("blend-modes/difference.psd",),
@@ -617,3 +617,190 @@ def test_get_blend_func_degrades_the_descriptor_keys_too(key: bytes) -> None:
     Cb, Cs = _mixed_pair(4)
     blend_fn = get_blend_func(key, ColorMode.MULTICHANNEL)
     assert np.array_equal(blend_fn(Cb.copy(), Cs.copy()), normal(Cb, Cs))
+
+
+# The separable half of the same experiment that produced ``PHOTOSHOP_CMYK``
+# above, and the answer to #189: 17 of the 20 modes here already agreed with
+# Photoshop to within quantization, so the compositor's CMYK convention -- the
+# canvas counts what is left of the ink, and the separable formulas apply to
+# that complement -- was never the problem the issue supposed. Three modes were
+# wrong, and wrong in every colour mode rather than only in CMYK:
+# ``soft_light`` keyed D on the source, ``vivid_light`` inherited backdrop
+# special cases Photoshop does not apply, and ``hard_mix`` fudged the tie.
+# Pairs 2 and 3 are the ones that discriminate: pair 2 carries the two
+# ``vivid_light`` corners (Cb == 1 with Cs == 0, and Cb == 0 with Cs == 1) and
+# pair 3 carries the ``hard_mix`` tie from both sides (Cb + Cs == 1 with Cb
+# above and below a half) together with two backdrops under a quarter, where
+# ``soft_light``'s D actually differs. Format: ``(backdrop, source, {mode:
+# result})``, ink percent, authored the same way -- Photoshop's own render.
+PHOTOSHOP_CMYK_SEPARABLE: list[
+    tuple[list[float], list[float], dict[str, list[float]]]
+] = [
+    (
+        [80, 20, 10, 5],
+        [10, 70, 60, 20],
+        {
+            "color_burn": [88.63, 66.27, 24.71, 6.27],
+            "color_dodge": [0, 0, 0, 0],
+            "darken": [80, 69.8, 60, 20],
+            "difference": [29.8, 50.2, 49.8, 85.1],
+            "divide": [77.65, 0, 0, 0],
+            "exclusion": [25.88, 38.43, 41.96, 77.25],
+            "hard_light": [16.08, 51.76, 27.84, 1.96],
+            "hard_mix": [0, 0, 0, 0],
+            "lighten": [9.8, 20, 9.8, 5.1],
+            "linear_burn": [89.8, 89.8, 69.8, 25.1],
+            "linear_dodge": [0, 0, 0, 0],
+            "linear_light": [0, 60, 30.2, 0],
+            "multiply": [81.96, 75.69, 63.92, 23.92],
+            "normal": [9.8, 69.8, 60, 20],
+            "overlay": [63.92, 27.84, 11.76, 1.96],
+            "pin_light": [19.61, 40, 20.39, 5.1],
+            "screen": [7.84, 14.12, 5.88, 1.18],
+            "soft_light": [60.39, 26.27, 11.76, 3.53],
+            "subtract": [100, 50.2, 49.8, 85.1],
+            "vivid_light": [0, 33.33, 12.16, 0],
+        },
+    ),
+    (
+        [10, 70, 60, 20],
+        [80, 20, 10, 5],
+        {
+            "color_burn": [49.02, 87.45, 66.67, 21.18],
+            "color_dodge": [0, 0, 0, 0],
+            "darken": [80, 69.8, 60, 20],
+            "difference": [29.8, 50.2, 49.8, 85.1],
+            "divide": [0, 62.35, 55.69, 15.69],
+            "exclusion": [25.88, 38.43, 41.96, 77.25],
+            "hard_light": [63.92, 28.24, 12.16, 1.96],
+            "hard_mix": [0, 0, 0, 0],
+            "lighten": [9.8, 20, 9.8, 5.1],
+            "linear_burn": [89.8, 89.8, 69.8, 25.1],
+            "linear_dodge": [0, 0, 0, 0],
+            "linear_light": [70.2, 10.2, 0, 0],
+            "multiply": [81.96, 75.69, 63.92, 23.92],
+            "normal": [80, 20, 9.8, 5.1],
+            "overlay": [15.69, 51.76, 27.84, 1.96],
+            "pin_light": [60, 40, 19.61, 10.2],
+            "screen": [7.84, 14.12, 5.88, 1.18],
+            "soft_light": [15.29, 54.9, 41.57, 11.76],
+            "subtract": [29.8, 100, 100, 100],
+            "vivid_light": [24.71, 24.31, 0, 0],
+        },
+    ),
+    (
+        [100, 0, 50, 0],
+        [0, 100, 50, 0],
+        {
+            "color_burn": [100, 0, 99.22, 0],
+            "color_dodge": [100, 0, 0, 0],
+            "darken": [100, 100, 49.8, 0],
+            "difference": [0, 0, 100, 100],
+            "divide": [100, 0, 0, 0],
+            "exclusion": [0, 0, 49.8, 100],
+            "hard_light": [0.39, 100, 49.8, 0],
+            "hard_mix": [100, 0, 0, 0],
+            "lighten": [0, 0, 49.8, 0],
+            "linear_burn": [100, 100, 99.61, 0],
+            "linear_dodge": [0, 0, 0, 0],
+            "linear_light": [0.39, 100, 49.8, 0],
+            "multiply": [100, 100, 74.9, 0],
+            "normal": [0, 100, 49.8, 0],
+            "overlay": [100, 0, 49.8, 0],
+            "pin_light": [0, 100, 49.8, 0],
+            "screen": [0, 0, 24.71, 0],
+            "soft_light": [100, 0, 49.8, 0],
+            "subtract": [100, 0, 100, 100],
+            "vivid_light": [0, 100, 49.8, 0],
+        },
+    ),
+    (
+        [25, 75, 95, 95],
+        [75, 25, 0, 25],
+        {
+            "color_burn": [100, 100, 94.9, 100],
+            "color_dodge": [0, 0, 0, 79.61],
+            "darken": [74.9, 74.9, 94.9, 94.9],
+            "difference": [50.2, 50.2, 5.1, 30.2],
+            "divide": [0, 66.67, 94.9, 93.33],
+            "exclusion": [37.65, 37.65, 5.1, 27.84],
+            "hard_light": [62.35, 38.04, 0.39, 47.84],
+            "hard_mix": [0, 100, 0, 100],
+            "lighten": [25.1, 25.1, 0, 25.1],
+            "linear_burn": [100, 100, 94.9, 100],
+            "linear_dodge": [0, 0, 0, 20],
+            "linear_light": [75.29, 25.49, 0, 45.49],
+            "multiply": [81.18, 81.18, 94.9, 96.08],
+            "normal": [74.9, 25.1, 0, 25.1],
+            "overlay": [37.65, 62.35, 89.8, 92.55],
+            "pin_light": [49.8, 50.59, 0, 50.59],
+            "screen": [18.82, 18.82, 0, 23.92],
+            "soft_light": [34.51, 62.35, 82.35, 88.63],
+            "subtract": [50.2, 100, 100, 100],
+            "vivid_light": [50.2, 50.2, 0, 89.8],
+        },
+    ),
+    (
+        [0, 0, 0, 0],
+        [100, 100, 100, 100],
+        {
+            "color_burn": [0, 0, 0, 0],
+            "color_dodge": [0, 0, 0, 0],
+            "darken": [100, 100, 100, 100],
+            "difference": [0, 0, 0, 0],
+            "divide": [0, 0, 0, 0],
+            "exclusion": [0, 0, 0, 0],
+            "hard_light": [100, 100, 100, 100],
+            "hard_mix": [0, 0, 0, 0],
+            "lighten": [0, 0, 0, 0],
+            "linear_burn": [100, 100, 100, 100],
+            "linear_dodge": [0, 0, 0, 0],
+            "linear_light": [100, 100, 100, 100],
+            "multiply": [100, 100, 100, 100],
+            "normal": [100, 100, 100, 100],
+            "overlay": [0, 0, 0, 0],
+            "pin_light": [100, 100, 100, 100],
+            "screen": [0, 0, 0, 0],
+            "soft_light": [0, 0, 0, 0],
+            "subtract": [0, 0, 0, 0],
+            "vivid_light": [100, 100, 100, 100],
+        },
+    ),
+]
+
+
+def _cmyk_canvas_8bit(ink: list[float]) -> np.ndarray:
+    """Ink percent snapped to the 8-bit value Photoshop actually stored.
+
+    ``_cmyk_canvas`` above converts the percentage directly, which is fine when
+    a blend is continuous in its operands. ``hard_mix`` is not: it turns on a
+    tie at ``Cb + Cs == 1``, and a nominal 50% ink is stored as 128/255 rather
+    than the 0.5 that a direct conversion yields -- close enough to read as a
+    tie that is not one, and to assert the wrong branch. Snapping first makes
+    the readable round numbers in the table above mean exactly what Photoshop
+    held; it reproduces all 40 stored operands there.
+    """
+    value = np.round((1.0 - np.array(ink, dtype=np.float64) / 100.0) * 255.0)
+    return (value / 255.0).astype(np.float32).reshape(1, 1, 4)
+
+
+@pytest.mark.parametrize(
+    "mode", sorted(PHOTOSHOP_CMYK_SEPARABLE[0][2]), ids=lambda m: m
+)
+@pytest.mark.parametrize(
+    "pair", range(len(PHOTOSHOP_CMYK_SEPARABLE)), ids=lambda i: "pair%d" % i
+)
+def test_separable_matches_photoshop_on_cmyk(pair: int, mode: str) -> None:
+    """Every separable mode against Photoshop's own CMYK render (#189).
+
+    This is the coverage the 164-layer ``cmyk-blend-modes.psd`` fixture cannot
+    give. That document exercises all of these modes, but its error is diluted
+    across the whole canvas: it sat at 0.000179 against a 0.01 threshold while
+    three modes were wrong, and two of the three defects moved it by less than
+    a thousandth. Reverting any one of the three fails a row here instead.
+    """
+    backdrop, source, expected = PHOTOSHOP_CMYK_SEPARABLE[pair]
+    blend_fn = getattr(blend_module, mode)
+    result = blend_fn(_cmyk_canvas_8bit(backdrop), _cmyk_canvas_8bit(source))
+    ink = list((1.0 - result.reshape(4)) * 100.0)
+    assert ink == pytest.approx(expected[mode], abs=2 * _ONE_STEP * 100.0)

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -51,7 +51,7 @@ def test_lighter_color_descriptor_key() -> None:
         ("blend-modes/linear-burn.psd",),
         ("blend-modes/hard-light.psd",),
         ("blend-modes/soft-light.psd",),
-        # Was xfailed as a "vivid light algorithm discrepency" until #189: the
+        # Was xfailed as a vivid light algorithm discrepancy until #189: the
         # mode delegated to the guarded color_burn/color_dodge, whose backdrop
         # special cases Photoshop does not apply here. 0.020755 -> 0.000001.
         ("blend-modes/vivid-light.psd",),

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -812,10 +812,15 @@ def test_the_table_operands_round_trip_to_photoshops_bytes() -> None:
 
     The table reads in round nominal ink because that is legible, and relies on
     the snap landing on the byte Photoshop stored. ``normal`` returns the source
-    untouched, so its row is Photoshop's own report of that operand and gives
-    the check for free on one side; the backdrops are covered by the fact that
-    every pair's backdrop appears as some pair's source, or as its own
-    ``darken``/``lighten`` row.
+    untouched, so its row is Photoshop's own report of that operand and settles
+    the source side outright.
+
+    The backdrops get no such row -- only two of the five recur as another
+    pair's source -- so they are covered the other way round: a backdrop off by
+    a single byte would drag some mode row of that pair outside the tolerance
+    the test below asserts. That is the property worth having, since it is what
+    makes a mis-snapped backdrop a failure rather than a silent shift, so it is
+    measured here instead of argued.
     """
     for backdrop, source, expected in PHOTOSHOP_CMYK_SEPARABLE:
         stored = list((1.0 - _cmyk_canvas_8bit(source).reshape(4)) * 100.0)
@@ -823,7 +828,24 @@ def test_the_table_operands_round_trip_to_photoshops_bytes() -> None:
         # back as 9.8. One 8-bit step is 100/255 == 0.392 of a percent, so this
         # tolerates that report rounding and still catches a whole byte.
         assert stored == pytest.approx(expected["normal"], abs=0.01)
-        assert _cmyk_canvas_8bit(backdrop).dtype == np.float32
+
+    tolerance = 2 * _ONE_STEP * 100.0
+    for backdrop, source, expected in PHOTOSHOP_CMYK_SEPARABLE:
+        exact = _cmyk_canvas_8bit(backdrop)
+        noticed = False
+        for offset in (-1, 1):
+            nudged = np.clip(exact * 255.0 + offset, 0, 255) / 255.0
+            if np.array_equal(nudged, exact):
+                continue  # a backdrop already on 0 or 255 cannot move that way
+            for mode, row in expected.items():
+                blend_fn = getattr(blend_module, mode)
+                ink = (1.0 - blend_fn(nudged, _cmyk_canvas_8bit(source))) * 100.0
+                if (np.abs(ink.reshape(4) - np.array(row)) > tolerance).any():
+                    noticed = True
+                    break
+            if noticed:
+                break
+        assert noticed, f"a one-byte error in backdrop {backdrop} would go unseen"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #189.

## What #189 asked, and what the measurement says

> Separable blending modes in CMYK is currently inaccurate.

I checked that against Photoshop 2026's own render rather than against the spec: 3440 samples, captured by filling a Background with a CMYK ink colour, adding a layer, setting `blendMode`, flattening and reading the composited pixel back through `doc.colorSamplers` — the same technique #781 used. 20 separable modes over 43 (backdrop, source) pairs, including a 9×9 grid of complement levels and a dense sweep of the `Cb + Cs == 1` boundary.

**The premise turns out to be stale.** 17 of the 20 separable modes already agreed with Photoshop to within 1.4 steps of 1/255 — quantization, not model error. The compositor's CMYK convention is correct as it stands: the canvas counts what is *left* of the ink, and the separable formulas apply to that complement.

Three modes were genuinely wrong. None of them is a CMYK problem — all three are wrong in **every** colour mode, which is why the 2020 report on CMYK never led anywhere:

| mode | defect | worst row, steps of 1/255 |
| --- | --- | --- |
| `soft_light` | piecewise `D` selected with `Cs <= 0.25`; the spec keys `D` on `Cb`, so every `Cb <= 0.25` pixel sat on the `sqrt` arm | 12.58 → 0.95 |
| `vivid_light` | delegated to `color_burn`/`color_dodge`, which carry the spec's backdrop cases (`Cb == 1` burns to 1, `Cb == 0` dodges to 0). Photoshop does not apply them here — inside Vivid Light the *source* extreme wins | 255 → 2.00 |
| `hard_mix` | a `0.999999` factor for a "weird numerical issue" | 255 → 0.00 (exact) |

## On the two that look like judgement calls

**`vivid_light`.** Plain Color Burn and Color Dodge *do* keep the backdrop special cases — I verified that separately against the same ground truth, so the two genuinely differ and this is not a case of one of them being wrong. At `(Cb=1, Cs=0)` Photoshop gives 0 where we gave 1; at `(Cb=0, Cs=1)` it gives 1 where we gave 0. All four corners now match exactly.

**`hard_mix`.** The numerical issue the comment worried about does not exist: two complementary 8-bit values sum to exactly 1.0 in float32 for all 256 of them, so the tie is a real, testable case. Photoshop breaks it toward the backdrop — result 1 only where `Cb > 0.5`. Over 145 distinct 8-bit boundary samples that model fits all 145; the `0.999999` factor decided every tie the other way and got 9 wrong, and a plain `>= 1` gets 8 wrong the other way.

## On the Ghostscript suggestion

#189 proposes `gxblend.h` as a starting point. I deliberately did not take it. Ghostscript implements the PDF spec, and two of the three defects here are places where **Photoshop departs from that spec** — Vivid Light discards the backdrop special cases the spec's Color Burn and Color Dodge carry, and Hard Mix resolves the tie. A spec-faithful reference could not have found either; only Photoshop's own render can. The third, `soft_light`, was a straightforward misreading of the spec that a reference implementation would indeed have caught.

## Effect

`blend-modes/vivid-light.psd` leaves `xfail` — it had been parked as a "vivid light algorithm discrepency" and was the largest single error in the suite.

| fixture | before | after |
| --- | --- | --- |
| `blend-modes/vivid-light.psd` | 0.020755 | 0.000001 |
| `blend-modes/rgb-blend-modes.psd` | 0.000582 | 0.000056 |
| `blend-modes/cmyk-blend-modes.psd` | 0.000179 | 0.000045 |
| `blend-modes/gray-blend-modes.psd` | 0.000022 | 0.000015 |

Across the whole fixture corpus, **8 of 516** (file, force) renders change — those four fixtures in both force modes. Every one moves closer to the reference; none is worse.

## Testing

`PHOTOSHOP_CMYK_SEPARABLE` pins all 20 separable modes on CMYK against Photoshop's render, which is coverage the corpus cannot give. `cmyk-blend-modes.psd` exercises all of these modes across 164 layers, but its error is diluted canvas-wide: it sat at 0.000179 against a 0.01 threshold *while three modes were wrong*, and two of the three defects move it by less than a thousandth. So the table is checked for discrimination rather than assumed to have it — reverting each fix on its own fails a distinct row:

| reverted | fails |
| --- | --- |
| `soft_light` | `pair3-soft_light` |
| `vivid_light` | `pair4-vivid_light` |
| `hard_mix` | `pair3-hard_mix` |

Pairs 2 and 3 carry the discriminating operands: pair 2 the two `vivid_light` corners, pair 3 the `hard_mix` tie from both sides together with two backdrops under a quarter where `soft_light`'s `D` differs.

`_cmyk_canvas_8bit` snaps ink percent to the 8-bit value Photoshop stored, which `_cmyk_canvas` deliberately does not. `hard_mix` needs it: a nominal 50% ink is stored as 128/255, not the 0.5 a direct conversion yields, and the difference reads as a tie that is not one. Snapping does not help the existing non-separable table (1.20 → 1.27 steps), so that helper is left alone.

Full suite: 2881 passed, 3 skipped, 25 xfailed, 2 xpassed — the two xpasses predate this branch. All 65536 8-bit operand combinations of the three changed modes return finite values in [0, 1].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
