### PR TITLE
docs: compress the 1.19.0 changelog section and the densest rationale prose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,15 @@ Prefix each entry with its category: `[fix]`, `[api]`, `[security]`, `[chore]`,
 `[docs]`. Reference the issue and PR numbers. Flag any backwards-incompatible
 change explicitly in the entry text.
 
+**Budget: an entry is at most four lines** — one line of summary, plus a short
+"does this affect me" clause where the answer is not obvious, plus the refs.
+An entry's job is to let a reader decide whether they are affected and then
+hand them the link; it is not the place to explain the mechanism. That
+explanation is already published in three linked places — the PR body, the
+commit message, and the GitHub Release body — so a longer entry duplicates
+them and dates faster than they do. Corpus statistics, measured error figures,
+and the history of what earlier PRs got wrong all belong in the PR, not here.
+
 Entries are for user-visible change. Skip them for pure refactors, test-only
 changes, and dependabot bumps — dependency bumps are summarised in bulk by the
 release PR instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,10 @@ Prefix each entry with its category: `[fix]`, `[api]`, `[security]`, `[chore]`,
 `[docs]`. Reference the issue and PR numbers. Flag any backwards-incompatible
 change explicitly in the entry text.
 
-**Budget: an entry is at most four lines** — one line of summary, plus a short
-"does this affect me" clause where the answer is not obvious, plus the refs.
+**Budget: aim for four lines, and treat six as the ceiling** — one line of
+summary, plus a short "does this affect me" clause where the answer is not
+obvious, plus the refs. Spend the extra lines on a backwards-incompatibility
+warning or a migration instruction, never on mechanism.
 An entry's job is to let a reader decide whether they are affected and then
 hand them the link; it is not the place to explain the mechanism. That
 explanation is already published in three linked places — the PR body, the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,562 +5,167 @@ Changelog
 -------------------
 
 - [fix] Correct ``Soft Light``, ``Vivid Light`` and ``Hard Mix``, which
-  disagreed with Photoshop in every colour mode -- not only in CMYK, where #189
-  reported it. Rendering changes for RGB, Grayscale and CMYK alike wherever
-  those three are used; ``Vivid Light`` was the largest error in the suite and
-  had been xfailed as a known discrepancy. The other 17 separable modes already
-  matched Photoshop on CMYK to within 1.4/255 and are now pinned there against
-  its own render (#189, #784).
-
+  disagreed with Photoshop in every colour mode, not only in CMYK where #189
+  reported it. **Rendering change** wherever those three are used (#189, #784)
 - [fix] Blend the six non-separable modes on a CMYK document the way Photoshop
-  does -- on the CMY complement, with K carried across -- instead of through a
-  round trip that collapsed every one of them to a constant (#781). ``Hue``,
-  ``Saturation``, ``Color``, ``Luminosity``, ``Darker Color`` and ``Lighter
-  Color`` returned full CMY whatever their operands, so blending a colour with
-  itself did not return that colour: the conversion read the canvas as ink where
-  it holds what is left of it, the same inversion #747 fixed for fills. Two
-  narrower faults went with it -- K was taken from the source for all four
-  component modes where Photoshop takes the backdrop's for three of them, and
-  ``Darker``/``Lighter Color`` dropped the chosen operand's K and left K out of
-  the comparison that chooses. Measured against Photoshop 2026 over six CMYK
-  colour pairs, all six now land within 1.2/255 -- 8-bit quantization alone is
-  1/255 -- and
-  ``blend-modes/cmyk-blend-modes.psd`` falls from 0.026612 to 0.000179 mean
-  squared error against its own merged preview -- it was xfailed as "Fix me!"
-  and now passes.
-
-  **Rendering change**: a CMYK document using any of these six modes renders
-  differently. RGB, Lab, grayscale and multichannel documents are unaffected;
-  one fixture in the corpus moves, and it moves toward Photoshop.
-
-- [fix] Degrade the six non-separable blend modes -- ``Hue``, ``Saturation``,
-  ``Color``, ``Luminosity``, ``Darker Color`` and ``Lighter Color`` -- on every
-  document Photoshop does not offer them on, instead of crashing or reading the
-  channels as something they are not (#735, #746). The first four raised
-  ``IndexError`` or ``ValueError`` on every single-channel document -- grayscale
-  and duotone -- and on anything wider than CMYK, indexing channels 1 and 2 of
-  an array that has only channel 0; ``Darker Color`` and ``Lighter Color`` did
-  not raise but returned the backdrop unchanged whatever the source was. A
-  multichannel document showed neither symptom and was misread instead: three
-  spot plates blended as if they were R, G and B, and four with the fourth plate
-  taken for CMYK black generation. All six now fall back to ``Normal`` with a
-  debug log, as ``Dissolve`` already does; RGB and CMYK are unaffected, and Lab
-  keeps its as-if-RGB treatment, Photoshop offering all six there. Affects
-  grayscale and duotone documents, which are ordinary files, and multichannel
-  documents carrying layers, which Photoshop neither writes -- converting to
-  Multichannel flattens -- nor preserves on opening, so no file in the test
-  corpus renders differently.
-
-  The six functions in ``psd_tools.composite.blend`` take the document's colour
-  mode as an optional third argument, supplied by the new ``get_blend_func()``
-  lookup; ``BLEND_FUNC`` is unchanged.
-
+  does, instead of collapsing every one of them to a constant. **Rendering
+  change** for a CMYK document using ``Hue``, ``Saturation``, ``Color``,
+  ``Luminosity``, ``Darker Color`` or ``Lighter Color`` (#781)
+- [fix] Degrade those same six modes to ``Normal`` with a debug log on the
+  documents Photoshop does not offer them on -- grayscale, duotone and
+  multichannel -- instead of raising or misreading the channels. The six
+  functions in ``psd_tools.composite.blend`` gain an optional colour-mode
+  argument, supplied by the new ``get_blend_func()``; ``BLEND_FUNC`` is
+  unchanged (#735, #746)
 - [fix] Convert a single-channel *source* to the document's colour mode instead
-  of letting the blend arithmetic replicate it across every channel (#749,
-  #776, #777), as #722 already did for a backdrop. A grayscale pattern fill on a
-  CMYK document rendered a different colour from the same pattern applied as an
-  overlay effect. Affects only a one-channel source in a CMYK or Lab document, which
-  Photoshop does not write -- it converts a pattern to the document's colour
-  mode on embed -- so no file in the test corpus renders differently.
-
+  of replicating it, as #722 already did for a backdrop. Affects a one-channel
+  source in a CMYK or Lab document (#749, #776, #777)
 - [security] Size the ``max_alloc_bytes`` guard against what ``numpy()`` and
-  ``topil()`` peak at rather than the array they return; both hold several
-  intermediates, measured at up to 3.7x the old estimate (#767). Affects you only
-  if you set ``max_alloc_bytes`` or ``$PSD_TOOLS_MAX_ALLOC_BYTES`` -- it admits
-  and rejects different documents in both directions, so re-check a tuned budget.
-
+  ``topil()`` peak at rather than the array they return -- up to 3.7x the old
+  estimate. Re-check a tuned budget: it admits and rejects different documents
+  in both directions (#767)
 - [fix] Read and write a 1-bit (Bitmap mode) document at the row stride the
-  format uses (#768). A row of ``width`` pixels occupies ``ceil(width / 8)``
-  bytes and the depth-1 path floored that, so ``numpy()`` and
-  ``composite(ignore_preview=True)`` raised ``ValueError`` at most widths and
-  returned half padding at widths 1, 2 and 4, while re-encoding a modified
-  document sheared it by a byte a row. Affects bitmap documents only;
-  ``topil()`` was already correct except under RLE.
-
-- [fix] Return a 1-bit document the right way round: a set bit is black in
-  Bitmap mode, so ``numpy()`` and ``composite()`` were rendering every such
-  document as its own negative, disagreeing with both ``topil()`` and Photoshop
-  (#768).
-
+  format uses. ``numpy()`` and ``composite(ignore_preview=True)`` raised
+  ``ValueError`` at most widths, and re-encoding sheared the image by a byte a
+  row (#768)
+- [fix] Return a 1-bit document the right way round; a set bit is black in
+  Bitmap mode, so ``numpy()`` and ``composite()`` rendered every such document
+  as its own negative (#768)
 - [fix] Replace an undecodable 1-bit channel with black rather than raising
-  ``RuntimeError`` (#768). It now takes the same warn-and-degrade path as every
-  other depth, a black fill being expressible once a channel's length counts
-  packed rows.
-
+  ``RuntimeError``, as every other depth already did (#768)
 - [fix] Give the ``max_alloc_bytes`` estimate a depth term, so a 1-bit document
-  can no longer allocate eight times its budget (#737, #769). ``check_pixel_size()``
-  sizes an allocation at ``width * height * channels * 4``, but at depth 1
-  ``numpy_io._parse_array()`` unpacks the buffer with ``np.unpackbits`` -- one
-  float32 per *bit* -- so the array follows the byte count the codec returns
-  rather than the pixel count. The two disagreed eightfold: ``decompress()``'s
-  ``length`` counted a byte per pixel at depth 1, where a row of ``width``
-  pixels packs into ``ceil(width / 8)``, and a body written that wide was
-  returned in full, the length check being skipped below depth 8. A 64x64 1-bit document
-  therefore returned ``(64, 64, 8)``, 131,072 bytes, against a 16,384-byte
-  estimate, and the guard admitted it -- a gap in a security control
-  (GHSA-8q6g-vjhf-jp8m) whose whole job is to bound the allocation before it
-  happens.
-
-  ``_safe_zlib_decompress()`` also now enforces the ceiling it documents,
-  refusing a stream that inflates one byte past it rather than handing that byte
-  back. The eightfold gap itself is closed at its source by the row-stride fix
-  above (#768), which gives depth 1 the same arithmetic as every other depth, and
-  :py:func:`psd_tools.compression.decompressed_size_bound` remains available as a
-  public utility. That arithmetic is superseded on both image-data paths later in
-  this release (#767).
-
-- [fix] Replace a failed channel with exactly the byte count it declares, at
-  every depth (#737, #769). The black fill substituted for an undecodable channel was
-  a PIL image whose mode was picked from the depth -- ``"L"`` for 8, ``"RGBA"``
-  for anything else -- so depth 16 came back at four bytes per pixel against a
-  declared two, and every reader downstream saw the channels at twice their
-  width. A 4x4 RGB document whose merged image data fails to decode read
-  ``(4, 4, 6)`` instead of ``(4, 4, 3)`` -- ``ImageData.get_data()``
-  decompresses every channel in one call, so that section fails as a unit -- and
-  allocated twice what the guard had estimated. The same substitute serves the
-  per-channel readers, ``ChannelData.get_data()`` for layers and the pattern
-  reader, so a failed 16-bit channel there came back double-width too. Depths 8
-  and 32 are unaffected, their modes having happened to match.
-
+  can no longer allocate eight times its budget (GHSA-8q6g-vjhf-jp8m).
+  ``_safe_zlib_decompress()`` now enforces the ceiling it documents, and
+  :py:func:`psd_tools.compression.decompressed_size_bound` is public
+  (#737, #769)
+- [fix] Replace a failed channel with exactly the byte count it declares. The
+  substituted black fill picked its PIL mode from the depth, so a 16-bit
+  channel came back double-width (#737, #769)
 - [fix] Split a pattern's alpha off by its slot layout rather than by its
   colour mode, so a multichannel-mode pattern composites instead of raising
-  (#741). The split was keyed on ``EXPECTED_CHANNELS``, whose multichannel
-  entry is 64 -- the format's maximum number of channels, not any pattern's own
-  count. ``shape[2] > 64`` is never true, so the alpha stayed in the colour
-  array and the too-wide result was rejected downstream: ``AssertionError:
-  source has 4 channels, expected 1 or 3`` on a pattern fill layer, and
-  ``AssertionError: Inconsistent pattern channels.`` on a pattern overlay
-  effect. A pattern reserves ``len(channels) - 2`` colour slots and writes its
-  transparency into the last of the remaining two, which is the pattern's own
-  statement of where its boundary lies rather than a mode's.
-
-  Multichannel is the mode that can never reach its constant, but it is not the
-  only one that missed the split: the mode's count is the document's, not the
-  pattern's, so a pattern storing fewer colour planes than its mode's
-  constant -- an indexed or RGB one carrying a single colour plane and an
-  alpha -- kept its alpha in the colour array as well. Rendering is byte-for-byte
-  unchanged for every pattern layout in the test corpus and in the patterns
-  Photoshop ships.
-
+  ``AssertionError``. Rendering is unchanged for every pattern layout in the
+  corpus and in the patterns Photoshop ships (#741)
 - [fix] Convert a CMYK fill descriptor through ink space, so it no longer
-  renders black on every non-CMYK document (#763, #765). ``_get_cmyk()`` read the
-  descriptor into the compositor's canvas convention, where 1.0 is *no* ink,
-  and then handed that to :py:func:`psd_tools.color_convert.cmyk_to_rgb`, whose
-  contract is ink space, where 0.0 is no ink. The flip was never undone, so on
-  an RGB, indexed, grayscale, bitmap, duotone, multichannel or Lab document
-  every colour arrived as its own opposite and collapsed: white ``C0 M0 Y0 K0``
-  rendered ``(0, 0, 0)``, and so did cyan, magenta and yellow. Black was the
-  one colour that came out right, by coincidence. This is the same confusion as
-  #747 on the opposite leg; a CMYK document was never affected.
-
-- [fix] Clamp a fill descriptor's colour components so an out-of-range value
-  saturates instead of corrupting the render (#757, #764). Nothing in the format
-  constrains a component to the range its colour class normalizes by, so a
-  writer emitting ``Rd = 300`` or ``Gry = 150`` produces a value outside
-  ``[0, 1]``.
-
-  A flat opaque fill was shielded from this, because the compositor clips its
-  own arrays before the uint8 cast. What was not shielded is anything that
-  blends the value first -- a layer effect, a partial alpha, an anti-aliased
-  vector edge -- because the clip then runs on arithmetic that is already
-  wrong. A shape whose fill descriptor carries a beyond-black grey rendered
-  white pixels along its stroke, and a beyond-red ``HSBC`` rendered bright
-  cyan ones, where the stroke colour was dark grey.
-
-  All five colour classes are now guarded where the untrusted number enters, as
-  Lab already was since #743, so ``color_convert``'s documented ``[0, 1]``
-  input contracts stay unchanged. The colour-noise gradient's RGB path is
-  guarded too, since its bands come from raw ``"Mnm "``/``"Mxm "`` values. Hue is
-  excluded on purpose: it is an angle, so it still wraps.
-
-  :py:func:`psd_tools.color_convert.hsb_to_rgb` is now total, matching
-  :py:func:`~psd_tools.color_convert.lab_to_rgb`. Its documented ``[0, 1]``
-  result previously held only for in-range saturation and brightness, and a NaN
-  saturation propagated to the caller.
-
+  renders black on every non-CMYK document. A CMYK document was unaffected
+  (#763, #765)
+- [fix] Clamp a fill descriptor's colour components, so an out-of-range value
+  saturates instead of corrupting anything that blends it first -- a layer
+  effect, a partial alpha, an anti-aliased edge. Hue still wraps, being an
+  angle, and :py:func:`psd_tools.color_convert.hsb_to_rgb` is now total
+  (#757, #764)
 - [fix] Read a 32-bit document with transparency through
-  :py:meth:`~psd_tools.api.psd_image.PSDImage.numpy`, which raised
-  ``ValueError: assignment destination is read-only``. Photoshop writes 32-bit
-  RGB with a transparency channel routinely, so this was an ordinary file
-  shape rather than a malformed one, and
-  :py:func:`psd_tools.composite.composite` failed with it for the same reason.
-  ``topil()`` was unaffected, and ``PSDImage.composite()`` only appeared to be
-  because it short-circuits to the stored preview.
-
-  ``_parse_array()`` rescales at depths 1, 8 and 16, and the conversion that
-  needs hands back a fresh, writeable, native-endian array. Depth 32 needs no
-  rescaling, so it returned ``np.frombuffer()``'s view of the file's bytes --
-  read-only, and still big-endian where every other depth returns
-  ``np.float32``. Un-premultiplying the preview writes in place, and it runs
-  only for RGB with transparency, which is why just that one combination
-  raised. All four depths now return the same kind of array. The cost is one
-  more array the size of the merged image data on 32-bit documents, which is
-  what the other three depths already allocate (#738).
-
-- [fix] Convert a scalar backdrop instead of broadcasting it across every
-  channel. ``composite()`` accepts its backdrop as a scalar, a per-channel
-  sequence or a full array. #722, in this same release, taught the
-  single-channel *array* spelling to go through the colour mode's conversion,
-  but the scalar path was missed and stayed on ``np.full()`` -- so the same
-  backdrop had two answers depending on how it was written. A scalar now takes
-  the same conversion, and only a genuinely single component is converted: a
-  per-channel sequence is left exactly as given. Both halves land together, so
-  no released version carries the split; what *is* longstanding is the colour
-  below, which every released version got wrong by broadcasting either
-  spelling.
-
-  On a **Lab** document this was the default backdrop. ``color=1.0`` put both
-  chroma axes at byte 255 -- the extreme corner of each -- so a document
-  composited against maximum chroma at maximum lightness where white is
-  ``(255, 128, 128)``. On a **CMYK** document the default is unaffected, since
-  ``1.0`` is white either way, but other scalars were the over-inked build that
-  widening exists to avoid: ``color=0.0`` broadcast to ``(0, 0, 0, 0)``, every
-  plate at 100%. RGB, grayscale, indexed and multichannel are unchanged --
-  replication is the conversion there (#753).
-
-- [fix] Stop ``composite()`` shifting both chroma planes of a Lab document.
-  The result was built with ``Image.fromarray(pixels, "LAB")``, and PIL's
-  ``"LAB"`` unpacker reads the two chroma planes as *signed* and adds 128 --
-  so an array in the encoding the compositor carries, where byte 128 is
-  ``a = 0``, came back 128 off on both axes. Not a rounding gap but a different
-  colour: a flat ``Lab(60, 25, 25)`` converted to RGB as ``(0, 187, 255)``
-  where Photoshop puts it at ``(196, 126, 101)``. Every Lab document was
-  affected, and ``composite()`` disagreed with
-  :py:meth:`~psd_tools.api.psd_image.PSDImage.topil` on the same file --
-  ``topil()`` builds with ``Image.merge()``, which writes the planes verbatim
-  and was right all along. The planes are now merged the same way, and three of
-  the five Lab documents in the test corpus composite bitwise-identically to
-  Photoshop's own preview where before every one of them was 128 out.
-
-  ``numpy()`` and :py:func:`psd_tools.composite.composite` were never affected;
-  the arrays were correct and only the PIL step corrupted them. Note that
-  ``np.asarray()`` on a ``"LAB"`` image reads PIL's internal buffer rather than
-  the values ``getpixel()`` reports, which is why the round trip looked right
-  (#759).
-
+  :py:meth:`~psd_tools.api.psd_image.PSDImage.numpy` and
+  :py:func:`psd_tools.composite.composite`, which raised ``ValueError:
+  assignment destination is read-only``. Costs one extra array on 32-bit
+  documents, matching the other depths; ``topil()`` was unaffected (#738)
+- [fix] Convert a scalar backdrop to the document's colour mode instead of
+  broadcasting it; a per-channel sequence is still passed through as given. On
+  a Lab document this was the default backdrop, and on CMYK any scalar but
+  ``1.0`` was an over-inked build (#753)
+- [fix] Stop ``composite()`` shifting both chroma planes of a Lab document by
+  128, which affected every Lab document and disagreed with ``topil()`` on the
+  same file. ``numpy()`` was never affected (#759)
 - [fix] Size and interpret a colour-noise gradient from the document rather
-  than from its descriptor. A noise gradient carries a colour space of its own
-  -- Photoshop offers RGB, HSB and Lab, and keeps whichever was chosen in every
-  document mode -- but the synthesized table was built three wide and passed
-  through as if it were always RGB. Two consequences, both fixed here:
-
-  A noise gradient on a document that is not three channels raised
-  ``AssertionError: source has 3 channels, expected 1 or N`` out of the
-  compositor's width check -- every CMYK, grayscale, bitmap, duotone and
-  (unless its spot count happened to be three) multichannel document.
-
-  An HSB or Lab noise gradient rendered the wrong colours everywhere, including
-  on the RGB documents that did not raise: its components were read as RGB, so
-  a hue of 30 degrees at ``[8.33, 60, 80]`` rendered ``(21, 153, 204)`` where
-  Photoshop renders ``(204, 143, 82)``. The three spaces are now converted to
-  the document's own, with Lab landing in a Lab document unconverted because
-  the stored percentage already *is* that array's encoding. No gradient that
-  rendered correctly before changed value (#730, #758).
-
-- [fix] Read an HSB fill colour's hue as the angle it is. The descriptor's hue
-  key is degrees, so a full turn is 360, but it was being divided by 300: every
-  non-zero hue came out rotated -- ``HSB(120, 50, 80)`` rendered
-  ``(102, 204, 143)`` where Photoshop renders ``(102, 204, 102)`` -- and hue
-  360 landed past the end of the six-sector table, so a fully saturated red
-  rendered white (#754).
-
-  :py:func:`psd_tools.color_convert.hsb_to_rgb` now treats hue as cyclic
-  throughout, so any value outside ``[0, 1)`` wraps into it instead of falling
-  back to grey, and a non-finite hue degrades to the achromatic answer rather
-  than raising. Previously only an exact ``1.0`` was handled.
-
+  than its descriptor. It raised ``AssertionError`` on any document that is not
+  three channels, and rendered an HSB or Lab gradient's colours wrongly
+  everywhere. No gradient that rendered correctly changed value (#730, #758)
+- [fix] Read an HSB fill colour's hue as degrees rather than dividing by 300,
+  so every non-zero hue is no longer rotated and hue 360 no longer renders
+  white (#754)
 - [fix] Convert a Lab fill colour across colour modes instead of passing the
-  numbers through. Two mirror-image gaps, both closed here because they share
-  the conversion: a Lab descriptor on a **non**-Lab document was read with a
-  ``/255`` divisor that suited none of its three components, and any other
-  descriptor class on a **Lab** document was written into the Lab arrays
-  uninterpreted. Red on a Lab document arrived as ``(1.0, 0.0, 0.0)`` -- white
-  at the extreme green-blue corner -- where the answer is
-  ``(0.543, 0.819, 0.776)``.
-
-  ``psd_tools.color_convert`` gains :py:func:`~psd_tools.color_convert.lab_to_rgb`
-  and :py:func:`~psd_tools.color_convert.rgb_to_lab`, D50 with Bradford-adapted
-  sRGB matrices, matching Photoshop's own colour engine to 0.05 Lab units
-  converting in and a mean of 0.35/255 converting out. Lab values there are in
-  native CIE units -- ``L`` 0..100 and signed ``a``/``b`` -- which is the one
-  exception to the module's normalized-float rule, and the module now has a
-  reference page.
-
-  Backwards-incompatible in what it renders, for two cases that no Photoshop
-  file can contain -- Photoshop rewrites a fill descriptor into the document's
-  own colour class on save, so both need a third-party writer. Beyond the
-  conversion itself, the **reduction curve moves** for a Lab fill on a
-  grayscale, bitmap, duotone or multichannel document: it was ``L/255`` and is
-  now the BT.601 luminance of the converted colour, so even a neutral changes
-  (``Lab(50, 0, 0)`` goes from 0.196 to 0.466). A grey fill on a Lab document
-  changes too, from the raw grey to its ``L*``; the single-channel *widening*
-  path deliberately still does not convert, and says why (#743, #752).
-
-- [fix] Read a Lab fill colour with the right divisor for each of its three
-  components. ``L``, ``a`` and ``b`` were all divided by 255, which suits none
-  of them: ``L`` runs 0..100, and ``a``/``b`` are signed and stored offset by
-  128, so a neutral ``a = 0`` landed at the extreme end of its axis instead of
-  in the middle. A near-neutral mid-tone therefore rendered as a dark,
-  heavily saturated colour. Measured against a Photoshop-authored Lab document
-  the old reading was out by up to 155/255; the corrected one reproduces
-  Photoshop's own render of fourteen swatches spanning both ends of each chroma
-  axis to within 1/255. Affects solid-colour, gradient and stroke fills
-  authored with a Lab colour on a Lab document -- Pantone and other book
-  colours, which is how they arise in practice. Out-of-range components now
-  clamp to the end of their axis rather than wrapping to an unrelated colour.
-  The same offset encoding corrects two neutral a/b constants that were spelled
-  0.5, half a code value below the byte Photoshop writes: the artboard
-  background default and the single-channel widening added in #722.
-
-  Lab descriptors on a *non*-Lab document were left to the entry above, which
-  replaces the ``/255`` reading for them with a real conversion (#743).
-
+  numbers through, in both directions. ``psd_tools.color_convert`` gains
+  :py:func:`~psd_tools.color_convert.lab_to_rgb` and
+  :py:func:`~psd_tools.color_convert.rgb_to_lab` (D50, Bradford-adapted sRGB)
+  and a reference page. **Backwards incompatible** in what it renders, for two
+  cases no Photoshop file can contain; the reduction curve also moves for a Lab
+  fill on a grayscale, bitmap, duotone or multichannel document (#743, #752)
+- [fix] Read a Lab fill colour with the right divisor for each component --
+  all three were divided by 255 -- which was out by up to 155/255. Affects
+  fills authored with a Lab colour on a Lab document, which is how Pantone and
+  other book colours arise (#743)
 - [fix] Convert rather than replicate when a single-channel canvas is widened
-  to a CMYK or Lab document's channel count. A grey ``g`` became ``(g, g, g, g)``
-  in CMYK -- a heavily over-inked colour that is not the grey it came from --
-  and ``(L, L, L)`` in Lab, where a lightness copied onto the a/b axes is the
-  opposite of neutral. CMYK now transforms through the document's embedded ICC
-  profile, matching Photoshop's own conversion to within 3/255 across a grey
-  ramp where replication was out by ~100/255, and a grey widened this way
-  survives the round trip back out through ``apply_icc`` to within 3/255 --
-  except very near black, which is outside the CMYK gamut and comes back up to
-  7/255 lighter. A CMYK document with
-  no usable profile falls back to the K-only formula a grey *fill* already uses.
-  Lab becomes ``(g, 128/255, 128/255)``, a and b being offset-encoded so that
-  128/255 is neutral. RGB is unchanged, and multichannel keeps replicating -- its spot
-  planes have no colorimetric reading to convert into. Reachable when a caller
-  hands a single-channel backdrop to a multi-channel document, or through a
-  grayscale pattern fill (#722).
-
-- [fix] Stop cross-mode fills writing ink-space CMYK into an inverted canvas.
-  The compositor's CMYK arrays store what is *left* -- 1.0 is no ink, which
-  ``topil()`` inverts back on the way out -- but the three conversions into CMYK
-  in ``composite/paint.py`` handed them ``color_convert``'s ink-space output
-  unchanged, where white is ``(0, 0, 0, 0)``. A white solid-colour, gradient or
-  stroke fill on a CMYK document therefore composited to solid black, and a
-  black one to a muddy CMY; the artboard background constants were inverted the
-  same way. Fills authored from an RGB, grayscale, HSB or Lab descriptor are
-  affected; a CMYK descriptor on a CMYK document always read correctly.
-  ``psd_tools.color_convert`` is unchanged -- it is public API with a documented
-  ink-space contract -- and the ``background_color`` docstring, which repeated
-  the wrong spelling, is corrected (#747).
-
-- [fix] Let a per-channel colour be set on a multichannel document.
-  :py:attr:`~psd_tools.api.psd_image.PSDImage.background_color` validated the
-  sequence against a table whose multichannel entry is 64 -- the format's
-  maximum number of channels, not any file's own count -- so every sequence was
-  rejected and only a scalar could be set. Since ``background_color`` is the
-  backdrop ``save()`` composites the merged preview against, a multichannel
-  document had no way to be given a per-channel one.
-  ``PSDImage.new("MULTICHANNEL", ...)`` was unsatisfiable for the same reason:
-  it builds a one-channel document while the validator demanded 64
-  (#731, #742).
-
-- [fix] Size a fill from the document rather than from its descriptor. A solid
-  colour, gradient or stroke takes its colour from a descriptor whose colour
-  class is independent of the document's colour mode, and the width that came
-  back was the descriptor's. Where that was neither one channel nor the
-  document's own count the compositor's width assertion fired, which is what an
-  RGB, CMYK or Lab descriptor did on a bitmap, duotone or multichannel
-  document, a CMYK one on an indexed or Lab document, and a Lab one on a
-  grayscale or CMYK document. An HSB descriptor was worse -- it raised
-  ``ValueError`` on every mode but RGB and CMYK. Every descriptor class now
-  converts to the document's width. No colour that already rendered changed
-  value (#730, #742).
-
-- [fix] Stop ``composite_pil()`` declaring a PIL mode that its pixel array does
-  not match. The mode and the array were chosen separately, and they could
-  disagree in three ways -- two of which produced pixels that corresponded to
-  nothing in the file, and one of which raised (#729):
-
-  A multichannel document came back **garbled**. Its colour array has one plane
-  per spot channel, and the narrowing to the single plane PIL can hold was keyed
-  on the mode and ran *after* alpha had been appended -- by which point the mode
-  was ``"LA"`` and no longer matched, so it never fired. ``Image.fromarray()``
-  does not reject a four-plane array declared as two: it reads two bytes out of
-  every four, and the planes that came back corresponded to nothing in the file.
-  The narrowing now happens before alpha is appended, and the dropped channels
-  are announced with a warning instead of being lost silently. Use
-  :py:func:`psd_tools.composite.composite` to keep every channel.
-
-  Under ``force``, bitmap, CMYK and Lab documents **raised**. ``"A"`` was
-  appended to the mode whether or not an alpha variant of it exists, so those
-  asked ``Image.fromarray()`` for ``"1A"``, ``"CMYKA"`` and ``"LABA"`` and got
-  ``ValueError: unrecognized image mode`` or ``TypeError: Cannot handle this
-  data type``. Of the modes this function can produce, only ``"L"`` and
-  ``"RGB"`` have an alpha variant, so for the others the alpha is no longer
-  packed into the array -- it is handed to ``post_process()``, which still
-  carries it for CMYK by converting to RGB first. So ``force=True`` on a CMYK
-  document now returns the same ``"RGBA"`` that ``force=False`` always did.
-  Bitmap results carry no alpha in either mode: ``post_process()`` applies it
-  only to ``"RGB"`` and ``"L"``, and the ICC conversion that gets CMYK there
-  cannot reach a 1-bit image -- little-cms builds no transform for one, so the
-  profile is skipped and the mode stays ``"1"``. Lab results carry none either,
-  for a third reason: a Lab document with an ICC profile raises before it gets
-  that far -- #740.
-
-  A bitmap document came back **garbled in both modes**.
-  ``Image.fromarray(uint8, "1")`` does not mean "these bytes, as bilevel": PIL
-  reads the raw mode literally at one bit per pixel, consuming one byte per
-  eight columns and expanding its bits across the row, so a 4x4 document
-  returned the bits of its first four bytes. The plane is now built as ``"L"``,
-  where a byte is a pixel, and reduced afterwards. That was also the
-  compositor's only ``Image.fromarray()`` call whose ``mode`` reinterprets the
-  array's data type -- the use Pillow deprecated and removes in Pillow 13 --
-  so it no longer warns. Passing ``mode`` where it matches the dtype, as the
-  other colour modes do, is unaffected.
-
-  Of the 284 fixtures outside ``third-party-psds``, rendered in both modes:
-  every ``force=False`` render is bitwise identical except the bitmap one, and
-  under ``force`` seventeen renders that previously raised now return an image,
-  while exactly one changes from one image to another -- the garbled
-  multichannel document.
+  to a CMYK or Lab document. CMYK now transforms through the document's
+  embedded ICC profile, falling back to the K-only formula when there is none;
+  RGB is unchanged and multichannel keeps replicating. Reachable through a
+  grayscale pattern fill (#722)
+- [fix] Stop cross-mode fills writing ink-space CMYK into an inverted canvas: a
+  white fill on a CMYK document composited to solid black. Affects fills
+  authored from an RGB, grayscale, HSB or Lab descriptor.
+  ``psd_tools.color_convert`` is unchanged, its ink-space contract being public
+  API (#747)
+- [fix] Let a per-channel colour be set on a multichannel document, and make
+  ``PSDImage.new("MULTICHANNEL", ...)`` satisfiable; the validator demanded 64
+  components (#731, #742)
+- [fix] Size a fill from the document rather than its descriptor, so a colour
+  class that does not match the document's mode no longer fires the
+  compositor's width assertion -- or, for HSB, raises ``ValueError`` on every
+  mode but RGB and CMYK. No colour that already rendered changed value
+  (#730, #742)
+- [fix] Stop ``composite_pil()`` declaring a PIL mode its pixel array does not
+  match. Multichannel and bitmap documents came back garbled, and bitmap, CMYK
+  and Lab raised under ``force`` -- ``force=True`` on CMYK now returns the same
+  ``"RGBA"`` as ``force=False``. Dropped channels are now warned about; use
+  :py:func:`psd_tools.composite.composite` to keep them. Also removes the
+  ``Image.fromarray()`` spelling Pillow removes in 13 (#729)
 - [fix] Correct pass-through group compositing when the group opacity is below
-  255. The group's contribution was blended against the backdrop twice, so a
-  partially transparent backdrop bled its colour into the result and the output
-  varied with nesting depth (#703, #706).
+  255. The group's contribution was blended against the backdrop twice, so the
+  output varied with nesting depth (#703, #706)
 - [fix] Detect the real user mask header from the channel list rather than by
-  record length alone. ``MaskData`` misidentified its presence, so
-  ``user_mask_density``, ``user_mask_feather``, ``vector_mask_density`` and
-  ``vector_mask_feather`` returned ``None`` for affected files (#693, #704).
-- [fix] Accept every scalar spelling of the composite backdrop. ``color=1`` and
-  ``color=np.float32(1.0)`` raised ``TypeError`` because only ``float`` was
-  recognised as a scalar. The backdrop is now normalised once at the API
-  boundary rather than reinterpreted at each point of use (#708, #709).
+  record length alone, so ``user_mask_density``, ``user_mask_feather``,
+  ``vector_mask_density`` and ``vector_mask_feather`` no longer return ``None``
+  for affected files (#693, #704)
+- [fix] Accept every scalar spelling of the composite backdrop; ``color=1`` and
+  ``color=np.float32(1.0)`` raised ``TypeError`` (#708, #709)
 - [fix] Recognise a transparent backdrop given as a NumPy scalar, a 0-d array,
-  or a per-pixel array of zeros. Compositing a document with no layers used
-  ``alpha=np.float32(0.0)`` as if it were opaque, which whitened every
-  uncovered pixel (#708).
-- [fix] Reject a multi-channel backdrop ``alpha``. Alpha is single-channel by
-  definition, but a wider array was accepted and reached ``composite_pil()``,
-  which concatenates it onto the colour array and built an image of the wrong
-  width (#708).
+  or a per-pixel array of zeros, which was treated as opaque and whitened every
+  uncovered pixel (#708)
+- [fix] Reject a multi-channel backdrop ``alpha``, which reached
+  ``composite_pil()`` and built an image of the wrong width (#708)
 - [fix] Composite over a single-channel backdrop array in a multi-channel
-  document. The compositor's colour canvas was widened lazily at the first
-  source layer, so a document with no source to apply -- every layer filtered
-  out or invisible, or a document whose only layers are adjustments -- kept a
-  one-channel array and raised ``TypeError`` from ``Image.fromarray()`` or
-  ``ValueError: Channel count does not match colormode``. The channel count is
-  now fixed when the compositor is built (#710).
-- [fix] Reject a backdrop whose channel count is neither 1 nor the document's.
-  A three-channel backdrop against a CMYK document used to surface as a NumPy
-  broadcast error from inside the blend arithmetic (#710).
-- [fix] Composite a layerless multichannel document over a backdrop. The
-  backdrop was sized from ``EXPECTED_CHANNELS``, which reports 64 channels for
-  multichannel documents regardless of how many the file actually carries, so
-  the blend raised ``ValueError`` (#708).
-- [fix] Composite a multichannel document that *has* layers. The same
-  ``EXPECTED_CHANNELS`` count of 64 sized the backdrop on the layered path, so
-  the canvas was built 64 channels wide and the first layer met it with an
-  ``AssertionError``. The width now comes from the document header. Note that
-  this fixes the NumPy ``composite()`` entry point; ``PSDImage.composite()``
-  keeps only the first spot channel for multichannel documents, as it already
-  did for layerless ones (#720).
+  document; one with no source layer to apply kept a one-channel canvas and
+  raised (#710)
+- [fix] Reject a backdrop whose channel count is neither 1 nor the document's,
+  rather than surfacing a NumPy broadcast error from inside the blend
+  arithmetic (#710)
+- [fix] Composite a multichannel document, with layers or without.
+  ``EXPECTED_CHANNELS`` reports 64 -- the format's maximum, not the file's
+  count -- so the canvas was built 64 wide and raised. ``PSDImage.composite()``
+  still keeps only the first spot channel (#708, #720)
 - [fix] Never let the ``max_alloc_bytes`` estimate in ``composite()`` fall
-  below the canvas it guards. The guard is there to reject a hostile file
-  *before* it allocates, but it was given the header's channel count alone,
-  which under-counted an indexed document's canvas by 3x -- its single stored
-  channel becomes three through the palette. It is now given the wider of the
-  header count and the canvas width, so no colour mode under-estimates. This
-  can reject a document that a very tight budget previously admitted. Applies
-  to ``composite()``'s own guard only: a document with no layers returns early,
-  before that estimate, and falls to the check in ``numpy()``, which was fixed
-  separately (#720, #732).
+  below the canvas it guards; an indexed document's was under-counted
+  threefold. May reject a document a very tight budget previously admitted
+  (#720, #732)
 - [fix] Never let the ``max_alloc_bytes`` estimate in ``numpy()`` fall below
-  the array it guards. ``get_image_data()`` was given the header's channel
-  count, which is below what it goes on to allocate for an indexed document:
-  the palette is applied to the whole buffer, so each stored channel becomes
-  three and the estimate was threefold short. Flattened indexed documents are
-  what Photoshop ordinarily writes, and such a document takes the zero-layer
-  early return in :py:func:`psd_tools.composite.composite`, which leaves this
-  the only estimate on that path. The count is now multiplied by the palette
-  expansion, so it matches the allocation exactly for every colour mode, depth
-  and channel count. This can reject a document that a very tight budget
-  previously admitted, and only an 8-bit indexed one (#732).
-
-  Note that the header's channel count is not cross-checked against the colour
-  mode, so the expansion scales with it: a header declaring eight channels
-  allocates twenty-four planes. The guard is sized for that, since it exists to
-  bound hostile headers rather than well-formed ones.
-
-  The same entry point no longer over-estimates its synthesised results either.
-  ``numpy("mask")``, and ``numpy("shape")`` on a document with no transparency,
-  return a ``(h, w, 1)`` array without reading the image data, but were
-  estimated at the document's stored width -- so a budget that fitted such a
-  request four times over could still reject it on a CMYK document. That
-  over-estimate was not specific to indexed and predates this entry.
-
-  The estimate bounds the array that is returned, which is what
-  ``check_pixel_size()`` measured as of this entry; peak usage was a small
-  multiple of it, closed later in this release (#767). 1-bit documents were
-  under-counted eightfold, which predated this entry as well and is fixed by the
-  row-stride entry above (#768).
-- [fix] Composite duotone documents at their stored width.
-  ``EXPECTED_CHANNELS`` reported 2 for duotone -- the ink count -- while duotone
-  pixel data is a single grayscale channel, the one to four ink curves living
-  in the colour mode data section. Three consequences, all fixed:
-  ``composite()`` returned a two-channel array whose second channel was not
-  data from the file but the backdrop copied; ``PSDImage.composite(force=True)``
-  returned *wrong pixels*, because the over-wide array was handed to PIL as
-  ``"LA"`` and the planes came out shifted against each other; and seven blend
-  modes -- ``ColorBurn``, ``ColorDodge``, ``HardLight``, ``LinearLight``,
-  ``PinLight``, ``SoftLight`` and ``VividLight`` -- raised ``IndexError`` on any
-  duotone document. Photoshop keeps layers in duotone mode, so every one of
-  these was reachable on ordinary files (#733).
-
-  ``Hue``, ``Saturation``, ``Color`` and ``Luminosity`` still raise on a duotone
-  document. They raise identically on a grayscale one, so that is a pre-existing
-  limitation of single-channel documents rather than anything this entry
-  changes; it is tracked in #735.
-- [fix] Read the alpha channel of a duotone document as alpha. Because the
-  colour array was taken to be two channels wide, a duotone file carrying a
-  transparency channel returned it as *colour* data from ``numpy("color")``,
-  and ``has_transparency()`` reported ``False`` -- while ``pil_mode`` said
-  ``"LA"``, so the document contradicted itself. No fixture has this shape
-  (#733).
-- [api] ``PSDImage.new("DUOTONE", ...)`` now accepts a colour. It previously
-  rejected every sequence: the constructor demanded two components while the
-  header it built declared one channel, so no value satisfied both (#733).
-
-  **Backwards incompatible**: a per-channel ``background_color`` on a duotone
-  document now takes one component instead of two.
-  ``psd.background_color = (0.5, 0.5)`` raises ``ValueError``; pass ``(0.5,)``
-  or a scalar. The second component was inert -- it had no channel to be
-  written to, and the saved bytes are identical without it (#733).
+  the array it guards, for the same indexed-palette reason, and stop it
+  over-estimating ``numpy("mask")`` and ``numpy("shape")``. May reject an
+  8-bit indexed document a very tight budget previously admitted (#732)
+- [fix] Composite duotone documents at their stored single grayscale channel
+  rather than the ``EXPECTED_CHANNELS`` ink count of 2. ``composite()``
+  returned a channel of copied backdrop, ``composite(force=True)`` returned
+  wrong pixels, and seven blend modes raised ``IndexError`` (#733)
+- [fix] Read the alpha channel of a duotone document as alpha; it was returned
+  as colour data from ``numpy("color")`` while ``has_transparency()`` reported
+  ``False``. No fixture has this shape (#733)
+- [api] ``PSDImage.new("DUOTONE", ...)`` now accepts a colour, having rejected
+  every sequence. **Backwards incompatible**: a per-channel
+  ``background_color`` on a duotone document takes one component instead of
+  two -- pass ``(0.5,)`` or a scalar. The second was inert (#733)
 - [api] Widen the ``color`` parameter of ``composite()``, ``composite_pil()``,
-  ``Layer.composite()``, ``Group.composite()``, ``Artboard.composite()`` and
-  ``PSDImage.composite()`` -- and of ``LayerProtocol`` and ``PSDProtocol`` --
-  from ``float | tuple[float, ...] | np.ndarray`` to
-  ``float | Sequence[float] | np.ndarray``, matching what is accepted at
-  runtime. This is a widening; existing calls are unaffected (#708).
-
-  **Backwards incompatible**: a per-channel backdrop whose length disagrees
-  with the document's colour mode now raises ``ValueError`` instead of being
-  silently accepted. ``psd.composite(color=(1.0, 1.0, 1.0))`` against a
-  grayscale or bitmap document previously produced a three-channel result that
-  was then reduced to its first channel; pass a scalar, or a sequence matching
-  ``psd.color_mode``.
+  ``Layer/Group/Artboard/PSDImage.composite()``, ``LayerProtocol`` and
+  ``PSDProtocol`` from ``tuple[float, ...]`` to ``Sequence[float]``, matching
+  what is accepted at runtime. **Backwards incompatible**: a per-channel
+  backdrop whose length disagrees with the colour mode now raises
+  ``ValueError`` instead of being silently reduced to its first channel (#708)
 - [fix] Apply a pattern overlay effect to a single-channel layer in a
-  multi-channel document. The effect took its target channel count from the
-  layer's own colour rather than from the document, so an RGB pattern over a
-  grayscale layer was rejected with ``AssertionError: Inconsistent pattern
-  channels.`` even though the pattern matched the document (#711).
-- [fix] Apply a stroke layer effect to a layer that has no mask. The mask
-  coverage is a bare scalar in that case, which the stroke effect handed
-  straight to an array routine, raising ``AttributeError: 'float' object has no
-  attribute 'shape'``. Reachable for a fill layer with no vector mask (#711).
-- [fix] Implement Knockout compositing (#707). Groups and layers with Knockout
-  enabled previously rendered as if the setting were absent. Shallow knockout
-  now punches through to the enclosing group's backdrop, and deep knockout to
-  the document backdrop -- passing through enclosing pass-through groups but
-  stopping at an isolated one, and at the Background layer where the document
-  has one. Also distinguishes shallow from deep, which were read as a single
-  boolean, via the new ``psd_tools.constants.Knockout`` enum.
-
-  **Backwards incompatible**: documents that combine Knockout with a fill
-  opacity below 100% now render differently. Documents without Knockout, or
-  with Knockout at fill opacity 100% -- where it has no visible effect by
-  design -- are unaffected.
+  multi-channel document, which was rejected with ``AssertionError:
+  Inconsistent pattern channels.`` (#711)
+- [fix] Apply a stroke layer effect to a layer that has no mask, which raised
+  ``AttributeError: 'float' object has no attribute 'shape'``. Reachable for a
+  fill layer with no vector mask (#711)
+- [fix] Implement Knockout compositing, previously rendered as if the setting
+  were absent, and distinguish shallow from deep via the new
+  ``psd_tools.constants.Knockout`` enum. **Backwards incompatible**: documents
+  combining Knockout with a fill opacity below 100% render differently (#707)
 
 1.18.0 (2026-08-07)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,18 +12,19 @@ Changelog
   change** for a CMYK document using ``Hue``, ``Saturation``, ``Color``,
   ``Luminosity``, ``Darker Color`` or ``Lighter Color`` (#781)
 - [fix] Degrade those same six modes to ``Normal`` with a debug log on the
-  documents Photoshop does not offer them on -- grayscale, duotone and
-  multichannel -- instead of raising or misreading the channels. The six
-  functions in ``psd_tools.composite.blend`` gain an optional colour-mode
-  argument, supplied by the new ``get_blend_func()``; ``BLEND_FUNC`` is
-  unchanged (#735, #746)
+  documents Photoshop does not offer them on -- grayscale, duotone,
+  multichannel, and any other width -- instead of raising or misreading the
+  channels. The six functions in ``psd_tools.composite.blend`` gain an
+  optional colour-mode argument from the new ``get_blend_func()``
+  (#735, #746)
 - [fix] Convert a single-channel *source* to the document's colour mode instead
   of replicating it, as #722 already did for a backdrop. Affects a one-channel
   source in a CMYK or Lab document (#749, #776, #777)
 - [security] Size the ``max_alloc_bytes`` guard against what ``numpy()`` and
   ``topil()`` peak at rather than the array they return -- up to 3.7x the old
-  estimate. Re-check a tuned budget: it admits and rejects different documents
-  in both directions (#767)
+  estimate. Re-check a tuned budget -- ``max_alloc_bytes`` or
+  ``$PSD_TOOLS_MAX_ALLOC_BYTES`` -- since it admits and rejects different
+  documents in both directions (#767)
 - [fix] Read and write a 1-bit (Bitmap mode) document at the row stride the
   format uses. ``numpy()`` and ``composite(ignore_preview=True)`` raised
   ``ValueError`` at most widths, and re-encoding sheared the image by a byte a
@@ -36,14 +37,16 @@ Changelog
 - [fix] Give the ``max_alloc_bytes`` estimate a depth term, so a 1-bit document
   can no longer allocate eight times its budget (GHSA-8q6g-vjhf-jp8m).
   ``_safe_zlib_decompress()`` now enforces the ceiling it documents, and
-  :py:func:`psd_tools.compression.decompressed_size_bound` is public
-  (#737, #769)
+  :py:func:`psd_tools.compression.decompressed_size_bound` is public. The
+  depth-1 arithmetic itself is superseded later in this release, at source by
+  #768 and on both image-data paths by #767 (#737, #769)
 - [fix] Replace a failed channel with exactly the byte count it declares. The
   substituted black fill picked its PIL mode from the depth, so a 16-bit
   channel came back double-width (#737, #769)
 - [fix] Split a pattern's alpha off by its slot layout rather than by its
   colour mode, so a multichannel-mode pattern composites instead of raising
-  ``AssertionError``. Rendering is unchanged for every pattern layout in the
+  ``AssertionError`` -- as does any pattern storing fewer colour planes than
+  its mode implies. Rendering is unchanged for every pattern layout in the
   corpus and in the patterns Photoshop ships (#741)
 - [fix] Convert a CMYK fill descriptor through ink space, so it no longer
   renders black on every non-CMYK document. A CMYK document was unaffected
@@ -77,8 +80,7 @@ Changelog
   :py:func:`~psd_tools.color_convert.lab_to_rgb` and
   :py:func:`~psd_tools.color_convert.rgb_to_lab` (D50, Bradford-adapted sRGB)
   and a reference page. **Backwards incompatible** in what it renders, for two
-  cases no Photoshop file can contain; the reduction curve also moves for a Lab
-  fill on a grayscale, bitmap, duotone or multichannel document (#743, #752)
+  cases no Photoshop file can contain (#743, #752)
 - [fix] Read a Lab fill colour with the right divisor for each component --
   all three were divided by 255 -- which was out by up to 155/255. Affects
   fills authored with a Lab colour on a Lab document, which is how Pantone and

--- a/src/psd_tools/api/numpy_io.py
+++ b/src/psd_tools/api/numpy_io.py
@@ -38,50 +38,27 @@ def _image_data_planes(psdimage: "PSDProtocol", flat: bool = False) -> int:
     """Planes :func:`get_image_data` will allocate, for its allocation guard.
 
     ``flat`` marks the paths that return a synthesised ``(h, w, 1)`` array
-    without reading the image data at all -- a mask, or a shape on a document
-    with no transparency. Those allocate one plane whatever the colour mode, so
-    estimating them at the stored width rejects requests that comfortably fit:
-    ``numpy("mask")`` on a CMYK document allocates a quarter of what the header
-    implies. That over-estimate predates the palette fix below for every
-    multi-channel mode; it is corrected here rather than left to grow a third
-    case.
+    without reading the image data -- a mask, or a shape on a document with no
+    transparency. Those allocate one plane whatever the colour mode.
 
-    Otherwise the header's channel count is what the merged image data *stores*,
-    and for every colour mode but one it is also what gets allocated. Indexed at
-    depth 8
-    is the exception: :func:`_parse_array` applies the palette to the whole
-    buffer rather than to one plane, so ``(channels * h * w,)`` becomes
-    ``(channels * h * w, 3)`` and the reshape below yields
-    ``(h, w, 3 * channels)``. The header alone under-counted that threefold.
+    Otherwise the header's channel count is what the merged image data stores,
+    and for every colour mode but one it is what gets allocated. Indexed at
+    depth 8 is the exception: :func:`_parse_array` applies the palette to the
+    whole buffer, so the result is ``(h, w, 3 * channels)``. Only that branch
+    applies it, so a malformed 16- or 32-bit indexed document keeps its stored
+    width and must not be tripled.
 
     Deliberately *not* ``max(channels, get_color_channels(psdimage))``, the
-    shape #728 gave the compositor's guard. That one bounds a canvas built at
-    the resolved width, so the wider of the pair is right there. This one bounds
-    the stored array, whose width the header fixes -- and taking the wider of
-    the pair here would over-estimate any file whose header declares fewer
-    channels than its mode implies. Those parse fine and produce a narrow array:
-    a one-channel RGB document returns ``(h, w, 1)`` and would have been
-    rejected at four times its real size, which for a guard whose whole job is
-    admitting sound files is a false positive rather than a safety margin.
+    shape the compositor's guard uses. That one bounds a canvas built at the
+    resolved width; this one bounds the stored array, whose width the header
+    fixes. Taking the wider of the pair would reject a one-channel RGB document
+    at four times its real size -- a false positive, not a safety margin.
 
-    The palette is applied only in :func:`_parse_array`'s depth-8 branch, so a
-    16- or 32-bit indexed document -- malformed, indexed being an 8-bit mode --
-    keeps its stored width and must not be tripled either.
-
-    Depth 1 had a case of its own until #768, the array following the *byte*
-    count rather than the pixel count -- ``np.unpackbits`` yields one float32
-    per bit, and ``length`` counted a byte per pixel, so it came back eightfold
-    (#737). Both halves of that are gone: ``length`` counts packed rows and
-    :func:`_parse_array` trims each row's padding, so a 1-bit document
-    allocates one float32 per pixel and the header bounds it exactly.
-
-    This bounds the array that is returned. The transient peak on top of it --
-    :func:`_parse_array` holding two float32 arrays at once,
-    :func:`_remove_background` adding several more -- is
-    :func:`_image_data_peak_bytes`'s subject, and it is what the guard is given
-    (#767). Keep this one about the width of the result: the two are separate
-    because the plane count is a property of the format and the transients are a
-    property of the code, and they go stale for different reasons.
+    This bounds the array that is returned; the transient peak on top of it is
+    :func:`_image_data_peak_bytes`'s subject, and is what the guard is given
+    (#767). Keep the two separate: the plane count is a property of the format
+    and the transients are a property of the code, and they go stale for
+    different reasons.
     """
     if flat:
         return 1
@@ -358,25 +335,14 @@ def get_pattern_color_channels(pattern: Pattern) -> int:
     at the front of its array and any alpha at the back.
 
     Reading the boundary off the slot layout is what makes it answerable at
-    all. The alternative -- :py:data:`~psd_tools.api.utils.EXPECTED_CHANNELS`
-    keyed on the pattern's color mode -- states the width a *document* in that
-    mode carries, which is only incidentally the width this pattern stored.
-    Multichannel is the mode that can never agree, its entry being 64, the
-    format's maximum rather than any pattern's count; but any pattern storing
-    fewer color planes than its mode's constant missed the split the same way,
-    and the combined array was then rejected downstream as inconsistent with
-    the canvas (#741).
+    all. :py:data:`~psd_tools.api.utils.EXPECTED_CHANNELS` keyed on the
+    pattern's color mode states the width a *document* in that mode carries,
+    which is only incidentally the width this pattern stored (#741).
 
-    Measured over the 65 patterns Photoshop 2026 ships in
-    ``Presets/Patterns/*.pat``: RGB writes slots ``(0, 1, 2)``, RGB with
-    transparency ``(0, 1, 2, 25)``, grayscale ``(0,)``.
-
-    That measurement is what the rule rests on, and it is the whole of what it
-    rests on: a pattern that wrote its alpha into a color slot instead of a
-    trailing one would be read as all color, which is the failure this fixes,
-    facing the other way. Nothing in the corpus or in Photoshop's own presets
-    is laid out that way, and for multichannel there is no constant to fall
-    back on regardless.
+    The rule rests on how Photoshop's shipped presets are laid out -- alpha in
+    a trailing slot, never a color one. A pattern written the other way would
+    be read as all color; nothing in the corpus or in those presets is, and for
+    multichannel there is no constant to fall back on regardless.
     """
     channels = pattern.data.channels
     color_slots = max(len(channels) - 2, 0)

--- a/src/psd_tools/api/utils.py
+++ b/src/psd_tools/api/utils.py
@@ -188,32 +188,15 @@ EXPECTED_CHANNELS = {
 def get_color_channels(psdimage: "PSDProtocol") -> int:
     """Number of color channels a document's pixel arrays carry.
 
-    :data:`EXPECTED_CHANNELS` names a constant per color mode, which is the
-    right answer for every mode whose channel count the mode itself fixes.
-    Multichannel is the exception: its entry is 64, the *format's maximum*
-    number of channels rather than any document's actual count, so a
-    multichannel document is the only one that has to be asked how many
-    channels it carries.
+    Use this, rather than :data:`EXPECTED_CHANNELS`, wherever a caller must
+    *allocate* a canvas as wide as the document's own arrays or validate a
+    color against one. The constant is right for every mode whose channel count
+    the mode itself fixes, but its multichannel entry is 64 -- the format's
+    maximum, not any document's count -- so only the document can say.
 
-    Leaving that 64 in place is deliberate, though not harmless. The reader that
-    genuinely wants it is the defensive cap in ``numpy_io._find_channel()``,
-    where a layer record may declare more channels than the header does; 64
-    never truncates there, which is what keeps a real mismatch visible to the
-    compositor instead of quietly trimmed. Two more are inert rather than
-    correct -- the ``psdimage.channels > expected`` thresholds in
-    :func:`has_transparency` and :func:`get_transparency_index` can never fire,
-    because ``FileHeader.channels`` is validated to at most 56, and
-    :func:`~psd_tools.api.numpy_io.get_image_data` special-cases multichannel
-    before it reaches the table at all. The one that was simply wrong was
-    ``_validate_color_input()``, which required a sequence of exactly 64
-    components and so rejected every per-channel
-    :py:attr:`PSDImage.background_color` on a multichannel document; #731 fixed
-    that by giving it an explicit channel count, supplied by this function or
-    by :func:`color_channels`, rather than by letting it read the table.
-
-    So this is for the callers the constant cannot serve: the ones that must
-    *allocate* a canvas as wide as the document's own arrays, or validate a
-    color against one.
+    That 64 is left in place on purpose: ``numpy_io._find_channel()`` uses it as
+    a defensive cap, where never truncating is what keeps a layer record
+    declaring more channels than the header visible to the compositor.
 
     Args:
         psdimage: The PSD image protocol object

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -11,9 +11,11 @@ representing pixel color channels. They follow Adobe's PDF Blend Mode specificat
 Blend mode categories:
 
 **Normal modes:**
+
 - ``normal``: Source replaces backdrop (no blending)
 
 **Darken modes:**
+
 - ``darken``: Selects darker of source and backdrop
 - ``multiply``: Multiplies colors (darkens)
 - ``color_burn``: Darkens backdrop to reflect source
@@ -21,6 +23,7 @@ Blend mode categories:
 - ``darker_color``: Selects darker color (non-separable)
 
 **Lighten modes:**
+
 - ``lighten``: Selects lighter of source and backdrop
 - ``screen``: Inverted multiply (lightens)
 - ``color_dodge``: Brightens backdrop to reflect source
@@ -28,6 +31,7 @@ Blend mode categories:
 - ``lighter_color``: Selects lighter color (non-separable)
 
 **Contrast modes:**
+
 - ``overlay``: Combination of multiply and screen
 - ``soft_light``: Soft version of overlay
 - ``hard_light``: Hard version of overlay
@@ -37,17 +41,18 @@ Blend mode categories:
 - ``hard_mix``: Posterizes to primary colors
 
 **Inversion modes:**
+
 - ``difference``: Absolute difference between colors
 - ``exclusion``: Similar to difference but lower contrast
 
 **Component modes (non-separable):**
+
 - ``hue``: Preserves luminosity and saturation, replaces hue
 - ``saturation``: Preserves luminosity and hue, replaces saturation
 - ``color``: Preserves luminosity, replaces hue and saturation
 - ``luminosity``: Preserves hue and saturation, replaces luminosity
-- ``darker_color``, ``lighter_color``: Return whichever operand is darker or
-  lighter, whole -- listed under Darken and Lighten above, but non-separable
-  like the four here, and wrapped by the same guards
+- ``darker_color``, ``lighter_color``: Return one operand whole (also listed
+  under Darken and Lighten, but non-separable like the four here)
 
 Implementation details:
 
@@ -363,36 +368,26 @@ def non_separable(k: Literal["b", "s"]):
 
     - **Multichannel** falls back, and is checked first for that reason. Its
       channels are spot inks, so a hue or a luminosity read off them is
-      meaningless whether there are three of them or thirty; keying on the width
-      alone had four plates claimed as CMYK and three blended as if they were R,
-      G and B (#746).
-    - **One channel** falls back on the width: grayscale, duotone and bitmap are
-      each one channel wide, and Photoshop offers none of the six on any of
-      them. Two channels, and five or more, likewise.
+      meaningless at any plate count; keying on the width alone had four plates
+      claimed as CMYK and three blended as if they were R, G and B (#746).
+    - **One channel** falls back on the width -- grayscale, duotone, bitmap --
+      as do two, and five or more.
     - **CMYK** blends its CMY complement. **RGB** blends directly, and so does
       indexed, whose canvas
       :py:data:`~psd_tools.api.utils.EXPECTED_CHANNELS` fixes at three.
+    - **Lab** is three wide and so is blended as if it were RGB, which is this
+      module's pre-existing treatment and the right side to leave it on:
+      Photoshop does offer all six there.
 
-    Photoshop offers none of the six on any of the modes that fall back.
-    Scripted against Photoshop 2026, a grayscale document rejects every one with
-    *The command "Set" is not currently available* and they are greyed out in
-    the UI; bitmap mode does not admit layers at all; and a multichannel
-    document does not either -- converting to Multichannel flattens, so the
-    blend mode cannot be set on one in the first place. So there is no result to
-    reproduce, and widening or reinterpreting the array would produce output
-    Photoshop never does (#735, #746).
+    Photoshop offers none of the six on any mode that falls back, so there is
+    no result to reproduce and widening the array would invent output it never
+    produces (#735, #746).
 
     With no mode to ask -- a bare :py:class:`~psd_tools.composite.Compositor`,
-    or one of these functions called directly -- the width decides alone, as it
-    did before #746, and four channels are taken for CMYK. That is a guess, and
-    on a four-plate multichannel array it is the wrong one; it is the same guess
-    the whole module made before #746, kept because a caller who supplies no
-    document is not asking to be told which mode it has.
-
-    Lab is three channels wide and so is blended as if it were RGB. That is this
-    module's pre-existing treatment of Lab, not something the fallback decides,
-    and it is the right side to leave Lab on: Photoshop does offer all six modes
-    on a Lab document.
+    or one of these called directly -- the width decides alone and four
+    channels are taken for CMYK. That is a guess, and wrong on a four-plate
+    multichannel array; it is kept because a caller who supplies no document is
+    not asking to be told which mode it has.
     """
 
     def decorator(func):
@@ -410,20 +405,15 @@ def non_separable(k: Literal["b", "s"]):
 def non_separable_selection(func):
     """Wrap Darker Color or Lighter Color, which choose between whole pixels.
 
-    These two differ from the four component modes in taking the array whole
-    rather than by its first three channels: they return one operand or the
-    other unchanged, and on CMYK that has to include its K. Photoshop agrees --
-    over six colour pairs its Darker Color is one of the two inputs exactly, K
-    and all -- and forcing K from a fixed operand instead, as #781 found, gave a
-    colour neither input had (#781).
+    These two take the array whole rather than by its first three channels:
+    they return one operand or the other unchanged, and on CMYK that has to
+    include its K. They also compare a different quantity,
+    :py:func:`_lightness`, which folds K in, where the component modes blend
+    the CMY complement with no K term at all. Both halves of that asymmetry are
+    Photoshop's, not a simplification (#781).
 
-    They also compare a different quantity: :py:func:`_lightness`, which folds K
-    in, where the component modes blend the CMY complement with no K term at
-    all. Both halves of that asymmetry are Photoshop's, not a simplification.
-
-    The multichannel and width fallbacks are the same ones
-    :py:func:`non_separable` documents; both decorators get them from
-    :py:func:`_guarded`.
+    The multichannel and width fallbacks are :py:func:`non_separable`'s, both
+    decorators getting them from :py:func:`_guarded`.
     """
     return _guarded(func, func)
 
@@ -742,20 +732,18 @@ def get_blend_func(
     fourth is not black generation -- so the mode is bound to those here rather
     than plumbed through every blend signature (#746).
 
-    The result takes ``(Cb, Cs)`` either way, so the compositor calls it without
-    caring which kind it got. Pass no *color_mode* and the width decides alone,
-    exactly as it did before; :py:data:`BLEND_FUNC` itself is unchanged and
-    stays the mode-blind table.
+    The result takes ``(Cb, Cs)`` either way. Pass no *color_mode* and the
+    width decides alone; :py:data:`BLEND_FUNC` stays the mode-blind table.
 
-    *blend_mode* is ``bytes`` and not :py:class:`~psd_tools.constants.BlendMode`
-    because :py:data:`BLEND_FUNC` is keyed by two families -- enum members for a
-    layer's own mode, raw descriptor keys such as ``b"lighterColor"`` for a
-    stroke's or an effect's -- and ``BlendMode`` subclasses ``bytes``, so the
-    supertype admits both without a union of a type and its own supertype.
+    *blend_mode* is ``bytes`` rather than
+    :py:class:`~psd_tools.constants.BlendMode` because :py:data:`BLEND_FUNC` is
+    keyed by two families -- enum members for a layer's own mode, raw
+    descriptor keys such as ``b"lighterColor"`` for a stroke's or an effect's
+    -- and ``BlendMode`` subclasses ``bytes``.
 
-    Unknown keys answer :py:func:`normal`, as the ``.get`` calls this replaces
-    did. ``PASS_THROUGH`` is one of them and reaches here for real: a group that
-    isolates its adjustments is composited as an ordinary source.
+    Unknown keys answer :py:func:`normal`. ``PASS_THROUGH`` is one of them and
+    reaches here for real: a group that isolates its adjustments is composited
+    as an ordinary source.
     """
     func = BLEND_FUNC.get(blend_mode, normal)
     if color_mode is None or func not in _MODE_AWARE:

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -46,39 +46,20 @@ _SINGLE_CHANNEL_MODES = (
 def _clamp01(value: float) -> float:
     """Hold *value* inside the range a color array is allowed to carry.
 
-    Every descriptor color class normalizes by a fixed divisor, and nothing in
-    the format constrains the component to the range that divisor assumes: a
-    writer emitting ``a = 200`` yields 1.29, ``Gry = 150`` yields -0.5 and
-    ``Rd   = 300`` yields 1.18.
+    Nothing in the format constrains a descriptor component to the range its
+    color class normalizes by, and ``Compositor``'s own ``utils.clip()`` runs
+    too late to help: wherever the color is blended rather than laid down flat
+    -- an effect, a partial alpha, an anti-aliased vector edge -- the
+    out-of-range component has already corrupted the arithmetic (#757).
 
-    A component outside ``[0, 1]`` reaches the image by two routes, and only
-    one of them is still open. ``Compositor`` runs ``utils.clip()`` on its own
-    arrays, but the clip runs *after* the value has been blended, so wherever
-    the color is composited rather than laid down flat -- an effect, a partial
-    alpha, an anti-aliased vector edge -- the out-of-range component corrupts
-    the arithmetic first and clipping has nothing left to recover. Forging
-    ``Gry = 150`` into ``adjustment-fillers.psd`` puts 194 white pixels along
-    the shape's stroke where the stroke is ``(26, 26, 26)``, and
-    ``H = 0, Strt = 120, Brgh = 150`` puts 150 bright cyan ones there (#757).
+    Applied where the untrusted number enters rather than inside
+    ``color_convert``, so those conversions keep their documented ``[0, 1]``
+    input contracts. Saturation and brightness never arrive here;
+    :py:func:`psd_tools.color_convert.hsb_to_rgb` is total and clamps them.
 
-    The closed route is the uint8 cast. ``composite_pil()`` used to write
-    ``(255 * color).astype(np.uint8)``, and numpy *wraps* rather than
-    saturating, so those three components would have landed on bytes 72, 129
-    and 44. It clips as of #757, so nothing here depends on that cast to
-    saturate; the two guards are independent on purpose.
-
-    Clamping degrades to the end of the axis instead, which is the policy
-    :py:func:`psd_tools.color_convert.lab_to_rgb` already follows. Applied
-    where the untrusted number enters rather than inside ``color_convert``, so
-    those conversions keep their documented ``[0, 1]`` input contracts instead
-    of having to defend them. Saturation and brightness are the exception: they
-    reach :py:func:`psd_tools.color_convert.hsb_to_rgb`, which is total and
-    clamps them itself, so they never arrive here.
-
-    NaN maps to 0.0, because ``nan > 0.0`` is false and ``max`` therefore keeps
-    its first argument. That is wanted -- a malformed descriptor degrades to the
-    end of the axis rather than poisoning the canvas -- but it is a property of
-    the argument order, so do not reverse it.
+    NaN maps to 0.0, because ``nan > 0.0`` is false and ``max`` keeps its first
+    argument. That degradation is wanted, but it is a property of the argument
+    order -- do not reverse it.
     """
     return min(1.0, max(0.0, value))
 
@@ -135,11 +116,9 @@ def _from_rgb(color_mode: ColorMode, rgb: tuple[float, ...]) -> tuple[float, ...
     Indexed is deliberately three: its single stored channel expands through
     the palette, so three is the width its pixel arrays carry.
 
-    Lab is a real conversion rather than a width choice. It used to fall through
-    to ``return rgb``, which is three wide and so passed the width assertion
-    while meaning nothing: red arrived as ``(1.0, 0.0, 0.0)``, which a Lab array
-    reads as white at the extreme green-blue corner rather than as
-    ``(0.543, 0.819, 0.776)`` (#752).
+    Lab is a real conversion rather than a width choice: ``return rgb`` is
+    three wide and so passes the width assertion while meaning nothing, red
+    arriving as white at the extreme green-blue corner (#752).
     """
     if color_mode == ColorMode.CMYK:
         return _ink_to_canvas(rgb_to_cmyk(*rgb))

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -52,6 +52,10 @@ def _clamp01(value: float) -> float:
     -- an effect, a partial alpha, an anti-aliased vector edge -- the
     out-of-range component has already corrupted the arithmetic (#757).
 
+    ``composite_pil()``'s uint8 cast clips as of #757 and would saturate these
+    too, but the two guards are independent on purpose -- do not drop this one
+    on the strength of that one.
+
     Applied where the untrusted number enters rather than inside
     ``color_convert``, so those conversions keep their documented ``[0, 1]``
     input contracts. Saturation and brightness never arrive here;

--- a/src/psd_tools/composite/widen.py
+++ b/src/psd_tools/composite/widen.py
@@ -143,32 +143,17 @@ def _naive_cmyk(color: np.ndarray) -> np.ndarray:
 def _lab(color: np.ndarray) -> np.ndarray:
     """A grey is on Lab's neutral axis: a and b are neutral, L carries it.
 
-    ``a``/``b`` are offset-encoded, so neutral is ``128 / 255`` and not the
-    0.5 written here originally -- 0.5 truncates to byte 127 on the way out
-    where Photoshop writes 128 (#743). Photoshop agrees that a grey is neutral:
-    it reports ``a = b = 0`` for every grey.
+    ``a``/``b`` are offset-encoded, so neutral is ``128 / 255``; 0.5 truncates
+    to byte 127 where Photoshop writes 128 (#743).
 
-    ``L`` is passed through as the grey itself rather than as its L*, matching
-    the artboard defaults beside it. Lab has no exit ICC transform to anchor a
-    transfer function against, so converting here would bake an sRGB gamma
-    assumption into a mode the compositor already lists as unsupported.
-
-    Since #752 that makes this deliberately disagree with the *fill* path, which
-    does convert: a grey fill descriptor now reaches a Lab canvas at its L*, so
-    grey 0.6 lands at 0.632 where a widened grey 0.6 array stays at 0.6. The
-    asymmetry is intended, and the line is drawn at the descriptor rather than
-    at the canvas. A descriptor carries a colour a person picked in some space,
-    and for every class but Lab that space is sRGB-ish, so interpreting it is
-    sound. An arbitrary single-channel array carries no such claim -- it may be
-    a mask, a spot plane, a caller's scalar or a grayscale pattern's device
-    grey -- and interpreting it would invent a colour space it never had.
-
-    Since #749 that array can be a *source* and not only a canvas, which is
-    where the split becomes visible inside one document: a grey pattern fill
-    arrives one channel wide and is widened here to L = g, while the same grey
-    written as a ``Gry `` descriptor never reaches this function at all --
-    ``paint._get_gray()`` converts it to its L* and hands over three
-    channels.
+    ``L`` is passed through as the grey itself rather than as its L*. This
+    deliberately disagrees with the *fill* path, which converts (#752): a
+    descriptor carries a colour a person picked in some space, so interpreting
+    it is sound, while an arbitrary single-channel array -- a mask, a spot
+    plane, a caller's scalar, a grayscale pattern's device grey -- carries no
+    such claim, and converting it would invent a colour space it never had. The
+    line is drawn at the descriptor, not at the canvas; do not "fix" the
+    asymmetry.
     """
     neutral = np.full_like(color, LAB_NEUTRAL_CHROMA)
     return np.concatenate((color, neutral, neutral), axis=2)

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -354,26 +354,14 @@ def decompressed_size_bound(
     document *before* it exists.
 
     ``length`` is :py:func:`decompress`'s own ``height`` rows of
-    :func:`_row_size`; the two are meant to be read together. For a well-formed
-    body the bound is exact for RAW and RLE, and an over-estimate for the two
-    ZIP codecs, whose inflated size cannot be known without inflating the
-    stream. A malformed body only ever comes back smaller -- a truncated RLE
-    byte-count table yields fewer rows than ``height`` -- which is the safe
-    direction for a guard:
+    :func:`_row_size`; the two are meant to be read together. The bound is
+    exact for RAW and RLE and an over-estimate for the two ZIP codecs, whose
+    inflated size cannot be known without inflating the stream. A malformed
+    body only ever comes back smaller, which is the safe direction for a guard.
 
-    - RAW returns ``data[:length]``, so the body's own length caps it. At depth
-      8 and up a body shorter than ``length`` raises the mismatch check instead
-      of returning, so the ``min`` only bites at depth 1, where that check is
-      skipped.
-    - RLE returns exactly ``height`` rows of :func:`_row_size` bytes, each row
-      padded or clipped to that size by ``decode()`` rather than raising --
-      which is ``length`` exactly, the same rows counted the same way.
-    - Both ZIP codecs are capped at ``length`` by ``_safe_zlib_decompress()``,
-      and so is the black fill substituted for a channel that fails to decode.
-
-    Since #768 gave every depth the same row arithmetic, only RAW can now come
-    in under ``length``; before it, depth 1 counted a byte per pixel here and
-    eight times too few in the RLE codec, and the two codecs disagreed.
+    Only RAW can come in under ``length``, returning ``data[:length]``; at
+    depth 8 and up a short body raises the mismatch check instead, so the
+    ``min`` bites at depth 1 alone.
 
     :param data: the compressed body; read for its length only.
     :param compression: compression type, see :py:class:`.Compression`.

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -359,6 +359,10 @@ def decompressed_size_bound(
     inflated size cannot be known without inflating the stream. A malformed
     body only ever comes back smaller, which is the safe direction for a guard.
 
+    ZIP is bounded at all only because ``_safe_zlib_decompress()`` is given
+    ``length`` as its ceiling, as is the black fill substituted for a channel
+    that fails to decode. Loosen either and this stops being an upper bound.
+
     Only RAW can come in under ``length``, returning ``data[:length]``; at
     depth 8 and up a short body raises the mismatch check instead, so the
     ``min`` bites at depth 1 alone.

--- a/src/psd_tools/compression/__init__.py
+++ b/src/psd_tools/compression/__init__.py
@@ -363,9 +363,14 @@ def decompressed_size_bound(
     ``length`` as its ceiling, as is the black fill substituted for a channel
     that fails to decode. Loosen either and this stops being an upper bound.
 
-    Only RAW can come in under ``length``, returning ``data[:length]``; at
-    depth 8 and up a short body raises the mismatch check instead, so the
-    ``min`` bites at depth 1 alone.
+    RAW is the only codec whose under-run is by design -- it returns
+    ``data[:length]``, which is why the ``min`` below is on its branch alone. A
+    ZIP body can inflate to fewer than ``length`` bytes too, since
+    ``_safe_zlib_decompress()`` caps the output without requiring it; at depth 8
+    and up :py:func:`decompress`'s mismatch check rejects that, so it reaches a
+    caller at depth 1 only, where the check is skipped. RLE is exact whenever it
+    returns at all, ``decode_rle()`` padding or clipping each row to
+    :func:`_row_size`.
 
     :param data: the compressed body; read for its length only.
     :param compression: compression type, see :py:class:`.Compression`.


### PR DESCRIPTION
Closes #770.

Two halves, as the issue frames them: the changelog section, and the source prose the `tools/prose_density.py` sweep flags. No behaviour change — the executable code is provably untouched (see below).

## The changelog section

| | before | after |
| --- | --- | --- |
| 1.19.0 (unreleased) | 561 lines, 43 entries | **168 lines, 42 entries** |
| whole file | 1736 lines | 1343 lines |
| lines per entry | 13.0 | **4.0** |

Historically the file ran 2.5 lines per entry, and 1.19.0's section had grown to 30% of a fourteen-year file. What comes out is mechanism, which is already published in the cited PR, the commit message, and the GitHub Release body the `release` workflow generates from `git log`. What stays is one line of summary plus a "does this affect me" clause.

Verified mechanically against `main`:

- every issue/PR reference preserved except `#740`, which appeared only as an aside inside another entry's mechanism and points at a separate open issue rather than a fix in this release;
- all four `**Backwards incompatible**` flags and both `**Rendering change**` flags survive;
- entry count 43 → 42, accounted for entirely by merging the two multichannel compositing entries (#708, #720), both refs kept.

`CLAUDE.md` gains the budget explicitly — four lines as the aim, six as the ceiling, extra lines spent on a BC warning or a migration instruction and never on mechanism. The template already said "Short description of the user-visible change"; that was guidance without a number, and the section reached 13 lines an entry anyway.

## The source prose

`tools/prose_density.py` flagged 34 functions at ≥3x. **I did not compress all 34, deliberately.** Roughly two-thirds are properties whose two-line body makes the ratio meaningless while the docstring is ordinary API documentation with doctests and examples — `color_convert`'s converters, `PSDImage.image_resources`, `Shape.paths`. Optimizing the metric there would delete good docs. The metric is a way to find candidates, not a target.

What is compressed is the rationale essay: `get_color_channels()` at 39 lines over 2, `paint._clamp01()` at 36 over 2, `numpy_io._image_data_planes()` at 48 over 7, and six more. Each keeps the fact that cost real measurement and would otherwise be re-derived or re-broken — why `_clamp01()` guards at entry rather than inside `color_convert` and why its argument order must not be reversed; why `_image_data_planes()` is deliberately *not* `max(channels, get_color_channels())`; why `widen._lab()` disagrees with the fill path on purpose; why `length` is an upper bound for ZIP at all. What goes is the history of what earlier PRs got wrong, the corpus statistics that date fast, and the same explanation repeated at three layers.

Repo-wide: 4201 → 4085 prose lines against 10073 of code (0.42x → 0.41x), 34 → 33 flagged. The remaining flags are the property false positives above.

## Incidental docs fix

`composite/blend.py`'s module docstring had no blank line after any of its `**Darken modes:**` headings, so docutils read each bullet list as a run-on paragraph and raised `ERROR: Unexpected indentation` on the one wrapped item. Those lists were never rendering as lists. Sphinx now builds the module clean; the one remaining warning in the tree is a pre-existing ambiguous `List` cross-reference in an untouched file.

## Verification

- **No executable code changed.** ASTs with docstrings stripped hash identically to `main` for all six source files.
- `uv run pytest` — 2883 passed, 3 skipped, 25 xfailed, 2 xpassed (unchanged from `main`).
- `ruff check`, `ruff format --check`, `mypy` — clean.
- `sphinx-build` — clean but for the pre-existing warning above.

A subagent review of the first three commits caught one load-bearing fact cut too far (the ZIP soundness clause) and four entries narrowed past what they claim; the last commit restores them.

## Sequencing

#772 (ruff `D` rules) is sequenced after this, since its `D205`/`D400` fixes land on the summary lines this PR rewrites. I'll branch it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
