### PR TITLE
chore: enable ruff's pydocstyle rules as a scoped subset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [api] Annotate ``PhotoFilter.xyz`` as ``tuple[int, ...] | None`` rather than
+  ``bool``, which it never returned -- a version 3 record holds three
+  coordinates and a version 2 record leaves it ``None``. Type-checker output
+  only; the runtime value is unchanged (#772)
 - [docs] Stop five docstrings rendering interpreted escape sequences. The
   ``psd_tools.compression.rle`` module docstring shipped a literal NUL byte and
   a mojibake ``ÿ`` where its example wrote ``\x00`` and ``\xff``, which

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
-- [docs] Stop seven docstrings rendering interpreted escape sequences. The
+- [docs] Stop five docstrings rendering interpreted escape sequences. The
   ``psd_tools.compression.rle`` module docstring shipped a literal NUL byte and
   a mojibake ``ÿ`` where its example wrote ``\x00`` and ``\xff``, which
   ``help()`` rendered as such (#772)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- [docs] Stop seven docstrings rendering interpreted escape sequences. The
+  ``psd_tools.compression.rle`` module docstring shipped a literal NUL byte and
+  a mojibake ``ÿ`` where its example wrote ``\x00`` and ``\xff``, which
+  ``help()`` rendered as such (#772)
 - [fix] Correct ``Soft Light``, ``Vivid Light`` and ``Hard Mix``, which
   disagreed with Photoshop in every colour mode, not only in CMYK where #189
   reported it. **Rendering change** wherever those three are used (#189, #784)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,11 +7,11 @@ Changelog
 - [api] Annotate ``PhotoFilter.xyz`` as ``tuple[int, ...] | None`` rather than
   ``bool``, which it never returned -- a version 3 record holds three
   coordinates and a version 2 record leaves it ``None``. Type-checker output
-  only; the runtime value is unchanged (#772)
+  only; the runtime value is unchanged (#772, #787)
 - [docs] Stop five docstrings rendering interpreted escape sequences. The
   ``psd_tools.compression.rle`` module docstring shipped a literal NUL byte and
   a mojibake ``ÿ`` where its example wrote ``\x00`` and ``\xff``, which
-  ``help()`` rendered as such (#772)
+  ``help()`` rendered as such (#772, #787)
 - [fix] Correct ``Soft Light``, ``Vivid Light`` and ``Hard Mix``, which
   disagreed with Photoshop in every colour mode, not only in CMYK where #189
   reported it. **Rendering change** wherever those three are used (#189, #784)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,18 +99,20 @@ exclude = ["*.md"]
 # the rest are still being evaluated in #692.
 select = ["E4", "E7", "E9", "F"]
 extend-select = ["PLC0415", "T10", "D"]
+# Held back deliberately, on noise grounds rather than principle; each is
+# tracked in #786. Counts are repo-wide, since `ignore` is.
 ignore = [
-    # Missing docstrings. Requiring one on every public method is a different
-    # project from formatting the ones that exist, and it is the rule most
-    # readily satisfied with """Return the value.""" -- 581 violations, 395 of
-    # them D102. Tracked separately (#772).
+    # Missing docstrings, 1121 of them (544 D102). Requiring one on every
+    # public method is a different project from formatting the ones that
+    # exist, and it is the rule most readily satisfied with
+    # """Return the value.""".
     "D1",
-    # Collapse a short multi-line docstring. No safe fixes available, and it
-    # rewrites docstrings for a stylistic preference (#772).
+    # Collapse a short multi-line docstring, 87. No safe fixes available: all
+    # 87 are behind --unsafe-fixes.
     "D200",
-    # Imperative mood. A genuine convention, but it misfires on the property
-    # docstrings this codebase has many of -- "Gradient type, one of ..." --
-    # and reads as noise there (#772).
+    # Imperative mood, 96. A genuine convention, but it misfires on the
+    # property docstrings this codebase has many of -- "Gradient type, one of
+    # ..." -- and reads as noise there.
     "D401",
 ]
 
@@ -118,7 +120,7 @@ ignore = [
 # pep257, not google or numpy: it is the convention that matches this
 # codebase's reST/Sphinx docstrings (`:param x:`), and it leaves D212
 # multi-line-summary-first-line disabled. Under `google` that rule alone is
-# 452 violations -- a reflow of nearly every multi-line docstring in the tree.
+# 453 violations -- a reflow of nearly every multi-line docstring in the tree.
 convention = "pep257"
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,32 @@ exclude = ["*.md"]
 
 [tool.ruff.lint]
 # Ruff 0.16 greatly expanded the default rule set (59 -> 413 rules). Pin the
-# previous defaults so dependency bumps stay behaviour-neutral; adopting the
-# new rules can be done deliberately in a separate change.
+# previous defaults so dependency bumps stay behaviour-neutral, and adopt the
+# new rules deliberately, a family at a time -- D below is the first (#772);
+# the rest are still being evaluated in #692.
 select = ["E4", "E7", "E9", "F"]
-extend-select = ["PLC0415", "T10"]
+extend-select = ["PLC0415", "T10", "D"]
+ignore = [
+    # Missing docstrings. Requiring one on every public method is a different
+    # project from formatting the ones that exist, and it is the rule most
+    # readily satisfied with """Return the value.""" -- 581 violations, 395 of
+    # them D102. Tracked separately (#772).
+    "D1",
+    # Collapse a short multi-line docstring. No safe fixes available, and it
+    # rewrites docstrings for a stylistic preference (#772).
+    "D200",
+    # Imperative mood. A genuine convention, but it misfires on the property
+    # docstrings this codebase has many of -- "Gradient type, one of ..." --
+    # and reads as noise there (#772).
+    "D401",
+]
+
+[tool.ruff.lint.pydocstyle]
+# pep257, not google or numpy: it is the convention that matches this
+# codebase's reST/Sphinx docstrings (`:param x:`), and it leaves D212
+# multi-line-summary-first-line disabled. Under `google` that rule alone is
+# 452 violations -- a reflow of nearly every multi-line docstring in the tree.
+convention = "pep257"
 
 [tool.mypy]
 files = ["src/psd_tools", "tests", "tools", "docs/conf.py"]

--- a/src/psd_tools/api/adjustments.py
+++ b/src/psd_tools/api/adjustments.py
@@ -346,7 +346,7 @@ class PhotoFilter(AdjustmentLayer):
     """Photo filter adjustment."""
 
     @property
-    def xyz(self) -> bool:
+    def xyz(self) -> tuple[int, ...] | None:
         """XYZ coordinates, present in version 3 records.
 
         Version 2 records carry `color_space` and `color_components` instead,

--- a/src/psd_tools/api/adjustments.py
+++ b/src/psd_tools/api/adjustments.py
@@ -349,7 +349,10 @@ class PhotoFilter(AdjustmentLayer):
     def xyz(self) -> bool:
         """XYZ coordinates, present in version 3 records.
 
-        :return: `bool`
+        Version 2 records carry `color_space` and `color_components` instead,
+        and leave this `None`.
+
+        :return: `tuple` of three `int`, or `None`
         """
         return _assert_data(self._data).xyz
 

--- a/src/psd_tools/api/adjustments.py
+++ b/src/psd_tools/api/adjustments.py
@@ -67,7 +67,9 @@ class GradientFill(FillLayer):
     @property
     def gradient_kind(self) -> str:
         """
-        Kind of the gradient, one of the following:
+        Kind of the gradient.
+
+        One of the following:
 
          - `Linear`
          - `Radial`
@@ -345,7 +347,7 @@ class PhotoFilter(AdjustmentLayer):
 
     @property
     def xyz(self) -> bool:
-        """xyz.
+        """XYZ coordinates, present in version 3 records.
 
         :return: `bool`
         """

--- a/src/psd_tools/api/effects.py
+++ b/src/psd_tools/api/effects.py
@@ -147,9 +147,10 @@ class _Effect(_EffectProtocol):
 
     @property
     def value(self) -> Descriptor:
-        """Deprecated
+        """Effect descriptor value.
 
-        Effect descriptor value. Use `descriptor` property instead.
+        .. deprecated::
+            Use the :py:attr:`descriptor` property instead.
         """
         logger.debug("Deprecated, use 'descriptor' property instead.")
         return self.descriptor
@@ -259,8 +260,9 @@ class _GradientMixin(_EffectProtocol):
     @property
     def type(self) -> bytes:
         """
-        Gradient type, one of `linear`, `radial`, `angle`, `reflected`, or
-        `diamond`.
+        Gradient type.
+
+        One of `linear`, `radial`, `angle`, `reflected`, or `diamond`.
         """
         type_value = self.descriptor.get(Key.Type)
         return (
@@ -478,8 +480,10 @@ class BevelEmboss(_Effect, _AngleMixin):
     @property
     def bevel_style(self) -> bytes:
         """
-        Bevel style, one of `OuterBevel`, `InnerBevel`, `Emboss`,
-        `PillowEmboss`, or `StrokeEmboss`.
+        Bevel style.
+
+        One of `OuterBevel`, `InnerBevel`, `Emboss`, `PillowEmboss`, or
+        `StrokeEmboss`.
         """
         style = self.descriptor.get(Key.BevelStyle)
         return getattr(style, "enum", b"OtrB") if style is not None else b"OtrB"
@@ -533,7 +537,7 @@ class BevelEmboss(_Effect, _AngleMixin):
 
 @register(Klass.ChromeFX.value)
 class Satin(_Effect, _ColorMixin):
-    """Satin effect"""
+    """Satin effect."""
 
     @property
     def anti_aliased(self) -> bool:

--- a/src/psd_tools/api/effects.py
+++ b/src/psd_tools/api/effects.py
@@ -149,8 +149,7 @@ class _Effect(_EffectProtocol):
     def value(self) -> Descriptor:
         """Effect descriptor value.
 
-        .. deprecated::
-            Use the :py:attr:`descriptor` property instead.
+        .. note:: Deprecated. Use the ``descriptor`` property instead.
         """
         logger.debug("Deprecated, use 'descriptor' property instead.")
         return self.descriptor

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -186,8 +186,10 @@ class Layer(LayerProtocol):
     @property
     def kind(self) -> str:
         """
-        Kind of this layer, such as group, pixel, shape, type, smartobject,
-        or psdimage. Class name without `layer` suffix.
+        Kind of this layer.
+
+        One of group, pixel, shape, type, smartobject, or psdimage -- the
+        class name without its `layer` suffix.
 
         :return: `str`
         """
@@ -418,8 +420,9 @@ class Layer(LayerProtocol):
 
     def has_pixels(self) -> bool:
         """
-        Returns True if the layer has associated pixels. When this is True,
-        `topil` method returns :py:class:`PIL.Image.Image`.
+        Whether the layer has associated pixels.
+
+        When True, the `topil` method returns :py:class:`PIL.Image.Image`.
 
         :return: `bool`
         """
@@ -1247,7 +1250,7 @@ class GroupMixin(GroupMixinProtocol, Protocol):
 
     def find(self, name: str) -> Layer | None:
         """
-        Returns the first layer found for the given layer name
+        Return the first layer found for the given layer name.
 
         :param name:
         """
@@ -1454,8 +1457,9 @@ class Group(GroupMixin, Layer):
         include_clipping: bool = False,
     ) -> tuple[int, int, int, int]:
         """
-        Returns a bounding box for ``layers`` or (0, 0, 0, 0) if the layers
-        have no bounding box.
+        Return a bounding box for ``layers``.
+
+        Gives (0, 0, 0, 0) if the layers have no bounding box.
 
         :param layers: sequence of layers or a group.
         :param include_invisible: include invisible layers in calculation.
@@ -1505,8 +1509,10 @@ class Group(GroupMixin, Layer):
         open_folder: bool = True,
     ) -> Self:
         """
-        Create a new Group object with minimal records and data channels and metadata
-        to properly include the group in the PSD file.
+        Create a new Group object.
+
+        Builds the minimal records, data channels and metadata needed to
+        include the group in the PSD file.
 
         :param name: The display name of the group. Default to "Group".
         :param open_folder: Boolean defining whether the folder will be open or closed
@@ -2019,10 +2025,10 @@ class TypeLayer(Layer):
 
     @property
     def text(self) -> str:
-        """
+        r"""
         Text in the layer. Read-only.
 
-        .. note:: New-line character in Photoshop is `'\\\\r'`.
+        .. note:: New-line character in Photoshop is `'\\r'`.
         """
         return self._data.text_data.get(b"Txt ").value.rstrip("\x00")
 

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -681,7 +681,6 @@ class Layer(LayerProtocol):
 
             layer.lock(ProtectedFlags.COMPOSITE | ProtectedFlags.POSITION)
         """
-
         locks = self.locks
 
         if locks is None:
@@ -1252,7 +1251,6 @@ class GroupMixin(GroupMixinProtocol, Protocol):
 
         :param name:
         """
-
         for layer in self.findall(name):
             return layer
         return None
@@ -1263,7 +1261,6 @@ class GroupMixin(GroupMixinProtocol, Protocol):
 
         :param name:
         """
-
         for layer in self.descendants():
             if layer.name == name:
                 yield layer
@@ -1899,7 +1896,6 @@ class PixelLayer(Layer):
         **kwargs: Any,
     ) -> tuple[LayerRecord, ChannelDataList]:
         """Build layer record and channel data list from a PIL image."""
-
         # Initialize the layer record and channel data list.
         layer_record = LayerRecord(
             top=top,

--- a/src/psd_tools/api/layers.py
+++ b/src/psd_tools/api/layers.py
@@ -2028,7 +2028,7 @@ class TypeLayer(Layer):
         r"""
         Text in the layer. Read-only.
 
-        .. note:: New-line character in Photoshop is `'\\r'`.
+        .. note:: New-line character in Photoshop is ``'\r'``.
         """
         return self._data.text_data.get(b"Txt ").value.rstrip("\x00")
 

--- a/src/psd_tools/api/mask.py
+++ b/src/psd_tools/api/mask.py
@@ -70,7 +70,7 @@ class Mask(MaskProtocol):
 
     @property
     def bbox(self) -> tuple[int, int, int, int]:
-        """BBox"""
+        """BBox."""
         return self.left, self.top, self.right, self.bottom
 
     @property

--- a/src/psd_tools/api/pil_io.py
+++ b/src/psd_tools/api/pil_io.py
@@ -209,7 +209,6 @@ def convert_image_data_to_pil(
 
     :raises ValueError: If an invalid channel is specified
     """
-
     # The header's own channel count, with none of the corrections the numpy
     # path needs (:func:`~psd_tools.api.numpy_io._image_data_planes`), because
     # PIL allocates a plane per stored channel at every depth and mode. It sizes

--- a/src/psd_tools/api/protocols.py
+++ b/src/psd_tools/api/protocols.py
@@ -38,7 +38,7 @@ class MaskProtocol(Protocol):
 
     @property
     def bbox(self) -> tuple[int, int, int, int]:
-        """BBox"""
+        """BBox."""
         ...
 
     @property
@@ -116,8 +116,9 @@ class LayerProtocol(Protocol):
     @property
     def kind(self) -> str:
         """
-        Kind of this layer, such as group, pixel, shape, type, smartobject,
-        or psdimage.
+        Kind of this layer.
+
+        One of group, pixel, shape, type, smartobject, or psdimage.
         """
         ...
 
@@ -446,8 +447,10 @@ class PSDProtocol(GroupMixinProtocol, Protocol):
 
     def _update_record(self) -> None:
         """
-        Compiles the low-level tree layer structure back into records and channels list
-        recursively from the API layer structure.
+        Compile the low-level tree layer structure back into flat lists.
+
+        Walks the API layer structure recursively, producing the records and
+        channels list.
         """
         ...
 

--- a/src/psd_tools/api/psd_image.py
+++ b/src/psd_tools/api/psd_image.py
@@ -396,8 +396,9 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
 
     def has_preview(self) -> bool:
         """
-        Returns if the document has real merged data. When True, `topil()`
-        returns pre-composed data.
+        Whether the document has real merged data.
+
+        When True, `topil()` returns pre-composed data.
         """
         version_info = self.image_resources.get_data(Resource.VERSION_INFO)
         if version_info:
@@ -531,8 +532,9 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
     @property
     def color_mode(self) -> ColorMode:
         """
-        Document color mode, such as 'RGB' or 'GRAYSCALE'. See
-        :py:class:`~psd_tools.constants.ColorMode`.
+        Document color mode, such as 'RGB' or 'GRAYSCALE'.
+
+        See :py:class:`~psd_tools.constants.ColorMode`.
 
         :return: :py:class:`~psd_tools.constants.ColorMode`
         """
@@ -569,6 +571,7 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
     def image_resources(self) -> ImageResources:
         """
         Document image resources.
+
         :py:class:`~psd_tools.psd.image_resources.ImageResources` is a
         dict-like structure that keeps various document settings.
 
@@ -698,8 +701,9 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
 
     def thumbnail(self) -> Image.Image | None:
         """
-        Returns a thumbnail image in PIL.Image. When the file does not
-        contain an embedded thumbnail image, returns None.
+        Return a thumbnail image in PIL.Image.
+
+        Gives None when the file contains no embedded thumbnail image.
         """
         if Resource.THUMBNAIL_RESOURCE in self.image_resources:
             return pil_io.convert_thumbnail_to_pil(
@@ -939,8 +943,10 @@ class PSDImage(layers.GroupMixin, PSDProtocol):
 
     def _update_record(self) -> None:
         """
-        Compiles the tree layer structure back into records and channels list
-        recursively from the API layer structure.
+        Compile the tree layer structure back into flat lists.
+
+        Walks the API layer structure recursively, producing the records and
+        channels list.
         """
         # Initialize the layer structure information if not present.
         if self._record.layer_and_mask_information.layer_info is None:
@@ -995,7 +1001,7 @@ def _build_record_tree(
     layer_group: layers.GroupMixin,
 ) -> tuple[LayerRecords, ChannelImageData]:
     """
-    Builds the layer tree structure from records and channels list recursively
+    Build the layer tree structure from records and channels list, recursively.
     """
     layer_records = LayerRecords()
     channel_image_data = ChannelImageData()

--- a/src/psd_tools/api/shape.py
+++ b/src/psd_tools/api/shape.py
@@ -69,8 +69,9 @@ class VectorMask(object):
     @property
     def paths(self) -> list[Subpath]:
         """
-        List of :py:class:`~psd_tools.psd.vector.Subpath`. Subpath is a
-        list-like structure that contains one or more
+        List of :py:class:`~psd_tools.psd.vector.Subpath`.
+
+        Subpath is a list-like structure that contains one or more
         :py:class:`~psd_tools.psd.vector.Knot` items. Knot contains
         relative coordinates of control points for a Bezier curve.
         :py:attr:`~psd_tools.psd.vector.Subpath.index` indicates which
@@ -124,8 +125,10 @@ class VectorMask(object):
     @property
     def bbox(self) -> tuple[float, float, float, float]:
         """
-        Bounding box tuple (left, top, right, bottom) in relative coordinates,
-        where top-left corner is (0., 0.) and bottom-right corner is (1., 1.).
+        Bounding box tuple (left, top, right, bottom).
+
+        In relative coordinates, where the top-left corner is (0., 0.) and the
+        bottom-right corner is (1., 1.).
 
         The bounding box accounts for the full extent of all cubic Bezier
         curves, not just the anchor points.
@@ -256,8 +259,7 @@ class Stroke(object):
     @property
     def line_dash_set(self) -> list:
         """
-        Line dash set in list of
-        :py:class:`~psd_tools.decoder.actions.UnitFloat`.
+        Line dash set in list of :py:class:`~psd_tools.decoder.actions.UnitFloat`.
 
         :return: list
         """
@@ -301,7 +303,7 @@ class Stroke(object):
 
     @property
     def stroke_adjust(self) -> Any:
-        """Stroke adjust"""
+        """Stroke adjust."""
         return self._data.get(b"strokeStyleStrokeAdjust")
 
     @property
@@ -448,6 +450,7 @@ class RoundedRectangle(Origination):
     def radii(self) -> Any:
         """
         Corner radii of rounded rectangles.
+
         The order is top-left, top-right, bottom-left, bottom-right.
 
         :return: :py:class:`~psd_tools.psd.descriptor.Descriptor`
@@ -479,7 +482,7 @@ class Line(Origination):
     @property
     def line_weight(self) -> float:
         """
-        Line weight
+        Line weight.
 
         :return: `float`
         """

--- a/src/psd_tools/api/typesetting.py
+++ b/src/psd_tools/api/typesetting.py
@@ -469,10 +469,10 @@ class TextRun:
 
 
 class Paragraph:
-    """
+    r"""
     A paragraph of text containing one or more styled runs.
 
-    Paragraphs are delimited by carriage return characters (``\\r``)
+    Paragraphs are delimited by carriage return characters (``\r``)
     in Photoshop's text model.
 
     Example::

--- a/src/psd_tools/composite/adjustments.py
+++ b/src/psd_tools/composite/adjustments.py
@@ -284,7 +284,6 @@ def apply_levels(
     layer: Levels,
 ) -> np.ndarray:
     """Applies a levels adjustment to an image."""
-
     levels_data = layer.data
 
     lut_size = _get_lut_size(layer)
@@ -655,7 +654,6 @@ def apply_invert(
     layer: Invert,
 ) -> np.ndarray:
     """Applies an invert adjustment to an image."""
-
     return _1 - img
 
 
@@ -666,7 +664,6 @@ def apply_posterize(
     layer: Posterize,
 ) -> np.ndarray:
     """Applies a posterize adjustment to an image."""
-
     lut_size = _get_lut_size(layer)
     # layer.posterize is a 1–255 integer from the PSD spec. The [2, 255] clamp is
     # intentional: PS minimum is 2. This range is correct for both 8-bit and 16-bit
@@ -688,7 +685,6 @@ def apply_threshold(
     layer: Threshold,
 ) -> np.ndarray:
     """Applies a threshold adjustment to an image."""
-
     # CMYK requires accurate luminance conversion
     if colormode == ColorMode.CMYK:
         logger.info("Threshold isn't currently supported for CMYK.")

--- a/src/psd_tools/composite/adjustments.py
+++ b/src/psd_tools/composite/adjustments.py
@@ -147,8 +147,9 @@ def _get_lut_size(layer: Layer) -> Literal[256, 65536]:
 @functools.lru_cache(maxsize=2)
 def _lut_domain(lut_size: int) -> NDArray[np.float32]:
     """
-    Returns the normalized domain [0, 1] used for LUT interpolation,
-    with `lut_size` evenly spaced samples. Cached per size.
+    Return the normalized domain [0, 1] used for LUT interpolation.
+
+    Gives `lut_size` evenly spaced samples. Cached per size.
     """
     return np.linspace(_0, _1, lut_size, dtype=np.float32)
 

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -188,8 +188,9 @@ def soft_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 def vivid_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
-    Burns or dodges the colors by increasing or decreasing the contrast,
-    depending on the blend color. If the blend color (light source) is lighter
+    Burn or dodge the colors by increasing or decreasing the contrast.
+
+    Which one depends on the blend color. If the blend color (light source) is lighter
     than 50% gray, the image is lightened by decreasing the contrast. If the
     blend color is darker than 50% gray, the image is darkened by increasing
     the contrast.
@@ -212,8 +213,9 @@ def vivid_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 def linear_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
-    Burns or dodges the colors by decreasing or increasing the brightness,
-    depending on the blend color. If the blend color (light source) is lighter
+    Burn or dodge the colors by decreasing or increasing the brightness.
+
+    Which one depends on the blend color. If the blend color (light source) is lighter
     than 50% gray, the image is lightened by increasing the brightness. If the
     blend color is darker than 50% gray, the image is darkened by decreasing
     the brightness.
@@ -226,7 +228,9 @@ def linear_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 def pin_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
-    Replaces the colors, depending on the blend color. If the blend color
+    Replace the colors, depending on the blend color.
+
+    If the blend color
     (light source) is lighter than 50% gray, pixels darker than the blend color
     are replaced, and pixels lighter than the blend color do not change. If the
     blend color is darker than 50% gray, pixels lighter than the blend color
@@ -253,8 +257,9 @@ def subtract(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 def hard_mix(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
-    Adds the red, green and blue channel values of the blend color to the RGB
-    values of the base color. If the resulting sum for a channel is above 255 it
+    Add the blend color's channel values to those of the base color.
+
+    If the resulting sum for a channel is above 255 it
     receives a value of 255, and below 255 a value of 0; on exactly 255 it is
     255 only where the base is above half, as the comment below sets out.
     Therefore, all blended pixels have red, green, and blue channel values of
@@ -278,8 +283,9 @@ def hard_mix(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
 
 def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
-    Looks at the color information in each channel and divides the blend color
-    from the base color.
+    Divide the blend color from the base color.
+
+    Looks at the color information in each channel.
     """
     B = Cb / (Cs + _FLOAT_EPSILON)
     B[B > 1] = 1

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -285,7 +285,7 @@ def divide(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     """
     Divide the blend color from the base color.
 
-    Looks at the color information in each channel.
+    Operates on the color information in each channel independently.
     """
     B = Cb / (Cs + _FLOAT_EPSILON)
     B[B > 1] = 1

--- a/src/psd_tools/composite/blend.py
+++ b/src/psd_tools/composite/blend.py
@@ -194,7 +194,6 @@ def vivid_light(Cb: np.ndarray, Cs: np.ndarray) -> np.ndarray:
     blend color is darker than 50% gray, the image is darkened by increasing
     the contrast.
     """
-
     # Deliberately not color_burn/color_dodge: those carry the spec's backdrop
     # special cases -- Cb == 1 burns to 1, Cb == 0 dodges to 0 -- and Photoshop
     # does not apply them here. Inside Vivid Light the *source* extreme wins,

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -134,7 +134,7 @@ def _from_rgb(color_mode: ColorMode, rgb: tuple[float, ...]) -> tuple[float, ...
 
 
 def _get_color(color_mode: ColorMode, desc: Descriptor) -> tuple[float, ...]:
-    """Return color tuple from descriptor.
+    r"""Return color tuple from descriptor.
 
     Example descriptor::
 
@@ -331,7 +331,7 @@ def draw_pattern_fill(
     psd: Any,
     desc: Descriptor,
 ) -> tuple[np.ndarray | None, np.ndarray | None]:
-    """
+    r"""
     Create a pattern fill.
 
     Example descriptor::
@@ -612,7 +612,7 @@ def _noise_to_canvas(
 def _make_noise_gradient_color(
     color_mode: ColorMode, grad: Descriptor
 ) -> tuple[Any | None, Any | None]:
-    """
+    r"""
     Make a noise gradient color.
 
     TODO: Improve noise gradient quality.

--- a/src/psd_tools/composite/paint.py
+++ b/src/psd_tools/composite/paint.py
@@ -618,7 +618,6 @@ def _make_noise_gradient_color(
     TODO: Improve noise gradient quality.
 
     Example:
-
         Descriptor(b'Grdn'){
             'Nm  ': 'Custom\x00',
             'GrdF': (b'GrdF', b'ClNs'),

--- a/src/psd_tools/compression/rle.py
+++ b/src/psd_tools/compression/rle.py
@@ -64,7 +64,6 @@ def decode(data: bytes, size: int) -> bytes:
     remaining bytes are zero-padded.  The function always returns exactly *size*
     bytes without raising.
     """
-
     i, j = 0, 0
     length = len(data)
     data_arr = bytearray(data)
@@ -97,7 +96,6 @@ def encode(data: bytes) -> bytes:
 
     Apple PackBits RLE encoder.
     """
-
     MAX_LEN = 0xFF >> 1
     length = len(data)
     i = 0

--- a/src/psd_tools/compression/rle.py
+++ b/src/psd_tools/compression/rle.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Pure Python RLE (Run-Length Encoding) codec implementation.
 
 This module provides pure Python implementations of Apple PackBits RLE encoding
@@ -55,9 +55,7 @@ installing with build tools available.
 
 
 def decode(data: bytes, size: int) -> bytes:
-    """decode(data, size) -> bytes
-
-    Apple PackBits RLE decoder.
+    """Apple PackBits RLE decoder.
 
     Tolerant implementation: runs that would exceed *size* are clipped at the
     row boundary, runs whose input is truncated copy what is available, and any
@@ -92,10 +90,7 @@ def decode(data: bytes, size: int) -> bytes:
 
 
 def encode(data: bytes) -> bytes:
-    """encode(data) -> bytes
-
-    Apple PackBits RLE encoder.
-    """
+    """Apple PackBits RLE encoder."""
     MAX_LEN = 0xFF >> 1
     length = len(data)
     i = 0

--- a/src/psd_tools/constants.py
+++ b/src/psd_tools/constants.py
@@ -1,5 +1,5 @@
 """
-Various constants for psd_tools
+Various constants for psd_tools.
 """
 
 from enum import Enum, IntEnum, auto
@@ -7,8 +7,9 @@ from enum import Enum, IntEnum, auto
 
 class CompatibilityMode(Enum):
     """
-    Compatibility modes that describe how compositing and
-    layer control should attempt to behave.
+    Compatibility modes for compositing and layer control.
+
+    Each describes how those two should attempt to behave.
     """
 
     PHOTOSHOP = auto()
@@ -532,7 +533,7 @@ class SheetColorType(IntEnum):
 
 class TextType(IntEnum):
     """
-    Type of text
+    Type of text.
     """
 
     POINT = 0
@@ -576,7 +577,7 @@ class WritingDirection(IntEnum):
 
 class ProtectedFlags(IntEnum):
     """
-    Flags for layer locking
+    Flags for layer locking.
     """
 
     TRANSPARENCY = 0x01

--- a/src/psd_tools/psd/adjustments.py
+++ b/src/psd_tools/psd/adjustments.py
@@ -110,8 +110,9 @@ class ColorBalance(BaseElement):
 @register(Tag.COLOR_LOOKUP)
 class ColorLookup(DescriptorBlock2):
     """
-    Dict-like Descriptor-based structure. See
-    :py:class:`~psd_tools.psd.descriptor.Descriptor`.
+    Dict-like Descriptor-based structure.
+
+    See :py:class:`~psd_tools.psd.descriptor.Descriptor`.
 
     .. py:attribute:: version
     .. py:attribute:: data_version
@@ -544,8 +545,9 @@ class HueSaturation(BaseElement):
 @define(repr=False)
 class Levels(ListElement):
     """
-    List of level records. See :py:class:
-    `~psd_tools.psd.adjustments.LevelRecord`.
+    List of level records.
+
+    See :py:class:`~psd_tools.psd.adjustments.LevelRecord`.
 
     .. py:attribute:: version
 

--- a/src/psd_tools/psd/base.py
+++ b/src/psd_tools/psd/base.py
@@ -36,8 +36,10 @@ T = TypeVar("T", bound="BaseElement")
 
 class BaseElement:
     """
-    Base element of various PSD file structs. All the data objects in
-    :py:mod:`psd_tools.psd` subpackage inherit from this class.
+    Base element of various PSD file structs.
+
+    All the data objects in the :py:mod:`psd_tools.psd` subpackage inherit
+    from this class.
 
     .. py:classmethod:: read(cls, fp)
 

--- a/src/psd_tools/psd/bin_utils.py
+++ b/src/psd_tools/psd/bin_utils.py
@@ -101,7 +101,7 @@ def write_length_block(
     padding: int = 1,
     **kwargs: Any,
 ) -> int:
-    """
+    r"""
     Writes a block of data with a length marker at the beginning.
 
     Example::
@@ -264,8 +264,7 @@ def write_be_array(fp: IO[bytes], arr: array.array) -> int:
 
 def fix_byteorder(arr: array.array) -> array.array:
     """
-    Fixes the byte order of the array (assuming it was read
-    from a Big Endian data).
+    Fix the byte order of an array read from big-endian data.
     """
     if sys.byteorder == "little":
         arr.byteswap()

--- a/src/psd_tools/psd/bin_utils.py
+++ b/src/psd_tools/psd/bin_utils.py
@@ -264,7 +264,7 @@ def write_be_array(fp: IO[bytes], arr: array.array) -> int:
 
 def fix_byteorder(arr: array.array) -> array.array:
     """
-    Fix the byte order of an array read from big-endian data.
+    Fix the byte order of an array, assuming it was read from big-endian data.
     """
     if sys.byteorder == "little":
         arr.byteswap()

--- a/src/psd_tools/psd/color_mode_data.py
+++ b/src/psd_tools/psd/color_mode_data.py
@@ -47,7 +47,6 @@ class ColorModeData(ValueElement):
         """
         Returns interleaved color table in bytes.
         """
-
         return b"".join(
             array.array(
                 "B", [(self.value[i]), (self.value[i + 256]), (self.value[i + 512])]

--- a/src/psd_tools/psd/descriptor.py
+++ b/src/psd_tools/psd/descriptor.py
@@ -184,8 +184,9 @@ class Descriptor(_DescriptorMixin):
 @define(repr=False)
 class ObjectArray(_DescriptorMixin):
     """
-    Object array structure almost equivalent to
-    :py:class:`~psd_tools.psd.descriptor.Descriptor`.
+    Object array structure.
+
+    Almost equivalent to :py:class:`~psd_tools.psd.descriptor.Descriptor`.
 
     .. py:attribute:: items_count
 
@@ -645,8 +646,9 @@ class RawData(BaseElement):
 @register(OSType.CLASS1)
 class Class1(Class):
     """
-    Class structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.Class`.
+    Class structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.Class`.
     """
 
     pass
@@ -655,8 +657,9 @@ class Class1(Class):
 @register(OSType.CLASS2)
 class Class2(Class):
     """
-    Class structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.Class`.
+    Class structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.Class`.
     """
 
     pass
@@ -665,8 +668,9 @@ class Class2(Class):
 @register(OSType.CLASS3)
 class Class3(Class):
     """
-    Class structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.Class`.
+    Class structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.Class`.
     """
 
     pass
@@ -675,8 +679,9 @@ class Class3(Class):
 @register(OSType.REFERENCE)
 class Reference(List):
     """
-    Reference structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.List`.
+    Reference structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.List`.
     """
 
     pass
@@ -685,8 +690,9 @@ class Reference(List):
 @register(OSType.ALIAS)
 class Alias(RawData):
     """
-    Alias structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.RawData`.
+    Alias structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.RawData`.
     """
 
     pass
@@ -695,8 +701,9 @@ class Alias(RawData):
 @register(OSType.GLOBAL_OBJECT)
 class GlobalObject(Descriptor):
     """
-    Global object structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.Descriptor`.
+    Global object structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.Descriptor`.
     """
 
     pass
@@ -705,8 +712,9 @@ class GlobalObject(Descriptor):
 @register(OSType.PATH)
 class Path(RawData):
     """
-    Undocumented path structure equivalent to
-    :py:class:`~psd_tools.psd.descriptor.RawData`.
+    Undocumented path structure.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.RawData`.
     """
 
     pass
@@ -715,8 +723,9 @@ class Path(RawData):
 @register(OSType.IDENTIFIER)
 class Identifier(Integer):
     """
-    Identifier equivalent to
-    :py:class:`~psd_tools.psd.descriptor.Integer`.
+    Identifier.
+
+    Equivalent to :py:class:`~psd_tools.psd.descriptor.Integer`.
     """
 
     pass
@@ -771,8 +780,9 @@ class Name(BaseElement):
 @define(repr=False)
 class DescriptorBlock(Descriptor):
     """
-    Dict-like Descriptor-based structure that has `version` field. See
-    :py:class:`~psd_tools.psd.descriptor.Descriptor`.
+    Dict-like Descriptor-based structure with a `version` field.
+
+    See :py:class:`~psd_tools.psd.descriptor.Descriptor`.
 
     .. py:attribute:: version
     """
@@ -794,9 +804,9 @@ class DescriptorBlock(Descriptor):
 @define(repr=False)
 class DescriptorBlock2(Descriptor):
     """
-    Dict-like Descriptor-based structure that has `version` and
-    `data_version` fields. See
-    :py:class:`~psd_tools.psd.descriptor.Descriptor`.
+    Dict-like Descriptor-based structure with `version` and `data_version`.
+
+    See :py:class:`~psd_tools.psd.descriptor.Descriptor`.
 
     .. py:attribute:: version
     .. py:attribute:: data_version

--- a/src/psd_tools/psd/effects_layer.py
+++ b/src/psd_tools/psd/effects_layer.py
@@ -439,8 +439,9 @@ class SolidFillInfo(BaseElement):
 @define(repr=False)
 class EffectsLayer(DictElement):
     """
-    Dict-like EffectsLayer structure. See
-    :py:class:`psd_tools.constants.EffectOSType` for available keys.
+    Dict-like EffectsLayer structure.
+
+    See :py:class:`psd_tools.constants.EffectOSType` for available keys.
 
     .. py:attribute:: version
     """

--- a/src/psd_tools/psd/image_resources.py
+++ b/src/psd_tools/psd/image_resources.py
@@ -1,6 +1,8 @@
 """
-Image resources section structure. Image resources are used to store non-pixel
-data associated with images, such as pen tool paths or slices.
+Image resources section structure.
+
+Image resources are used to store non-pixel data associated with images, such
+as pen tool paths or slices.
 
 See :py:class:`~psd_tools.constants.Resource` to check available
 resource names.
@@ -127,8 +129,7 @@ TYPES.update(
 @define(repr=False)
 class ImageResources(DictElement):
     """
-    Image resources section of the PSD file. Dict of
-    :py:class:`.ImageResource`.
+    Image resources section of the PSD file. Dict of :py:class:`.ImageResource`.
     """
 
     def get_data(self, key: Any, default: Any = None) -> Any:
@@ -363,7 +364,7 @@ class AlphaNamesUnicode(ListElement):
 @define(repr=False)
 class DisplayInfo(BaseElement):
     """
-    DisplayInfo is a list of AlphaChannels
+    DisplayInfo is a list of AlphaChannels.
     """
 
     version: int = 1

--- a/src/psd_tools/psd/layer_and_mask.py
+++ b/src/psd_tools/psd/layer_and_mask.py
@@ -312,7 +312,7 @@ class LayerInfo(BaseElement):
 @register(Tag.LAYER_32)
 @define(repr=False)
 class LayerInfoBlock(LayerInfo):
-    """ """
+    """Layer info carried inside a tagged block, with no outer length marker."""
 
     @classmethod
     def read(

--- a/src/psd_tools/psd/patterns.py
+++ b/src/psd_tools/psd/patterns.py
@@ -35,8 +35,9 @@ T_Pattern = TypeVar("T_Pattern", bound="Pattern")
 
 class Patterns(ListElement):
     """
-    List of Pattern structure. See
-    :py:class:`~psd_tools.psd.patterns.Pattern`.
+    List of Pattern structure.
+
+    See :py:class:`~psd_tools.psd.patterns.Pattern`.
     """
 
     @classmethod

--- a/src/psd_tools/psd/vector.py
+++ b/src/psd_tools/psd/vector.py
@@ -47,8 +47,10 @@ def encode_fixed_point(numbers: Sequence[float]) -> tuple[int, ...]:
 @define(repr=False)
 class Path(ListElement):
     """
-    List-like Path structure. Elements are either PathFillRule,
-    InitialFillRule, ClipboardRecord, ClosedPath, or OpenPath.
+    List-like Path structure.
+
+    Elements are either PathFillRule, InitialFillRule, ClipboardRecord,
+    ClosedPath, or OpenPath.
     """
 
     @classmethod
@@ -353,8 +355,9 @@ class VectorMaskSetting(BaseElement):
 @define(repr=False)
 class VectorStrokeContentSetting(Descriptor):
     """
-    Dict-like Descriptor-based structure. See
-    :py:class:`~psd_tools.psd.descriptor.Descriptor`.
+    Dict-like Descriptor-based structure.
+
+    See :py:class:`~psd_tools.psd.descriptor.Descriptor`.
 
     .. py:attribute:: key
     .. py:attribute:: version

--- a/src/psd_tools/validators.py
+++ b/src/psd_tools/validators.py
@@ -32,8 +32,10 @@ class _RangeValidator(object):
 
 def range_(minimum: Any, maximum: Any) -> _RangeValidator:
     """
-    A validator that raises a :exc:`ValueError` if the initializer is called
-    with a value that does not belong in the [minimum, maximum] range. The
-    check is performed using ``minimum <= value and value <= maximum``
+    Require a value inside the [minimum, maximum] range.
+
+    Raises a :exc:`ValueError` if the initializer is called with a value
+    outside it. The check is performed using
+    ``minimum <= value and value <= maximum``.
     """
     return _RangeValidator(minimum, maximum)

--- a/tests/psd_tools/api/test_layers.py
+++ b/tests/psd_tools/api/test_layers.py
@@ -216,7 +216,6 @@ def test_nested_clipping() -> None:
           [1] ShapeLayer('Shape 1' size=124x69)
           [2] +ShapeLayer('Shape 2' size=69x75 clip)
     """
-
     psd = PSDImage.open(full_name("clipping-mask.psd"))
     psd.compatibility_mode = CompatibilityMode.CLIP_STUDIO_PAINT
     psd[1].blend_mode = BlendMode.NORMAL

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -582,7 +582,8 @@ def test_has_transparency_positive_layer_count(tmp_path: Path) -> None:
 
 def test_get_transparency_index_negative_layer_count(tmp_path: Path) -> None:
     """get_transparency_index() returns the first alpha channel index
-    when layer_count is negative."""
+    when layer_count is negative.
+    """
     output = _save_psd_with_negative_layer_count(tmp_path)
     loaded = PSDImage.open(output)
     # RGB has 3 expected channels, so the transparency channel is at index 3

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -583,7 +583,7 @@ def test_has_transparency_positive_layer_count(tmp_path: Path) -> None:
 def test_get_transparency_index_negative_layer_count(tmp_path: Path) -> None:
     """get_transparency_index() finds the first alpha channel index.
 
-    Specifically when layer_count is negative.
+    It has to do so even when layer_count is negative.
     """
     output = _save_psd_with_negative_layer_count(tmp_path)
     loaded = PSDImage.open(output)

--- a/tests/psd_tools/api/test_psd_image.py
+++ b/tests/psd_tools/api/test_psd_image.py
@@ -581,8 +581,9 @@ def test_has_transparency_positive_layer_count(tmp_path: Path) -> None:
 
 
 def test_get_transparency_index_negative_layer_count(tmp_path: Path) -> None:
-    """get_transparency_index() returns the first alpha channel index
-    when layer_count is negative.
+    """get_transparency_index() finds the first alpha channel index.
+
+    Specifically when layer_count is negative.
     """
     output = _save_psd_with_negative_layer_count(tmp_path)
     loaded = PSDImage.open(output)

--- a/tests/psd_tools/api/test_smart_object.py
+++ b/tests/psd_tools/api/test_smart_object.py
@@ -242,7 +242,7 @@ class TestOpenSecurity:
     def test_fullpath_outside_external_dir_falls_back_to_relpath(
         self, tmp_path: Path
     ) -> None:
-        """fullPath outside external_dir is ignored; relPath inside is used."""
+        """A fullPath outside external_dir is ignored; relPath inside is used."""
         target = tmp_path / "asset.png"
         target.write_bytes(b"asset")
         so = _make_external_smart_object("/etc/passwd", "asset.png")
@@ -306,7 +306,7 @@ class TestExternalReadConfinement:
     def test_open_default_falls_back_to_relpath_inside_cwd(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """fullPath outside CWD is ignored; relPath inside CWD is used."""
+        """A fullPath outside CWD is ignored; relPath inside CWD is used."""
         workdir = tmp_path / "work"
         workdir.mkdir()
         (workdir / "asset.png").write_bytes(b"asset")

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -30,8 +30,10 @@ logger = logging.getLogger(__name__)
 
 
 def test_lighter_color_descriptor_key() -> None:
-    """Regression: b"lighterColor" was previously a typo (b"ligherColor")
-    which silently fell back to the normal blend mode for effects/strokes.
+    """Regression: b"lighterColor" was previously a typo (b"ligherColor").
+
+    The misspelling silently fell back to the normal blend mode for effects
+    and strokes.
     """
     assert BLEND_FUNC.get(b"lighterColor") is lighter_color
     assert BLEND_FUNC.get(b"lighterColor") is not normal
@@ -151,8 +153,9 @@ def _nested_passthrough_psd(depth: int, opacity: int, background: bool) -> PSDIm
 
 @pytest.mark.parametrize("depth", [1, 2, 3])
 def test_passthrough_group_opacity_over_opaque_backdrop(depth: int) -> None:
-    """Group opacity must scale the effective alpha of the group's contents
-    instead of blending the backdrop in twice (issue #703).
+    """Group opacity must scale the effective alpha of the group's contents.
+
+    Blending the backdrop in twice instead is what issue #703 reported.
     """
     psd = _nested_passthrough_psd(depth, opacity=128, background=True)
     image = psd.composite(ignore_preview=True).convert("RGB")
@@ -163,8 +166,9 @@ def test_passthrough_group_opacity_over_opaque_backdrop(depth: int) -> None:
 
 @pytest.mark.parametrize("depth", [1, 2, 3])
 def test_passthrough_group_opacity_over_transparent_backdrop(depth: int) -> None:
-    """Without a backdrop, group opacity only scales alpha; the initial
-    backdrop color must not bleed into the result (issue #703).
+    """Without a backdrop, group opacity only scales alpha.
+
+    The initial backdrop color must not bleed into the result (issue #703).
     """
     psd = _nested_passthrough_psd(depth, opacity=128, background=False)
     image = psd.composite(ignore_preview=True).convert("RGBA")
@@ -174,8 +178,10 @@ def test_passthrough_group_opacity_over_transparent_backdrop(depth: int) -> None
 
 @pytest.mark.parametrize("depth", [1, 2, 3])
 def test_passthrough_group_opacity_over_partial_backdrop(depth: int) -> None:
-    """The interpolation has to happen in premultiplied space, so a partially
-    transparent backdrop contributes in proportion to its own alpha.
+    """The interpolation has to happen in premultiplied space.
+
+    So a partially transparent backdrop contributes in proportion to its own
+    alpha.
 
     This is the case the pre-#703 code got wrong even without nesting, because
     it keyed off ``_shape_g`` rather than the backdrop alpha.
@@ -209,8 +215,10 @@ def _flat_psd(alpha: int, background_alpha: int) -> PSDImage:
 def test_passthrough_group_opacity_equivalence(
     depth: int, opacity: int, layer_alpha: int, background_alpha: int
 ) -> None:
-    """A pass-through group at opacity ``m`` around a single normal layer at
-    alpha ``a`` must render identically to that layer ungrouped at ``m * a``.
+    """A pass-through group must not change what its single child renders.
+
+    At opacity ``m`` around one normal layer at alpha ``a``, it must render
+    identically to that layer ungrouped at ``m * a``.
 
     This is the invariant issue #703 violated: group opacity has to scale the
     effective alpha of the contents rather than blend the backdrop in twice.

--- a/tests/psd_tools/composite/test_blend.py
+++ b/tests/psd_tools/composite/test_blend.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 
 def test_lighter_color_descriptor_key() -> None:
     """Regression: b"lighterColor" was previously a typo (b"ligherColor")
-    which silently fell back to the normal blend mode for effects/strokes."""
+    which silently fell back to the normal blend mode for effects/strokes.
+    """
     assert BLEND_FUNC.get(b"lighterColor") is lighter_color
     assert BLEND_FUNC.get(b"lighterColor") is not normal
 
@@ -151,7 +152,8 @@ def _nested_passthrough_psd(depth: int, opacity: int, background: bool) -> PSDIm
 @pytest.mark.parametrize("depth", [1, 2, 3])
 def test_passthrough_group_opacity_over_opaque_backdrop(depth: int) -> None:
     """Group opacity must scale the effective alpha of the group's contents
-    instead of blending the backdrop in twice (issue #703)."""
+    instead of blending the backdrop in twice (issue #703).
+    """
     psd = _nested_passthrough_psd(depth, opacity=128, background=True)
     image = psd.composite(ignore_preview=True).convert("RGB")
     pixel = tuple(np.array(image, dtype=int)[4, 4])
@@ -162,7 +164,8 @@ def test_passthrough_group_opacity_over_opaque_backdrop(depth: int) -> None:
 @pytest.mark.parametrize("depth", [1, 2, 3])
 def test_passthrough_group_opacity_over_transparent_backdrop(depth: int) -> None:
     """Without a backdrop, group opacity only scales alpha; the initial
-    backdrop color must not bleed into the result (issue #703)."""
+    backdrop color must not bleed into the result (issue #703).
+    """
     psd = _nested_passthrough_psd(depth, opacity=128, background=False)
     image = psd.composite(ignore_preview=True).convert("RGBA")
     pixel = tuple(np.array(image, dtype=int)[4, 4])

--- a/tests/psd_tools/compression/test_compression.py
+++ b/tests/psd_tools/compression/test_compression.py
@@ -189,8 +189,9 @@ def test_compress_decompress_fail(
     [Compression.ZIP, Compression.ZIP_WITH_PREDICTION],
 )
 def test_decompress_zip_bomb_falls_back_to_black(kind: Compression) -> None:
-    """A zlib payload that expands beyond the declared channel size must not
-    exhaust memory; it should fall back to a black channel.
+    """A zlib payload expanding past the declared channel size must not exhaust memory.
+
+    It should fall back to a black channel instead.
     """
     oversized = zlib.compress(b"\x00" * 10_000)
     result = decompress(oversized, kind, width=2, height=2, depth=8)

--- a/tests/psd_tools/compression/test_compression.py
+++ b/tests/psd_tools/compression/test_compression.py
@@ -190,7 +190,8 @@ def test_compress_decompress_fail(
 )
 def test_decompress_zip_bomb_falls_back_to_black(kind: Compression) -> None:
     """A zlib payload that expands beyond the declared channel size must not
-    exhaust memory; it should fall back to a black channel."""
+    exhaust memory; it should fall back to a black channel.
+    """
     oversized = zlib.compress(b"\x00" * 10_000)
     result = decompress(oversized, kind, width=2, height=2, depth=8)
     assert result == b"\x00" * 4  # black fallback for 2×2 8-bit

--- a/tests/psd_tools/test_color_convert.py
+++ b/tests/psd_tools/test_color_convert.py
@@ -223,8 +223,9 @@ class TestHsbToRgb:
         ],
     )
     def test_out_of_range_saturation_and_brightness_saturate(self, s, v, expected):
-        """The ``Returns:`` contract has to hold for every float, not just for
-        in-range ones.
+        """The ``Returns:`` contract has to hold for every float.
+
+        Not just for in-range ones.
 
         Saturation and brightness are not angles, so unlike hue they clamp
         rather than wrap. Before #757 this function was total only in

--- a/tests/test_prose_density.py
+++ b/tests/test_prose_density.py
@@ -109,7 +109,8 @@ def test_untokenizable_body_warns_instead_of_scoring_zero(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
     """Silently counting an unmeasurable function as prose-free is the one
-    failure this tool must not have."""
+    failure this tool must not have.
+    """
 
     def boom(readline: Any) -> Any:
         raise SyntaxError("synthetic")

--- a/tests/test_prose_density.py
+++ b/tests/test_prose_density.py
@@ -108,8 +108,9 @@ def test_unparsable_file_yields_nothing(tmp_path: Path) -> None:
 def test_untokenizable_body_warns_instead_of_scoring_zero(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
-    """Silently counting an unmeasurable function as prose-free is the one
-    failure this tool must not have.
+    """Silently counting an unmeasurable function as prose-free.
+
+    This is the one failure this tool must not have.
     """
 
     def boom(readline: Any) -> Any:

--- a/tests/test_prose_density.py
+++ b/tests/test_prose_density.py
@@ -108,9 +108,9 @@ def test_unparsable_file_yields_nothing(tmp_path: Path) -> None:
 def test_untokenizable_body_warns_instead_of_scoring_zero(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
-    """Silently counting an unmeasurable function as prose-free.
+    """An unmeasurable function must never be counted as prose-free.
 
-    This is the one failure this tool must not have.
+    Silently doing so is the one failure this tool must not have.
     """
 
     def boom(readline: Any) -> Any:

--- a/tools/extract_terminology.py
+++ b/tools/extract_terminology.py
@@ -1,6 +1,7 @@
-"""
-Utility to generate terminology.py from PITerminology.h and
-PIStringTerminology.h in the Photoshop SDK. Use with Python 3.
+r"""
+Generate terminology.py from the Photoshop SDK headers.
+
+Reads PITerminology.h and PIStringTerminology.h. Use with Python 3.
 
 Usage:
 


### PR DESCRIPTION
Closes #772. Follow-up work split out into #786.

Enables ruff's `D` family with `convention = "pep257"`, holding back `D1`, `D200` and `D401`, and fixes the resulting violations. Per the issue thread: `tests/` is included, and the three held-back rules are deferred rather than rejected.

No behaviour change — ASTs with docstrings stripped hash identically to `main` for all 33 touched files.

## Commits

| | |
| --- | --- |
| 1 | 21 of ruff's 24 auto-fixes (`D202` ×14, `D209` ×6, `D412` ×1) |
| 2 | the 84 manual fixes, grouped by rule |
| 3 | the `pyproject.toml` change, with a green tree |
| 4 | changelog entry for the one user-visible part |
| 5 | review fixes |

## `D301` earned its place

As the issue predicted, this is the rule that caught a real defect rather than a formatting slip. Seven docstrings held escape sequences in non-raw strings, so `\x00` and `\xff` were interpreted at parse time — `psd_tools.compression.rle`'s module docstring shipped a **literal NUL byte and a mojibake `ÿ`** in text `help()` renders.

Five get an `r"""` prefix. The other two — `TypeLayer.text` and the typesetting module — had already been worked around by double-escaping, so they get the prefix *and* one backslash removed, leaving the rendered output byte-identical. Verified by dumping all 34,782 docstrings in the package before and after: exactly 15 differ, all the intended category, with `write_length_block` accounting for 12 of them by being re-exported into as many modules.

A second instance turned up in `tools/`, which the issue's measurement did not cover (it is outside ruff's `src` setting, though `ruff check` lints it): `extract_terminology.py`'s usage block used trailing backslashes as line continuations inside a non-raw docstring, collapsing a three-line shell command into one joined line. `D301` does not flag that shape, so it was found only by fixing the file's `D205`.

## Where ruff's own fixes were wrong

**All three `D403` fixes**, because the first word is an identifier rather than an English one. `fullPath` and `relPath` are literal descriptor keys in the PSD format, so "FullPath outside external_dir is ignored" names a key that does not exist; and `PhotoFilter.xyz` → `"""Xyz."""` restates the field name without describing it. Reverted in commit 1, rewritten by hand in commit 2.

**`D205`, all 55 of them**, are a wrapped summary line in every single case — so ruff's "insert a blank line" would have split a sentence in half. Each instead gets a real one-line summary with the remainder moved into the body.

`D400` is mostly a missing period, but two were not: `gradient_kind()`'s first line ends in a colon introducing a list, where a period would be wrong, and `validators.py` had a whole paragraph where the summary goes. Both restructured rather than punctuated.

## `PhotoFilter.xyz` (one API typing fix)

The property was annotated `-> bool`, but the low-level struct reads three uint32s on version 3 and leaves the field `None` on version 2 — and `tests/psd_tools/api/test_adjustments.py:113` already asserted `layer.xyz is None`. So `None` was a **tested** runtime value against a `bool` annotation. The vacuous `"""xyz."""` hid the conflict; an accurate summary exposed it.

I first deferred the annotation as out of scope and fixed only the `:return:`. On review that was the wrong call — shipping a docstring that openly contradicts the annotation beside it is worse than the small scope increase — so `xyz` is now `tuple[int, ...] | None`, with an `[api]` changelog entry. Runtime is unchanged.

Why it survived a fully typed tree: `_assert_data(data: Any) -> Any` erases the low-level type before the property returns it, so mypy never compares it against `bool`. The sibling properties (`color_space`, `color_components`, `density`, `luminosity`) are all `-> Any` and get no checking either. The low-level `xyz: tuple` field is left alone — it omits `None`, which is imprecise rather than wrong in kind.

## Verification

- `uv run ruff check` clean repo-wide; `ruff format --check` clean.
- `uv run pytest` — 2883 passed, 3 skipped, 25 xfailed, 2 xpassed (unchanged from `main`).
- `mypy` clean; `color_convert`'s doctests still pass.
- `sphinx-build` — no new warnings; the one remaining is the pre-existing ambiguous `List` cross-reference in an untouched file. As a bonus, `psd/adjustments.py`'s `Levels` had a `:py:class:` role split across lines on `main`, i.e. genuinely broken markup, now correct.

A subagent review of the first four commits caught a rendering regression I had introduced — `.. deprecated::` takes the version as a **required** argument, so an empty directive line made Sphinx render *"Deprecated since version Use: the descriptor property instead."* on all eight public effect classes, and it emits no warning for it. Commit 5 fixes that and three inaccurate counts in the config comments, which cited the issue's `src/`-only figures where `ignore` applies repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


