### PR TITLE
docs: make CLAUDE.md the single source for changelog categories

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -86,16 +86,10 @@ VERSION (YYYY-MM-DD)
 **Important**: The `-` underline must be at least as long as the title line (RST requirement).
 Count the exact characters in `VERSION (YYYY-MM-DD)` and use that many dashes.
 
-Use these categories (pick the most specific one per bullet):
-
-- `api` — public API additions or changes
-- `psd` — low-level PSD parsing/writing
-- `fix` — bug fixes
-- `refactor` — internal restructuring, no behaviour change
-- `docs` — documentation only
-- `ci` — CI/CD, GitHub Actions
-- `chore` — dependency bumps, tooling, housekeeping
-- `security` — security fixes
+The categories, and the rule for picking between them, are documented in the
+**Changelog** section of the repo-root `CLAUDE.md`, which loads as project
+instructions — use that list. It is deliberately not restated here: the second copy
+is what drifted (#791).
 
 Group related changes. Omit purely internal churn that users won't care about. Reference PR numbers where available.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,29 @@ Changelog
 - [fix] Short description of the user-visible change (#123, #456)
 ```
 
-Prefix each entry with its category: `[fix]`, `[api]`, `[security]`, `[chore]`,
-`[docs]`. Reference the issue and PR numbers. Flag any backwards-incompatible
-change explicitly in the entry text.
+Prefix each entry with its category, and reference the issue and PR numbers:
+
+- `[fix]` — a bug fix that leaves the public surface unchanged, wherever it
+  lives: parsing, rendering, compression
+- `[api]` — a change to the public surface: a new or renamed symbol, a new
+  parameter, a corrected annotation
+- `[security]` — security fixes
+- `[docs]` — documentation only
+- `[ci]` — CI, packaging and release engineering
+- `[refactor]` — internal restructuring a user can still observe, such as a
+  moved public module
+- `[chore]` — tooling and housekeeping; the release PR also writes one `[chore]`
+  line summarising that release's dependency bumps
+
+Pick the most specific one that applies. A category names the **kind** of change,
+not the subpackage it touches — a low-level parsing fix is `[fix]`, not `[psd]`.
+Only these seven are current: released sections still carry `[psd]`,
+`[composite]`, `[packaging]`, `[dev]` and the rest of a long tail, all retired,
+and that history stays as written. This list is the only one — anything else that
+needs the categories, the release skill included, points here rather than
+restating them (#791).
+
+Flag any backwards-incompatible change explicitly in the entry text.
 
 **Budget: aim for four lines, and treat six as the ceiling** — one line of
 summary, plus a short "does this affect me" clause where the answer is not
@@ -157,9 +177,11 @@ commit message, and the GitHub Release body — so a longer entry duplicates
 them and dates faster than they do. Corpus statistics, measured error figures,
 and the history of what earlier PRs got wrong all belong in the PR, not here.
 
-Entries are for user-visible change. Skip them for pure refactors, test-only
-changes, and dependabot bumps — dependency bumps are summarised in bulk by the
-release PR instead.
+Entries are for user-visible change, with `[ci]` and `[chore]` as the standing
+exception — the changelog carries the release-engineering record too. Skip
+test-only changes, and dependabot bumps, which the release PR summarises in bulk.
+Internal restructuring earns an entry only when a user can observe it, which is
+what `[refactor]` is for.
 
 ### Branch naming conventions
 


### PR DESCRIPTION
Fixes #791.

Three sources documented the changelog's category prefixes and none agreed:
`CLAUDE.md` listed 5, `.claude/skills/release/SKILL.md` listed 8, and
`docs/changelog.rst` as written uses 16. The divergence surfaced in #790, where
the skill's list suggested `[psd]` and Copilot flagged it against `CLAUDE.md`.

## What changed

**One list, in `CLAUDE.md` § Changelog.** Widened to the seven categories that
are genuinely in use — `fix`, `api`, `security`, `docs`, `ci`, `refactor`,
`chore` — each with the gloss that previously lived only in the release skill.

**`[psd]` is retired.** It was last used in 1.13.1 (2026-02-27); the five
releases since have tagged low-level fixes `[fix]`, including every one of the
40 entries in 1.19.0. The list is now backed by the rule that made the long tail
possible in the first place: *a category names the kind of change, not the
subpackage it touches*. That sentence is what stops `[psd]`, `[composite]`,
`[compression]` and the rest recurring, and the list is stated as closed so the
non-subpackage strays — `[dev]`, `[packaging]`, `[tests]`, `[deploy]` — are
covered too.

**The release skill defers instead of restating.** Its Step 2 list is replaced
by a pointer to that section — a restated list is what drifted.

**Released sections are untouched.** Rewriting history would churn the file for
no reader benefit, and the existing prefixes are the evidence for which
categories are live.

## Two things the widening forced

These are beyond the issue's literal scope but the section would have
contradicted itself without them.

- **`[refactor]` vs. "skip pure refactors".** The paragraph two below the list
  said to skip entries for pure refactors, while `[refactor]` was now a listed
  category. It now says internal restructuring earns an entry only when a user
  can observe it — matching #530 (moved public module) and #647.
- **`[ci]`/`[chore]` vs. "entries are for user-visible change".** 13 of the 22
  `[ci]` entries are pure release engineering (badge fix, stale workflow,
  Dependabot config), and 13 of the 15 `[chore]` entries are the bulk dependency
  line the release PR writes. Both are now named as the standing exception,
  rather than being silently forbidden by a rule the file has never followed.

Stating a `[fix]`/`[api]` boundary was also unavoidable once both were glossed —
the file has 6 bug fixes tagged `[api]`. It is drawn as surface vs. behaviour,
which is what 1.19.0 already does: its one `[api]` entry is an annotation
change, its 40 `[fix]` entries are behaviour.

No `docs/changelog.rst` entry: this touches only contributor-facing
instructions, and CLAUDE.md-only changes have never carried one (cf. 305fe3a).

## Follow-up worth considering separately

`docs/contributing.rst` never mentions per-PR changelog entries or the category
list, so an outside contributor gets no guidance from the public docs. Left out
here to keep this change to the divergence #791 describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
