### PR TITLE
fix: trace every stroke effect from the layer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,7 @@ Changelog
 - [fix] Trace every stroke effect from the layer. The second stroke on a layer
   outlined the first stroke instead of the layer, which left its own ring
   unpainted and painted over the first. **Rendering change** for a layer
-  carrying more than one stroke effect (#798)
+  carrying more than one stroke effect (#798, #801)
 - [fix] Draw a centered stroke effect at its full width. Every odd stroke size
   fell one pixel short on each side of the layer edge, because the dilation
   radius was truncated rather than rounded up. **Rendering change** for a layer

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
+- [fix] Trace every stroke effect from the layer. The second stroke on a layer
+  outlined the first stroke instead of the layer, which left its own ring
+  unpainted and painted over the first. **Rendering change** for a layer
+  carrying more than one stroke effect (#798)
 - [fix] Draw a centered stroke effect at its full width. Every odd stroke size
   fell one pixel short on each side of the layer edge, because the dilation
   radius was truncated rather than rounded up. **Rendering change** for a layer

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -1467,14 +1467,17 @@ class Compositor(object):
     def _apply_stroke_effect(
         self, layer: Layer, shape: float | np.ndarray, alpha: np.ndarray
     ) -> None:
+        # ``shape`` is _get_mask()'s output, which is a bare 1.0 for a layer
+        # with no mask -- and paste() needs something with a channel axis.
+        # broadcast_to gives a stride-0 view rather than a full canvas, which
+        # is all paste() requires since it only reads from it.
+        if not isinstance(shape, np.ndarray):
+            shape = np.broadcast_to(np.float32(shape), (self.height, self.width, 1))
+        # Photoshop traces every stroke from the layer, so ``shape`` stays the
+        # layer's coverage for the whole loop and each effect's own mask gets a
+        # separate name. Assigning the mask back over ``shape`` made the second
+        # stroke outline the first stroke rather than the layer (#798).
         for effect in _styled(layer.effects.find("stroke")):
-            # ``shape`` is _get_mask()'s output, which is a bare 1.0 for a layer
-            # with no mask -- and paste() needs something with a channel axis.
-            # broadcast_to gives a stride-0 view rather than a canvas: paste()
-            # only reads from it, and the full-viewport array it would otherwise
-            # allocate is discarded by the very next line.
-            if not isinstance(shape, np.ndarray):
-                shape = np.broadcast_to(np.float32(shape), (self.height, self.width, 1))
             # Effect must happen at the layer viewport, grown so an outset or
             # centered stroke has room for the part of itself that falls
             # outside the layer (#792).
@@ -1482,10 +1485,10 @@ class Compositor(object):
             if bbox[0] >= bbox[2] or bbox[1] >= bbox[3]:
                 continue
             shape_in_bbox = paste(bbox, self._viewport, shape)
-            color, shape_in_bbox = draw_stroke_effect(
+            color, mask_in_bbox = draw_stroke_effect(
                 bbox, shape_in_bbox, effect.value, layer._psd
             )
             color = paste(self._viewport, bbox, color)
-            shape = paste(self._viewport, bbox, shape_in_bbox)
+            mask = paste(self._viewport, bbox, mask_in_bbox)
             opacity = effect.opacity / 100.0
-            self._apply_source(color, shape, shape * opacity, effect.blend_mode)
+            self._apply_source(color, mask, mask * opacity, effect.blend_mode)

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -17,12 +17,16 @@ logger = logging.getLogger(__name__)
         ("effects/stroke-effects.psd",),
         ("effects/shape-fx2.psd",),
         ("effects/stroke-effect-transparent-shape.psd",),
-        ("effects/double-stroke-effects.psd",),
     ],
 )
 @pytest.mark.xfail
 def test_stroke_effects_xfail(filename: str) -> None:
     check_composite_quality(filename, threshold=0.01)
+
+
+def test_double_stroke_effects() -> None:
+    """Two stroke effects on one layer render close to Photoshop (#798)."""
+    check_composite_quality("effects/double-stroke-effects.psd", threshold=0.01)
 
 
 @pytest.mark.parametrize(
@@ -158,3 +162,43 @@ def test_centered_stroke_reach_matches_photoshop() -> None:
     assert measured == _CENTERED_REACH
 
     check_composite_quality("effects/center-stroke-sizes.psd", threshold=0.01)
+
+
+def test_second_stroke_traces_the_layer() -> None:
+    """Every stroke effect outlines the layer, not the stroke before it (#798).
+
+    ``double-stroke-effects.psd`` is one rectangle carrying a red outset stroke
+    and a blue inset stroke -- the only layer in the corpus with more than one.
+    Tracing the second stroke from the first one's mask inset the red ring
+    rather than the layer, which both left the blue ring unpainted and painted
+    over the red one. Both rings are read off Photoshop's own render and both
+    are checked, since the defect moves each of them for a different reason.
+    """
+    psd = PSDImage.open(full_name("effects/double-stroke-effects.psd"))
+    # ICC is off on both sides: the fixture carries a profile, and the ring
+    # pixel counts below are a calibration this test asserts exactly, so they
+    # should not move with the installed color management library.
+    preview = psd.topil(apply_icc=False)
+    composited = psd.composite(ignore_preview=True, apply_icc=False)
+    assert preview is not None and composited is not None
+    reference = np.asarray(preview.convert("RGB"), dtype=np.int16)
+    result = np.asarray(composited.convert("RGB"), dtype=np.int16)
+
+    outset = (reference[:, :, 0] > 128) & (reference[:, :, 2] < 128)
+    inset = (reference[:, :, 2] > 128) & (reference[:, :, 0] < 128)
+    assert (int(outset.sum()), int(inset.sum())) == (104, 96), (
+        "Photoshop's own render of the two rings moved, so the pixels this "
+        "test measures are no longer the ones it was calibrated against"
+    )
+
+    # Well under the 221 the correct render reaches, and well over the 33 the
+    # chained one left behind -- the gap is the whole ring, not a shading tweak.
+    floor = 192
+    assert int(result[:, :, 0][outset].min()) >= floor, (
+        "the outset stroke is painted over, which is what happens when the "
+        "inset stroke traces it instead of the layer"
+    )
+    assert int(result[:, :, 2][inset].min()) >= floor, (
+        "the inset stroke is missing from the layer's inner edge, which is "
+        "where it lands only when it traces the layer"
+    )


### PR DESCRIPTION
## Summary

`Compositor._apply_stroke_effect` used `shape` as both the loop variable and the accumulator: the mask a stroke produced was assigned back over the coverage the next stroke traced. A layer with two stroke effects therefore drew the second stroke around the **first stroke's outline** instead of around the layer, and the error compounds with each further stroke.

The fix keeps the layer's coverage in `shape` for the whole loop and gives each effect's own result the name `mask`. The `broadcast_to` that gives a maskless layer a channel axis moves out of the loop with it, since it no longer has to be redone once per effect.

Fixes #798. First tracking item of #799 — landing it separately keeps its error out of the primitive change.

## What it looks like

`effects/double-stroke-effects.psd` is one rectangle carrying a red **outset** stroke and a blue **inset** stroke. Chaining inset the red ring rather than the layer, which did two visible things at once: the blue ring was never painted, and it was painted over the red one.

| ring, measured where Photoshop paints it | before | after | Photoshop |
| --- | --- | --- | --- |
| min red on the outset ring | 33 | 255 | 255 |
| min blue on the inset ring | 0 | 221 | 255 |

## Measurement

MSE against the fixture's own Photoshop preview:

| | before | after |
| --- | --- | --- |
| `force=False` | 0.05653 | **0.00227** |
| `force=True` | 0.05568 | 0.04953 |

`force=False` is what the test asserts, and 0.00227 is essentially the entire error on that fixture — matching the figures in the issue. `force=True` improves only slightly: that path redraws the layer from its vector mask, and its remaining error comes from the stroke primitive itself, which is #799's subject rather than this one's.

## Scope

Hashing the rendered output of all 260 fixtures under `tests/psd_files` in **both** force modes shows exactly one fixture moving — the double-stroke one, in both modes. Nothing else in the corpus has a layer with more than one stroke effect (verified by sweeping the corpus, not assumed), which is why this went unnoticed.

## Tests

- `effects/double-stroke-effects.psd` comes out of `test_stroke_effects_xfail` into a plain `test_double_stroke_effects` at the same `threshold=0.01`, so this retires an `xfail` rather than only improving a number.
- `test_second_stroke_traces_the_layer` asserts both rings, since the defect moves each for a different reason — an error threshold alone would move for either half. The rings are read off Photoshop's stored preview, with ICC off on both sides so the calibrated pixel counts do not depend on the installed colour management library.

Both new tests fail on `main` and pass here. Full suite, `ruff check`, `ruff format --check` and `mypy` are clean.

## Note for anyone benchmarking this code

Two traps cost time here, both of which produce numbers that look like a real tie:

- `composite.py` binds `draw_stroke_effect` via `from ... import`, and `psd_tools.composite.composite` resolves to the re-exported *function*, not the module. Patching the primitive in the obvious places silently does nothing.
- `PSDImage.composite()` returns the **stored preview** rather than a render unless something forces a redraw. Comparing that against the preview compares the file with itself; pass `ignore_preview=True`, or use the low-level `composite()` the tests use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
