### PR TITLE
fix: draw outset and centered stroke effects as a signed-distance band

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
+- [fix] Draw outset and centered stroke effects as a band in the layer's
+  distance field rather than a dilated edge, placing them where Photoshop does
+  on a hard-edged layer and no longer quantizing the width to whole pixels.
+  **Rendering change** for any layer carrying an outset or centered stroke; a
+  soft-edged one may land slightly further from Photoshop than before, and the
+  inset style is unchanged (#799, #802)
 - [fix] Trace every stroke effect from the layer. The second stroke on a layer
   outlined the first stroke instead of the layer, which left its own ring
   unpainted and painted over the first. **Rendering change** for a layer

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ Changelog
   **Rendering change** for any layer carrying an outset or centered stroke; a
   soft-edged one may land slightly further from Photoshop than before, and the
   inset style is unchanged (#799, #802)
+- [fix] Draw outset and centered stroke effects without scikit-image installed,
+  which only the inset style still needs (#799, #802)
 - [fix] Trace every stroke effect from the layer. The second stroke on a layer
   outlined the first stroke instead of the layer, which left its own ring
   unpainted and painted over the first. **Rendering change** for a layer

--- a/docs/reference/psd_tools.composite.rst
+++ b/docs/reference/psd_tools.composite.rst
@@ -44,5 +44,5 @@ Effects Rendering
     :members:
 
 Layer effects rendering including strokes, shadows, and glows. Requires
-scipy for the distance transform that places strokes, and scikit-image for
-the edge filter the inset style still uses.
+scipy for the distance transform that places outset and centered strokes, and
+scikit-image for pattern fills and for the edge filter the inset style uses.

--- a/docs/reference/psd_tools.composite.rst
+++ b/docs/reference/psd_tools.composite.rst
@@ -44,4 +44,5 @@ Effects Rendering
     :members:
 
 Layer effects rendering including strokes, shadows, and glows. Requires
-scikit-image for morphological operations.
+scipy for the distance transform that places strokes, and scikit-image for
+the edge filter the inset style still uses.

--- a/src/psd_tools/composite/__init__.py
+++ b/src/psd_tools/composite/__init__.py
@@ -17,8 +17,9 @@ The composite extra includes:
 
 - ``aggdraw``: For vector path and bezier curve rasterization
 - ``scipy``: For advanced image processing operations, including the
-  distance transform that places stroke effects
-- ``scikit-image``: For the edge filter the inset stroke effect uses
+  distance transform that places outset and centered stroke effects
+- ``scikit-image``: For pattern fills, and for the edge filter the inset
+  stroke effect uses
 
 Key modules:
 

--- a/src/psd_tools/composite/__init__.py
+++ b/src/psd_tools/composite/__init__.py
@@ -16,8 +16,9 @@ Or using uv::
 The composite extra includes:
 
 - ``aggdraw``: For vector path and bezier curve rasterization
-- ``scipy``: For advanced image processing operations
-- ``scikit-image``: For morphological operations in effects
+- ``scipy``: For advanced image processing operations, including the
+  distance transform that places stroke effects
+- ``scikit-image``: For the edge filter the inset stroke effect uses
 
 Key modules:
 

--- a/src/psd_tools/composite/_compat.py
+++ b/src/psd_tools/composite/_compat.py
@@ -106,7 +106,7 @@ def require_skimage(func: F) -> F:
 
     Example:
         >>> @require_skimage
-        ... def draw_stroke_effect(viewport, shape, desc, psd):
+        ... def _draw_dilated_edge(shape, style, size):
         ...     # effect implementation
         ...     pass
     """

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -6,8 +6,10 @@ This module implements rendering for Photoshop layer effects (also known as
 layer styles). Effects are non-destructive visual enhancements applied to layers
 such as strokes, shadows, glows, and overlays.
 
-**Note**: Effects rendering requires scipy, and the inset stroke style also
-requires scikit-image. Install both with::
+**Note**: Effects rendering requires scipy. It additionally requires
+scikit-image for the inset stroke style and for any pattern fill, so only a
+solid or gradient outset or centered stroke draws without it. Install both
+with::
 
     pip install 'psd-tools[composite]'
 

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -25,7 +25,7 @@ Partially supported or limited effects:
 The main function :py:func:`draw_stroke_effect` handles stroke rendering by:
 
 1. Extracting the layer's alpha channel or shape mask
-2. Applying morphological operations (dilation/erosion) based on stroke size and position
+2. Placing the stroke relative to that shape according to its size and position
 3. Filling the stroke region with the specified paint (solid color, gradient, pattern)
 4. Returning the rendered stroke as a NumPy array
 
@@ -82,11 +82,11 @@ def stroke_bbox(
 ) -> tuple[int, int, int, int]:
     """The canvas :py:func:`draw_stroke_effect` needs to draw a stroke on.
 
-    The stroke is drawn by dilating the layer's edge, so an outset or centered
-    stroke lands partly outside ``bbox``. Drawing it on ``bbox`` itself has no
-    room for that part and silently discards it -- for a layer whose pixels
-    fill its bounding box, that is the whole stroke (#792). Growing the box by
-    the stroke's outward reach gives the dilation somewhere to land.
+    The stroke is drawn outward from the layer's edge, so an outset or
+    centered one lands partly outside ``bbox``. Drawing it on ``bbox`` itself
+    has no room for that part and silently discards it -- for a layer whose
+    pixels fill its bounding box, that is the whole stroke (#792). Growing the
+    box by the stroke's outward reach gives it somewhere to land.
 
     An empty ``bbox`` is returned untouched: there is no edge to trace, and
     growing it would place a stroke around the origin.
@@ -96,10 +96,61 @@ def stroke_bbox(
     reach = _OUTWARD_REACH.get(desc.get(Key.Style).enum, 1.0)
     if reach == 0.0:
         return bbox
-    # ceil() because a fractional stroke still covers the pixel it falls in,
-    # and +1 for the one-pixel spread of the edge filter itself.
+    # ceil() because a fractional stroke still covers the pixel it falls in.
+    # The +1 is slack: a band reaches exactly ceil(size * reach), and an
+    # unrecognised style falls through to the dilation path, whose edge filter
+    # spreads a pixel further. Inset never gets here, its reach being 0.
     margin = math.ceil(float(desc.get(Key.SizeKey, 1.0)) * reach) + 1
     return (bbox[0] - margin, bbox[1] - margin, bbox[2] + margin, bbox[3] + margin)
+
+
+def _signed_distance(alpha: np.ndarray) -> np.ndarray:
+    """Euclidean distance from each pixel to the mask boundary, negative inside.
+
+    ``distance_transform_edt`` measures to the nearest pixel of the other
+    class, so the two pixels straddling the boundary both come back 1.0 rather
+    than the 0.5 their centres really sit at. The magnitude is shrunk to put
+    the boundary back between them; subtracting 0.5 outright would be right
+    outside and a full pixel wrong inside, where the sign is negative.
+
+    A pixel that straddles the boundary knows better than the 0.5 iso-contour
+    does where within itself the boundary falls, so those pixels -- and only
+    those -- are reseeded from their own coverage. Reseeding every partial
+    pixel would drag the far side of a feathered mask to within half a pixel
+    of a boundary it is nowhere near, and paint a stroke across all of it.
+    """
+    from scipy.ndimage import distance_transform_edt  # type: ignore[import-untyped]  # noqa: PLC0415
+
+    inside = alpha >= 0.5
+    # With no boundary in view there is nothing to measure a stroke from, and
+    # ``distance_transform_edt`` is undefined on an input with no zeros: it
+    # reports distances to a phantom feature off the array corner, which a band
+    # would paint as a wedge in the corner of the canvas. Being uniformly
+    # infinitely far from the boundary leaves every band empty, which is right.
+    if inside.all():
+        return np.full(alpha.shape, -np.inf, dtype=np.float32)
+    if not inside.any():
+        return np.full(alpha.shape, np.inf, dtype=np.float32)
+
+    distance = distance_transform_edt(~inside).astype(np.float32)
+    distance -= distance_transform_edt(inside).astype(np.float32)
+    distance = np.sign(distance) * np.maximum(np.abs(distance) - 0.5, 0.0)
+    straddles = (alpha > 0) & (alpha < 1) & (np.abs(distance) <= 0.5)
+    distance[straddles] = 0.5 - alpha[straddles]
+    return distance
+
+
+def _distance_band(distance: np.ndarray, lo: float, hi: float) -> np.ndarray:
+    """Coverage of the band between ``lo`` and ``hi``, antialiased.
+
+    A distance field has unit gradient, so one pixel of distance is one pixel
+    of space, and a linear ramp across it is the exact area of a pixel cut by
+    a straight edge. That is what lets a fractional width mean something: the
+    band is never quantized to a whole number of pixels the way a dilation pen
+    is. Where the band's edge curves, around a corner, the ramp approximates
+    that area rather than matching it.
+    """
+    return np.clip(hi - distance + 0.5, 0, 1) * np.clip(distance - lo + 0.5, 0, 1)
 
 
 @require_skimage
@@ -109,10 +160,6 @@ def draw_stroke_effect(
     desc: Descriptor,
     psd: "PSDProtocol",
 ) -> tuple[np.ndarray, np.ndarray]:
-    # Import here after checking dependencies
-    from skimage import filters  # noqa: PLC0415
-    from skimage.morphology import disk  # noqa: PLC0415
-
     logger.debug("Stroke effect has limited support")
     height, width = viewport[3] - viewport[1], viewport[2] - viewport[0]
     if not isinstance(shape, np.ndarray):
@@ -140,13 +187,30 @@ def draw_stroke_effect(
 
     style = desc.get(Key.Style).enum
     size = float(desc.get(Key.SizeKey, 1.0))
-    if style in (Enum.OutsetFrame, Enum.InsetFrame):
+
+    # An outset or centered stroke is a band in the layer's signed distance
+    # field, which is exact on a hard-edged mask and needs no pen to quantize
+    # the radius to a whole pixel. Inset keeps the dilation below: it is
+    # anchored differently, and a symmetric band misses it by about a pixel
+    # (#799). Any style this does not name keeps the dilation too.
+    if style in (Enum.OutsetFrame, Enum.CenteredFrame):
+        limits = (0.0, size) if style == Enum.OutsetFrame else (-size / 2.0, size / 2.0)
+        distance = _signed_distance(shape[:, :, 0])
+        return color, np.expand_dims(_distance_band(distance, *limits), 2)
+
+    if style == Enum.InsetFrame:
         size *= 2
 
+    # Only the dilation path needs skimage, which is why @require_skimage
+    # still guards a function whose main path is scipy's alone.
+    from skimage import filters  # noqa: PLC0415
+    from skimage.morphology import disk  # noqa: PLC0415
+
     edges = filters.scharr(shape[:, :, 0])
-    # Rounded up rather than truncated: the doubling above leaves an outset or
-    # inset radius whole, but a centered one keeps its half pixel, and dropping
-    # that drew every odd centered stroke a pixel short per side (#792).
+    # Rounded up rather than truncated, which drew every odd stroke a pixel
+    # short per side (#792). Only inset reaches this now, so the doubling
+    # above always leaves the radius whole, but the ceil() still guards the
+    # unrecognised styles that fall through here undoubled.
     pen = disk(math.ceil(size / 2.0 - 1))
     mask = (
         filters.rank.maximum((255 * edges).astype(np.uint8), pen).astype(np.float32)
@@ -155,9 +219,7 @@ def draw_stroke_effect(
     mask = utils.divide(mask - np.min(mask), np.max(mask) - np.min(mask))
     mask = np.expand_dims(mask, 2)
 
-    if style == Enum.OutsetFrame:
-        mask = np.maximum(0, mask - shape)
-    elif style == Enum.InsetFrame:
+    if style == Enum.InsetFrame:
         mask = np.maximum(0, mask * shape)
 
     return color, mask

--- a/src/psd_tools/composite/effects.py
+++ b/src/psd_tools/composite/effects.py
@@ -6,7 +6,8 @@ This module implements rendering for Photoshop layer effects (also known as
 layer styles). Effects are non-destructive visual enhancements applied to layers
 such as strokes, shadows, glows, and overlays.
 
-**Note**: Effects rendering requires scikit-image. Install with::
+**Note**: Effects rendering requires scipy, and the inset stroke style also
+requires scikit-image. Install both with::
 
     pip install 'psd-tools[composite]'
 
@@ -58,7 +59,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from psd_tools.composite import paint, utils
-from psd_tools.composite._compat import require_skimage
+from psd_tools.composite._compat import HAS_SCIPY, require_skimage
 from psd_tools.psd.descriptor import Descriptor
 from psd_tools.terminology import Enum, Key
 
@@ -119,6 +120,14 @@ def _signed_distance(alpha: np.ndarray) -> np.ndarray:
     pixel would drag the far side of a feathered mask to within half a pixel
     of a boundary it is nowhere near, and paint a stroke across all of it.
     """
+    if not HAS_SCIPY:
+        raise ImportError(
+            "Outset and centered stroke effects require: scipy\n\n"
+            "Install with:\n"
+            "    pip install 'psd-tools[composite]'\n"
+            "Or:\n"
+            "    pip install scipy"
+        )
     from scipy.ndimage import distance_transform_edt  # type: ignore[import-untyped]  # noqa: PLC0415
 
     inside = alpha >= 0.5
@@ -154,6 +163,43 @@ def _distance_band(distance: np.ndarray, lo: float, hi: float) -> np.ndarray:
 
 
 @require_skimage
+def _draw_dilated_edge(shape: np.ndarray, style: bytes, size: float) -> np.ndarray:
+    """Trace the layer by dilating a gradient-magnitude edge.
+
+    The original stroke primitive, kept for the inset style: it is anchored
+    differently from the other two and a symmetric distance band misses it by
+    about a pixel, which is a separate tracking item of #799. Any style
+    :py:func:`draw_stroke_effect` does not recognise lands here too.
+
+    This is the only part of a stroke that still needs scikit-image, which is
+    why the decorator sits here rather than on the caller -- an outset or
+    centered stroke draws with scipy alone.
+    """
+    from skimage import filters  # noqa: PLC0415
+    from skimage.morphology import disk  # noqa: PLC0415
+
+    if style == Enum.InsetFrame:
+        size *= 2
+
+    edges = filters.scharr(shape[:, :, 0])
+    # Rounded up rather than truncated, which drew every odd stroke a pixel
+    # short per side (#792). Only inset reaches this now, so the doubling
+    # above always leaves the radius whole, but the ceil() still guards the
+    # unrecognised styles that fall through here undoubled.
+    pen = disk(math.ceil(size / 2.0 - 1))
+    mask = (
+        filters.rank.maximum((255 * edges).astype(np.uint8), pen).astype(np.float32)
+        / 255.0
+    )
+    mask = utils.divide(mask - np.min(mask), np.max(mask) - np.min(mask))
+    mask = np.expand_dims(mask, 2)
+
+    if style == Enum.InsetFrame:
+        mask = np.maximum(0, mask * shape)
+
+    return mask
+
+
 def draw_stroke_effect(
     viewport: tuple[int, int, int, int],
     shape: np.ndarray,
@@ -198,28 +244,4 @@ def draw_stroke_effect(
         distance = _signed_distance(shape[:, :, 0])
         return color, np.expand_dims(_distance_band(distance, *limits), 2)
 
-    if style == Enum.InsetFrame:
-        size *= 2
-
-    # Only the dilation path needs skimage, which is why @require_skimage
-    # still guards a function whose main path is scipy's alone.
-    from skimage import filters  # noqa: PLC0415
-    from skimage.morphology import disk  # noqa: PLC0415
-
-    edges = filters.scharr(shape[:, :, 0])
-    # Rounded up rather than truncated, which drew every odd stroke a pixel
-    # short per side (#792). Only inset reaches this now, so the doubling
-    # above always leaves the radius whole, but the ceil() still guards the
-    # unrecognised styles that fall through here undoubled.
-    pen = disk(math.ceil(size / 2.0 - 1))
-    mask = (
-        filters.rank.maximum((255 * edges).astype(np.uint8), pen).astype(np.float32)
-        / 255.0
-    )
-    mask = utils.divide(mask - np.min(mask), np.max(mask) - np.min(mask))
-    mask = np.expand_dims(mask, 2)
-
-    if style == Enum.InsetFrame:
-        mask = np.maximum(0, mask * shape)
-
-    return color, mask
+    return color, _draw_dilated_edge(shape, style, size)

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from psd_tools.api.psd_image import PSDImage
+from psd_tools.composite import _compat, effects
 from psd_tools.composite.effects import (
     _OUTWARD_REACH,
     _distance_band,
@@ -379,3 +380,37 @@ def test_a_feathered_mask_keeps_its_stroke_at_the_boundary() -> None:
         )
         for total in band.sum(axis=1):
             assert float(total) == pytest.approx(3.0)
+
+
+def test_band_strokes_draw_without_scikit_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An outset or centered stroke needs scipy, not scikit-image (#802).
+
+    Only the inset style's dilated edge still uses scikit-image. While the
+    whole of :py:func:`draw_stroke_effect` was gated on it, a scipy-only
+    install -- a platform with no scikit-image wheel, say -- failed to render
+    *any* document carrying *any* stroke, because nothing upstream catches the
+    ImportError and turns it into a missing effect.
+    """
+    monkeypatch.setattr(_compat, "HAS_SKIMAGE", False)
+    check_composite_quality("effects/outside-stroke.psd", threshold=1e-4)
+    check_composite_quality("effects/center-stroke-sizes.psd", threshold=1e-4)
+
+
+def test_each_stroke_path_names_the_dependency_it_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The two paths ask for different packages, so they must say which.
+
+    Asserted because the obvious way to guard the band is ``@require_scipy``,
+    whose message tells the reader to install scipy for *gradient fills* --
+    accurate about the package and misleading about why.
+    """
+    monkeypatch.setattr(_compat, "HAS_SKIMAGE", False)
+    with pytest.raises(ImportError, match="scikit-image"):
+        check_composite_quality("effects/shape-fx2.psd", threshold=1.0)
+
+    monkeypatch.setattr(effects, "HAS_SCIPY", False)
+    with pytest.raises(ImportError, match="stroke effects require: scipy"):
+        check_composite_quality("effects/outside-stroke.psd", threshold=1.0)

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -1,9 +1,16 @@
 import logging
+import math
 
 import numpy as np
 import pytest
 
 from psd_tools.api.psd_image import PSDImage
+from psd_tools.composite.effects import (
+    _OUTWARD_REACH,
+    _distance_band,
+    _signed_distance,
+)
+from psd_tools.terminology import Enum
 
 from ..utils import full_name
 from .test_composite import check_composite_quality
@@ -202,3 +209,173 @@ def test_second_stroke_traces_the_layer() -> None:
         "the inset stroke is missing from the layer's inner edge, which is "
         "where it lands only when it traces the layer"
     )
+
+
+@pytest.mark.parametrize(
+    ("filename",),
+    [
+        ("effects/outside-stroke.psd",),
+        ("effects/center-stroke-sizes.psd",),
+    ],
+)
+def test_hard_edged_stroke_matches_photoshop(filename: str) -> None:
+    """A stroke on a hard-edged mask lands where Photoshop puts it (#799).
+
+    Both files are squares with no partial alpha anywhere, so the boundary the
+    stroke is measured from is a fact rather than a modelling choice. Every
+    straight run of the stroke then matches Photoshop to the bit, because a
+    ramp that is linear in distance is the exact area of a pixel cut by a
+    straight edge. What is left is the corner arcs, where that ramp is only an
+    approximation of a curved cut: 16 pixels of 1024 and 24 of 9216, differing
+    by up to 0.073 and 0.110 coverage, which is why this asserts 1e-4 rather
+    than equality.
+
+    That is still 60x and 30x under what these scored when the stroke was a
+    dilated ``scharr`` edge -- 0.00626 and 0.00326 -- so the threshold
+    separates the band from an approximation of it, which the 0.01 used
+    elsewhere would not.
+    """
+    check_composite_quality(filename, threshold=1e-4)
+
+
+def test_distance_band_covers_its_width_on_a_pixel_boundary() -> None:
+    """A stroke of width *w* covers *w* pixels of coverage, fractional *w* too.
+
+    The dilation pen this replaced was built from ``disk(r)`` with an integer
+    ``r``, so a 3 px centered stroke could only reach 1 px or 2 px per side and
+    never the 1.5 it asks for -- #796 fixed that by rounding to the better of
+    two wrong integers. A band in a distance field has no such step, and this
+    pins the property that makes it worth having.
+
+    The boundary here falls exactly on a pixel edge, which is the case the
+    identity holds for. Where it cuts through a pixel instead, that pixel is
+    reseeded from its own coverage and the reseeding does not re-propagate, so
+    the field stops being 1-Lipschitz just where the band sits and the total
+    drifts by up to half a pixel. That is a property of the primitive as #799
+    specifies it, and squaring it away is that issue's fourth tracking item.
+    """
+    # A single hard vertical edge, covered on the left and empty on the right.
+    alpha = np.zeros((1, 12), dtype=np.float32)
+    alpha[:, :6] = 1.0
+    distance = _signed_distance(alpha)
+    # Pixel centres sit half a pixel off the boundary, and the sign says which
+    # side: this is the measurement everything below is derived from.
+    assert distance[0].tolist() == [
+        -5.5,
+        -4.5,
+        -3.5,
+        -2.5,
+        -1.5,
+        -0.5,
+        0.5,
+        1.5,
+        2.5,
+        3.5,
+        4.5,
+        5.5,
+    ]
+
+    for width in (0.5, 1.0, 1.5, 2.0, 2.5, 3.0):
+        outset = float(_distance_band(distance, 0.0, width).sum())
+        assert outset == pytest.approx(width), f"outset stroke of {width} px"
+        centered = float(_distance_band(distance, -width / 2.0, width / 2.0).sum())
+        assert centered == pytest.approx(width), f"centered stroke of {width} px"
+
+
+def test_centered_band_straddles_the_edge_evenly() -> None:
+    """A centered stroke puts half its width on each side of the boundary.
+
+    Asserted separately from the total width above, because a band anchored to
+    one side would still total the right coverage while sitting entirely in the
+    layer -- which is what an inset stroke is, not a centered one.
+    """
+    alpha = np.zeros((1, 12), dtype=np.float32)
+    alpha[:, :6] = 1.0
+    distance = _signed_distance(alpha)
+    band = _distance_band(distance, -1.5, 1.5)[0]
+    assert float(band[:6].sum()) == pytest.approx(1.5), "coverage inside the layer"
+    assert float(band[6:].sum()) == pytest.approx(1.5), "coverage outside the layer"
+
+
+@pytest.mark.parametrize("size", [0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 7.0, 7.5, 10.0])
+def test_band_fits_the_canvas_stroke_bbox_asks_for(size: float) -> None:
+    """The band never reaches past the margin :py:func:`stroke_bbox` grants.
+
+    That margin is what keeps an outset or centered stroke from being clipped
+    to the layer's own bounding box (#792). On a hard-edged mask the band
+    reaches exactly one pixel less than the margin at every size, so equality
+    is asserted rather than a bound: the reach and the margin are now stated
+    independently -- in the band limits here and in ``_OUTWARD_REACH`` -- and
+    a change to either that forgets the other would otherwise start shaving
+    the outside of every stroke, or reserving canvas nobody draws on.
+    """
+    pad = 40
+    alpha = np.zeros((2 * pad + 20, 2 * pad + 20), dtype=np.float32)
+    alpha[pad : pad + 20, pad : pad + 20] = 1.0
+    distance = _signed_distance(alpha)
+
+    for style, limits in (
+        (Enum.OutsetFrame, (0.0, size)),
+        (Enum.CenteredFrame, (-size / 2.0, size / 2.0)),
+    ):
+        band = _distance_band(distance, *limits)
+        ys, xs = np.nonzero(band)
+        # All four sides, not just the horizontal pair: the mask is square, so
+        # a band that reached unevenly would otherwise go unnoticed.
+        reach = max(
+            pad - int(xs.min()),
+            int(xs.max()) + 1 - (pad + 20),
+            pad - int(ys.min()),
+            int(ys.max()) + 1 - (pad + 20),
+        )
+        margin = math.ceil(size * _OUTWARD_REACH[style]) + 1
+        assert reach == margin - 1, (
+            f"{style!r} stroke of {size} px reaches {reach} px outside the "
+            f"layer, against the {margin} px stroke_bbox() reserves for it"
+        )
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [0.0, 1.0, 0.3, 0.9],
+    ids=["transparent", "opaque", "below-half", "above-half"],
+)
+def test_a_mask_with_no_boundary_draws_no_stroke(alpha: float) -> None:
+    """A stroke needs a boundary to trace, and a flat mask has none (#799).
+
+    ``distance_transform_edt`` is undefined on an input with no zeros: rather
+    than refusing, it reports distances to a phantom feature off the array
+    corner, and a band built on those paints a wedge of full-coverage stroke
+    into the corner of the canvas. Nothing in the fixture corpus has a
+    boundaryless mask -- a layer everywhere below half alpha is all it takes --
+    so no rendering comparison can catch this and only this test does.
+    """
+    flat = np.full((9, 9), alpha, dtype=np.float32)
+    distance = _signed_distance(flat)
+    # Uniformly infinitely far from a boundary that is not there.
+    assert not np.isfinite(distance).any()
+    for limits in ((0.0, 3.0), (-1.5, 1.5)):
+        band = _distance_band(distance, *limits)
+        assert float(band.sum()) == 0.0, f"stroke painted on a flat {alpha} mask"
+
+
+def test_a_feathered_mask_keeps_its_stroke_at_the_boundary() -> None:
+    """A wide alpha ramp takes a stroke at its half-coverage line, not across it.
+
+    Only a pixel the boundary actually cuts is reseeded from its coverage.
+    Reseeding every partial pixel instead -- which is the reading the issue's
+    own snippet invites -- puts the entire body of a feathered mask within half
+    a pixel of a boundary it is nowhere near, and the band spreads over all of
+    it: on this ramp that paints all 32 pixels of every row rather than 4, and
+    the field stops satisfying the unit gradient the linear ramp relies on.
+    """
+    ramp = np.tile(np.linspace(1.0, 0.0, 32, dtype=np.float32), (4, 1))
+    distance = _signed_distance(ramp)
+    for limits in ((0.0, 3.0), (-1.5, 1.5)):
+        band = _distance_band(distance, *limits)
+        painted = (band > 0).sum(axis=1)
+        assert painted.tolist() == [4, 4, 4, 4], (
+            f"a 3 px stroke covered {painted.tolist()} pixels of a 32 px ramp"
+        )
+        for total in band.sum(axis=1):
+            assert float(total) == pytest.approx(3.0)

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -385,17 +385,27 @@ def test_a_feathered_mask_keeps_its_stroke_at_the_boundary() -> None:
 def test_band_strokes_draw_without_scikit_image(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An outset or centered stroke needs scipy, not scikit-image (#802).
+    """A solid outset or centered stroke needs scipy, not scikit-image (#802).
 
-    Only the inset style's dilated edge still uses scikit-image. While the
-    whole of :py:func:`draw_stroke_effect` was gated on it, a scipy-only
-    install -- a platform with no scikit-image wheel, say -- failed to render
-    *any* document carrying *any* stroke, because nothing upstream catches the
-    ImportError and turns it into a missing effect.
+    Of the stroke itself, only the inset style's dilated edge still uses
+    scikit-image. While the whole of :py:func:`draw_stroke_effect` was gated on
+    it, a scipy-only install -- a platform with no scikit-image wheel, say --
+    failed to render *any* document carrying *any* stroke, because nothing
+    upstream catches the ImportError and turns it into a missing effect.
+
+    The paint is the other half of the answer, and it is why this says "solid":
+    a stroke filled with a pattern goes through
+    :py:func:`~psd_tools.composite.paint.draw_pattern_fill`, which needs
+    scikit-image whatever the style, so the last case here still raises.
     """
     monkeypatch.setattr(_compat, "HAS_SKIMAGE", False)
     check_composite_quality("effects/outside-stroke.psd", threshold=1e-4)
     check_composite_quality("effects/center-stroke-sizes.psd", threshold=1e-4)
+
+    psd = PSDImage.open(full_name("effects/stroke-effects.psd"))
+    pattern = next(layer for layer in psd.descendants() if layer.name == "Pattern")
+    with pytest.raises(ImportError, match="scikit-image"):
+        pattern.composite()
 
 
 def test_each_stroke_path_names_the_dependency_it_is_missing(


### PR DESCRIPTION
Implements the second tracking item of #799: an SDF band for `OutsetFrame` and
`CenteredFrame`, dilation retained for `InsetFrame`. #798 landed first, as that
issue requires, so none of the error below is misattributed to it.

## What changed

`draw_stroke_effect` traced the layer with `scharr` → `rank.maximum(disk(r))` →
normalize. An outset or centered stroke is now a band in the Euclidean signed
distance field of the layer's coverage: `[0, w]` outset, `[-w/2, +w/2]`
centered. Since `|grad d| = 1`, a one-pixel linear ramp in distance space is
the exact area of a pixel cut by a straight edge, so the width is never
quantized to a whole pixel the way a `disk(r)` pen forces.

Inset is untouched and keeps the `/max` contrast stretch that only it now
needs. The three inset-only fixtures render byte-for-byte identically.

The outset path also no longer subtracts the layer's own coverage
(`max(0, mask - shape)`): the band is already zero inside the layer. On a hard
mask that is a no-op; on partial-alpha edge pixels the stroke is no longer
clipped by the coverage underneath it.

Each path now requires only what it uses (review): the band needs scipy, and
`@require_skimage` moved onto the extracted `_draw_dilated_edge`. Gating the
whole function on scikit-image meant an install with scipy but no
scikit-image failed to render *any* document carrying *any* stroke, since
nothing upstream turns that `ImportError` into a missing effect.

## Measured against Photoshop's own preview

MSE over all 13 corpus fixtures that draw a stroke — #799 tabulated 8, these
are the rest. `force=False`, the mode `check_composite_quality` uses.

| fixture | dilation | band | |
| --- | --- | --- | --- |
| `effects/outside-stroke.psd` | 0.0062583 | **0.0000138** | 453× better |
| `effects/center-stroke-sizes.psd` | 0.0032611 | **0.0000042** | 776× better |
| `effects/double-stroke-effects.psd` | 0.0022634 | **0.0005095** | 4.4× better |
| `advanced-blending.psd` | 0.1223235 | 0.1222898 | ≈ |
| `masks.psb` | 0.0001767 | 0.0001764 | ≈ |
| `effects/shape-fx2.psd` | 0.0032663 | 0.0032663 | inset, identical |
| `effects/stroke-effect-transparent-shape.psd` | 0.0178824 | 0.0178824 | inset, identical |
| `effects/stroke-composite.psd` | 0.0039241 | 0.0039241 | inset, identical |
| `layer_effects.psd` | 0.0067033 | 0.0067050 | +0.0000017 |
| `layer_comps.psb` | 0.0068001 | 0.0068397 | +0.0000396 |
| `effect-stroke-gradient.psd` | 0.0389171 | 0.0389951 | +0.0000780 |
| `layer_params.psb` | 0.0113764 | 0.0120205 | +0.0006441 |
| `effects/stroke-effects.psd` | 0.0848850 | 0.1164576 | **+0.0315726** |

### What "exact" does and does not mean here

#799 calls the two hard-edged fixtures pixel-exact at <5e-6.
`center-stroke-sizes.psd` meets that (4.2e-6); `outside-stroke.psd` does not —
I measure 1.38e-5, about 3× the claim. Being precise about what is exact:

**The geometry is.** Every straight run of both strokes matches Photoshop bit
for bit, which is what a ramp linear in distance buys — it is the exact area of
a pixel cut by a straight edge. The whole residual is the corner arcs, 16
pixels of 1024 and 24 of 9216, where the boundary curves and a linear ramp only
approximates the true area. Photoshop's corner is the same shape covering the
same pixels; ours is antialiased slightly harder, e.g. 0.39/0.84 against its
0.35/0.76.

So the stroke lands where Photoshop puts it, and what stands between that and
equality is corner antialiasing — a much smaller and better-understood
remainder than the dilation's.

## Correcting #799: "net improvement on every fixture" does not hold

`stroke-effects.psd` regresses, 0.0849 → 0.1165. Flagging it rather than
burying it, because that issue's item 2 claims otherwise.

**That fixture measures the deferred item, not this one.** Its masks are
genuinely feathered — and the ramps are *in the file*, not something psd-tools
introduces: `Raster Rectangle` has no vector mask at all and its stored alpha
ramps smoothly from 1.0 to 0.0 across the shape, and 82–98% of every traced
layer's covered pixels sit strictly between 0.05 and 0.95. In the two fixtures
the band nails, it is 0%. As #799 puts it, "a feathered mask has no unique
boundary, so the 0.5 iso-contour is a modelling choice rather than a fact" —
choosing that boundary is tracking item 4, explicitly deferred. The dilation's
blur happens to suit a ramp better; the band commits to a boundary. The fixture
is already `xfail` and stays one.

The three sub-0.001 regressions are fixtures dominated by what psd-tools cannot
render at all: `effect-stroke-gradient.psd` is type layers, `layer_params.psb`
carries BevelEmboss, `layer_comps.psb` both.

`force=True` swaps the sign on two fixtures — `stroke-effects.psd` *improves*
there (0.0659 → 0.0623) while `double-stroke-effects.psd` regresses (0.0495 →
0.0611). Neither mode is uniformly better; the two hard-edged fixtures are
exact in both.

## Two departures from the primitive as #799 sketches it

Both were found by review and both are measured:

1. **Only a pixel the boundary actually cuts is reseeded from its coverage**,
   not every partial pixel. Seeding all of them drags the far side of a
   feathered mask to within half a pixel of a boundary it is nowhere near — a
   measured band coverage of 0.99–1.00 more than `size + 1.5` px out, across a
   whole layer body, which is not a band at all. It also destroys the
   `|grad d| = 1` property the issue cites as the justification for the linear
   ramp, and it scores worse (`stroke-effects.psd` 0.11765 vs 0.11646).

2. **A mask with no boundary in view draws nothing.** `distance_transform_edt`
   is undefined on an input with no zeros — it reports distances to a phantom
   feature off the array corner — so an all-transparent shape painted 11 px of
   full-coverage stroke into the canvas corner. No corpus fixture reaches this
   (verified across all stroke draws in both force modes), but a layer that is
   everywhere below half alpha does. The old dilation path was differently
   wrong here, via `utils.divide`'s `fill=1.0`; that stays as it is for inset,
   deliberately not inherited.

## Verification

- **Corpus sweep**: sha256 of the render of all 296 fixtures × both force
  modes. Exactly 20 of 592 entries changed — precisely the 10 fixtures that
  draw an outset or centered stroke, in both modes. Zero errors on either side.
- **Tests discriminate**: with only the source change reverted, both
  `test_hard_edged_stroke_matches_photoshop` cases fail (0.0063 and 0.0033
  against a 1e-4 threshold) and pass with it.
- **No test status changed.** Full suite: 2914 passed, 3 skipped, 20 xfailed,
  2 xpassed. Both XPASSes (`vector-mask2.psd`, `effects/shape-fx2.psd`) are
  pre-existing on main and untouched here — `shape-fx2` is inset-only.
- **Faster, as #799 expected**: 2.5× (256px, size 3) to 3.0× (1024px, size 15).

## Two traps, for anyone re-measuring

- `PSDImage.composite(force=False)` returns the **stored preview**, not a
  render. Use `ignore_preview=True`, or `psd_tools.composite.composite()`.
- `psd_tools.composite.composite` resolves to the re-exported *function*, not
  the module, so monkeypatching `draw_stroke_effect` through it silently does
  nothing. Reach the module via `sys.modules`, as `test_composite.py` does.

## Still open in #799

Items 3–5 (inset anchor study, partial-alpha boundary definition, dropping the
dilation path and the `/max` stretch with it) are untouched, so #799 stays
open. The inset anchor study is the natural next one — inset is the only style
still on the old primitive.

One observation for whoever picks up item 4: several `stroke-effects.psd`
layers whose stored mask is a pronounced ramp appear as *flat solid colour* in
Photoshop's own preview — `Shape Rectangle`'s stored alpha falls from 0.64 to
0.16 across the shape, and Photoshop renders it as a solid red square. So it
is not just that the 0.5 iso-contour is a modelling choice on these masks;
what Photoshop does with them at all is unresolved. Worth settling before that
item picks a boundary definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
