### PR TITLE
docs: correct which stroke fills need scikit-image

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,8 +10,9 @@ Changelog
   **Rendering change** for any layer carrying an outset or centered stroke; a
   soft-edged one may land slightly further from Photoshop than before, and the
   inset style is unchanged (#799, #802)
-- [fix] Draw outset and centered stroke effects without scikit-image installed,
-  which only the inset style still needs (#799, #802)
+- [fix] Draw outset and centered stroke effects without scikit-image
+  installed, as long as the fill is solid or a gradient. The inset style and
+  pattern fills still need it (#799, #802, #803)
 - [fix] Trace every stroke effect from the layer. The second stroke on a layer
   outlined the first stroke instead of the layer, which left its own ring
   unpainted and painted over the first. **Rendering change** for a layer


### PR DESCRIPTION
Corrects one unreleased changelog entry from #802 that overstates what a
scipy-only install can render.

The entry said outset and centered stroke effects draw without scikit-image,
"which only the inset style still needs". A stroke's paint is drawn before its
style is looked at, and `draw_pattern_fill` is `@require_skimage`, so a
pattern-filled stroke needs it whatever the style.

Copilot caught this on #802 and I corrected it in the module docstring,
`composite/__init__.py` and `docs/reference/psd_tools.composite.rst` — but left
it standing in the changelog, which is where a user is most likely to read it.

## Verified, not reasoned

`effects/stroke-effects.psd` carries three outset strokes that differ only in
their paint. With `skimage` made unimportable:

| fill | result |
| --- | --- |
| solid colour | renders |
| gradient | renders |
| pattern | `ImportError: Layer effects require: scikit-image` |

So "solid or a gradient" is the accurate boundary, and the code already behaves
that way — #802 added a test pinning the pattern case. This is a wording fix
with no code change.

No changelog entry of its own: it corrects the text of an unreleased entry
rather than describing a change. The entry is still under `1.19.1
(unreleased)`, so nothing released carries the wrong claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
