### PR TITLE
fix: trace a stroke effect from the layer, not the viewport edge

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,11 +4,14 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
-- [fix] Trace a stroke effect from the layer's own coverage instead of from
-  the compositor's clipped copy of it, which made the stroke follow the
-  viewport edge wherever the layer ran past it. **Rendering change** for a
-  layer that reaches off the canvas, and for any ``composite(viewport=...)``
-  narrower than the layer (#804, #806)
+- [fix] Trace a stroke effect from the layer's own coverage, not from the
+  compositor's clipped copy of it. **Rendering change** for a layer that
+  reaches off the canvas and for a ``composite(viewport=...)`` narrower than
+  the layer, where the stroke followed the viewport edge; a vector mask now
+  rasterizes on the box asked for, shifting anti-aliasing by up to 1/255. A
+  stroke on a group is unchanged (#804, #806)
+- [api] ``composite.vector.draw_vector_mask()`` takes a ``viewport`` to
+  rasterize onto, defaulting to the document canvas as before (#804, #806)
 - [fix] Draw nothing for a stroke effect of size 0 rather than raising. Only
   a descriptor can carry one -- Photoshop's own UI will not author it (#805)
 - [fix] Draw an inset stroke effect as a band too, anchored where Photoshop

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
+- [fix] Trace a stroke effect from the layer's own coverage instead of from
+  the compositor's clipped copy of it, which made the stroke follow the
+  viewport edge wherever the layer ran past it. **Rendering change** for a
+  layer that reaches off the canvas, and for any ``composite(viewport=...)``
+  narrower than the layer (#804, #806)
 - [fix] Draw nothing for a stroke effect of size 0 rather than raising. Only
   a descriptor can carry one -- Photoshop's own UI will not author it (#805)
 - [fix] Draw an inset stroke effect as a band too, anchored where Photoshop

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -1514,10 +1514,21 @@ class Compositor(object):
         paste() zero-filled the rest, and a stroke traced from that copy
         follows the viewport edge as if it were the layer's own -- so the
         coverage is read again, on the box actually asked for (#804).
+
+        A group is the exception: its coverage is the composite onto this
+        viewport and cannot be re-read anywhere else.
         """
         x0, y0, x1, y1 = viewport
         vx0, vy0, vx1, vy1 = self._viewport
         if vx0 <= x0 and vy0 <= y0 and x1 <= vx1 and y1 <= vy1:
+            return paste(viewport, self._viewport, shape)
+
+        if isinstance(layer, GroupMixin) and not traces_mask:
+            # A group's coverage is composited onto this viewport and exists
+            # nowhere else, so there is nothing to re-read outside it. Its
+            # stroke keeps tracing the clipped copy, which is wrong in the
+            # same way but still draws a stroke; recomputing would read the
+            # group as an object and find no coverage at all.
             return paste(viewport, self._viewport, shape)
 
         traced = self._get_mask(layer, viewport)

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -1547,10 +1547,12 @@ class Compositor(object):
         alpha: np.ndarray,
         traces_mask: bool,
     ) -> None:
-        # ``shape`` is _get_mask()'s output, which is a bare 1.0 for a layer
-        # with no mask -- and paste() needs something with a channel axis.
-        # broadcast_to gives a stride-0 view rather than a full canvas, which
-        # is all paste() requires since it only reads from it.
+        # ``shape`` is the layer's coverage on this compositor's viewport, or
+        # -- when the stroke traces the mask -- _get_mask()'s output, which is
+        # a bare 1.0 for a layer with no mask. _trace_shape() hands that to
+        # paste(), which needs something with a channel axis. broadcast_to
+        # gives a stride-0 view rather than a full canvas, which is all
+        # paste() requires since it only reads from it.
         if not isinstance(shape, np.ndarray):
             shape = np.broadcast_to(np.float32(shape), (self.height, self.width, 1))
         # Photoshop traces every stroke from the layer, so ``shape`` stays the

--- a/src/psd_tools/composite/composite.py
+++ b/src/psd_tools/composite/composite.py
@@ -955,7 +955,10 @@ class Compositor(object):
             not layer.has_pixels() and utils.has_fill(layer)
         )
         self._apply_stroke_effect(
-            layer, source.shape_mask if traces_mask else source.shape, source.alpha
+            layer,
+            source.shape_mask if traces_mask else source.shape,
+            source.alpha,
+            traces_mask,
         )
 
     def _apply_passthrough_source(
@@ -1289,27 +1292,55 @@ class Compositor(object):
 
         return color, shape, alpha, isolate_adjustments
 
-    def _get_object(self, layer: Layer) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """Get object attributes."""
+    def _read_object(self, layer: Layer) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """The layer's own color and coverage, on ``layer.bbox`` and unpasted.
+
+        Split out of :py:meth:`_get_object` so a stroke effect can re-read the
+        coverage on the box it draws on rather than on this compositor's
+        viewport (#804), without restating which of the two sources -- stored
+        pixels or a redrawn fill -- this layer's arrays come from.
+        """
         color, shape = layer.numpy("color"), layer.numpy("shape")
         if (self._force or not layer.has_pixels()) and utils.has_fill(layer):
             color, shape = paint.create_fill(layer, layer.bbox)
             if shape is None:
                 shape = np.ones((layer.height, layer.width, 1), dtype=np.float32)
+        return color, shape
 
-        if color is None and shape is None:
-            # Empty pixel layer.
-            color = np.ones((self.height, self.width, 1), dtype=np.float32)
-            shape = np.zeros((self.height, self.width, 1), dtype=np.float32)
+    @staticmethod
+    def _place_object_shape(
+        color: np.ndarray | None,
+        shape: np.ndarray | None,
+        bbox: tuple[int, int, int, int],
+        viewport: tuple[int, int, int, int],
+    ) -> np.ndarray:
+        """Place :py:meth:`_read_object`'s coverage on ``viewport``.
+
+        A layer with no shape channel covers the whole viewport; one with
+        neither color nor shape is an empty pixel layer and covers none of it.
+        """
+        if shape is not None:
+            return paste(viewport, bbox, shape)
+        height, width = viewport[3] - viewport[1], viewport[2] - viewport[0]
+        covered = 0.0 if color is None else 1.0
+        return np.full((height, width, 1), covered, dtype=np.float32)
+
+    def _get_object_shape(
+        self, layer: Layer, viewport: tuple[int, int, int, int]
+    ) -> np.ndarray:
+        """The layer's own coverage on ``viewport``, before its mask."""
+        color, shape = self._read_object(layer)
+        return self._place_object_shape(color, shape, layer.bbox, viewport)
+
+    def _get_object(self, layer: Layer) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Get object attributes."""
+        color, own_shape = self._read_object(layer)
+        shape = self._place_object_shape(color, own_shape, layer.bbox, self._viewport)
 
         if color is None:
             color = np.ones((self.height, self.width, 1), dtype=np.float32)
         else:
             color = paste(self._viewport, layer.bbox, color, 1.0)
-        if shape is None:
-            shape = np.ones((self.height, self.width, 1), dtype=np.float32)
-        else:
-            shape = paste(self._viewport, layer.bbox, shape)
 
         alpha = shape * 1.0  # Constant factor is always 1.
 
@@ -1352,20 +1383,27 @@ class Compositor(object):
         # that seed -- the clipped layers paint onto the base layer's color.
         return compositor.result_over_backdrop()
 
-    def _get_mask(self, layer: Layer) -> float | np.ndarray:
+    def _get_mask(
+        self, layer: Layer, viewport: tuple[int, int, int, int] | None = None
+    ) -> float | np.ndarray:
         """The layer's mask coverage, with any mask density already folded in.
+
+        ``viewport`` defaults to this compositor's; a stroke effect passes the
+        box it draws on, which may reach outside it (#804).
 
         The scalar 1.0 default is an allocation-avoidance path, not an API
         convenience like the backdrop spellings: most layers have no mask, and
         materializing an all-ones canvas for each of them is pure waste.
         """
+        if viewport is None:
+            viewport = self._viewport
         shape: float | np.ndarray = 1.0
         if layer.mask is not None and not layer.mask.disabled:
             # TODO: When force, ignore real mask.
             mask = layer.numpy("mask", real_mask=not self._force)
             if mask is not None:
                 shape = paste(
-                    self._viewport,
+                    viewport,
                     layer.mask.bbox,
                     mask,
                     layer.mask.background_color / 255.0,
@@ -1393,9 +1431,7 @@ class Compositor(object):
                 )
             )
         ):
-            shape_v = vector.draw_vector_mask(layer)
-            shape_v = paste(self._viewport, layer._psd.viewbox, shape_v)
-            shape *= shape_v
+            shape *= vector.draw_vector_mask(layer, viewport)
 
             if layer.mask is not None and layer.mask.parameters:
                 density_v = layer.mask.parameters.vector_mask_density
@@ -1464,8 +1500,41 @@ class Compositor(object):
                 color, shape * shape_e, alpha * shape_e * opacity, effect.blend_mode
             )
 
+    def _trace_shape(
+        self,
+        layer: Layer,
+        viewport: tuple[int, int, int, int],
+        shape: np.ndarray,
+        traces_mask: bool,
+    ) -> np.ndarray:
+        """The layer's own coverage on ``viewport``, read past the canvas edge.
+
+        ``shape`` is that same coverage on this compositor's viewport, and is
+        the answer wherever ``viewport`` stays inside it. Where it does not,
+        paste() zero-filled the rest, and a stroke traced from that copy
+        follows the viewport edge as if it were the layer's own -- so the
+        coverage is read again, on the box actually asked for (#804).
+        """
+        x0, y0, x1, y1 = viewport
+        vx0, vy0, vx1, vy1 = self._viewport
+        if vx0 <= x0 and vy0 <= y0 and x1 <= vx1 and y1 <= vy1:
+            return paste(viewport, self._viewport, shape)
+
+        traced = self._get_mask(layer, viewport)
+        if not traces_mask:
+            traced = self._get_object_shape(layer, viewport) * traced
+        if not isinstance(traced, np.ndarray):
+            # An unmasked layer whose stroke traces its mask: _get_mask()
+            # yields a bare 1.0, and draw_stroke_effect() needs a canvas.
+            traced = np.full((y1 - y0, x1 - x0, 1), traced, dtype=np.float32)
+        return traced
+
     def _apply_stroke_effect(
-        self, layer: Layer, shape: float | np.ndarray, alpha: np.ndarray
+        self,
+        layer: Layer,
+        shape: float | np.ndarray,
+        alpha: np.ndarray,
+        traces_mask: bool,
     ) -> None:
         # ``shape`` is _get_mask()'s output, which is a bare 1.0 for a layer
         # with no mask -- and paste() needs something with a channel axis.
@@ -1484,7 +1553,7 @@ class Compositor(object):
             bbox = stroke_bbox(layer.bbox, effect.value)
             if bbox[0] >= bbox[2] or bbox[1] >= bbox[3]:
                 continue
-            shape_in_bbox = paste(bbox, self._viewport, shape)
+            shape_in_bbox = self._trace_shape(layer, bbox, shape, traces_mask)
             color, mask_in_bbox = draw_stroke_effect(
                 bbox, shape_in_bbox, effect.value, layer._psd
             )

--- a/src/psd_tools/composite/vector.py
+++ b/src/psd_tools/composite/vector.py
@@ -139,7 +139,7 @@ def _draw_subpath(
 
     TODO: Replace aggdraw implementation with skimage.draw.
 
-    Note: Callers must be decorated with @needs_aggdraw before calling.
+    Note: Callers must be decorated with @require_aggdraw before calling.
     """
     import aggdraw  # type: ignore[import-not-found]  # noqa: PLC0415
 

--- a/src/psd_tools/composite/vector.py
+++ b/src/psd_tools/composite/vector.py
@@ -15,13 +15,21 @@ logger = logging.getLogger(__name__)
 
 
 @require_aggdraw
-def draw_vector_mask(layer: "Layer") -> np.ndarray:
+def draw_vector_mask(
+    layer: "Layer", viewport: tuple[int, int, int, int] | None = None
+) -> np.ndarray:
     """
     Draw a vector mask.
 
+    ``viewport`` is the region to rasterize onto, defaulting to the document
+    canvas. A stroke effect asks for the box it draws on instead, which may
+    reach outside the canvas: the path is placed in document coordinates
+    either way, so what falls outside the canvas is real coverage rather than
+    something to be clipped away (#804).
+
     Requires aggdraw for bezier curve rasterization.
     """
-    return _draw_path(layer, brush={"color": 255})
+    return _draw_path(layer, brush={"color": 255}, viewport=viewport)
 
 
 @require_aggdraw
@@ -67,10 +75,14 @@ def _draw_path(
     layer: "Layer",
     brush: dict[str, int | float] | None = None,
     pen: dict[str, int | float] | None = None,
+    viewport: tuple[int, int, int, int] | None = None,
 ) -> np.ndarray:
     if layer.vector_mask is None:
         raise ValueError("Layer does not have a vector mask.")
-    height, width = layer._psd.height, layer._psd.width
+    if viewport is None:
+        viewport = layer._psd.viewbox
+    width, height = viewport[2] - viewport[0], viewport[3] - viewport[1]
+    doc_size = (layer._psd.width, layer._psd.height)
     color = 0
     if layer.vector_mask.initial_fill_rule and len(layer.vector_mask.paths) == 0:
         color = 1
@@ -87,7 +99,7 @@ def _draw_path(
     # Apply shape operation.
     first = True
     for subpath_list in paths:
-        plane = _draw_subpath(subpath_list, width, height, brush, pen)
+        plane = _draw_subpath(subpath_list, viewport, doc_size, brush, pen)
         assert mask.shape == (height, width, 1)
         assert plane.shape == mask.shape
 
@@ -111,13 +123,19 @@ def _draw_path(
 
 def _draw_subpath(
     subpath_list: list,
-    width: int,
-    height: int,
+    viewport: tuple[int, int, int, int],
+    doc_size: tuple[int, int],
     brush: dict[str, int | float] | None,
     pen: dict[str, int | float] | None,
 ) -> np.ndarray:
     """
     Rasterize Bezier curves using aggdraw.
+
+    Knot coordinates are fractions of the document, so the symbol is always
+    built against the document size and then translated by the viewport
+    origin -- a viewport that starts outside the canvas translates by a
+    negative offset, which is what keeps the part of the path that lies off
+    the canvas on the plane.
 
     TODO: Replace aggdraw implementation with skimage.draw.
 
@@ -125,6 +143,7 @@ def _draw_subpath(
     """
     import aggdraw  # type: ignore[import-not-found]  # noqa: PLC0415
 
+    width, height = viewport[2] - viewport[0], viewport[3] - viewport[1]
     mask = Image.new("L", (width, height), 0)
     draw = aggdraw.Draw(mask)
     pen = aggdraw.Pen(**pen) if pen else None
@@ -133,9 +152,9 @@ def _draw_subpath(
         if len(subpath) <= 1:
             logger.warning("not enough knots: %d" % len(subpath))
             continue
-        path = " ".join(map(str, _generate_symbol(subpath, width, height)))
+        path = " ".join(map(str, _generate_symbol(subpath, *doc_size)))
         symbol = aggdraw.Symbol(path)
-        draw.symbol((0, 0), symbol, pen, brush)
+        draw.symbol((-viewport[0], -viewport[1]), symbol, pen, brush)
     draw.flush()
     del draw
     return np.expand_dims(np.array(mask).astype(np.float32) / 255.0, 2)

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -1424,7 +1424,7 @@ def test_composite_stroke_effect_over_a_layer_without_a_mask() -> None:
     alpha = np.zeros((psd.height, psd.width, 1), dtype=np.float32)
     compositor = Compositor(psd.viewbox, backdrop, alpha)
     # 1.0 is exactly what _get_mask() yields for an unmasked layer.
-    compositor._apply_stroke_effect(layer, 1.0, np.ones_like(alpha))
+    compositor._apply_stroke_effect(layer, 1.0, np.ones_like(alpha), True)
     assert compositor.finish()[0].shape == (psd.height, psd.width, 3)
 
 

--- a/tests/psd_tools/composite/test_composite.py
+++ b/tests/psd_tools/composite/test_composite.py
@@ -10,6 +10,7 @@ from psd_tools.api.numpy_io import _image_data_peak_bytes
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.composite import composite
 from psd_tools.composite.composite import Compositor
+from psd_tools.composite.effects import stroke_bbox
 from psd_tools.constants import BlendMode, ColorMode, CompatibilityMode, Tag
 from psd_tools.psd.base import ByteElement
 from PIL import Image
@@ -1412,6 +1413,12 @@ def test_composite_stroke_effect_over_a_layer_without_a_mask() -> None:
     combination is reachable for a fill layer with no vector mask, and 26 calls
     in the fixture corpus already pass the scalar; they escape only because
     those layers have no stroke effect.
+
+    The viewport is grown past the stroke's box on purpose. Only a stroke
+    drawn wholly inside the compositor's viewport reads the coverage it was
+    handed -- outside it, ``_trace_shape()`` reads the layer again and never
+    touches the scalar (#804) -- and on this layer's own canvas the stroke
+    box starts at ``(-1, -2)``, so the guarded line would go unvisited.
     """
     psd = PSDImage.open(full_name("effects/stroke-effects.psd"))
     layer = next(
@@ -1420,12 +1427,19 @@ def test_composite_stroke_effect_over_a_layer_without_a_mask() -> None:
         for sub in (getattr(top, "_layers", None) or [])
         if list(sub.effects.find("stroke"))
     )
-    backdrop = np.ones((psd.height, psd.width, 3), dtype=np.float32)
-    alpha = np.zeros((psd.height, psd.width, 1), dtype=np.float32)
-    compositor = Compositor(psd.viewbox, backdrop, alpha)
+    viewport = (-4, -4, psd.width, psd.height)
+    for effect in layer.effects.find("stroke"):
+        bbox = stroke_bbox(layer.bbox, effect.value)
+        assert viewport[0] <= bbox[0] and viewport[1] <= bbox[1]
+        assert bbox[2] <= viewport[2] and bbox[3] <= viewport[3]
+
+    height, width = viewport[3] - viewport[1], viewport[2] - viewport[0]
+    backdrop = np.ones((height, width, 3), dtype=np.float32)
+    alpha = np.zeros((height, width, 1), dtype=np.float32)
+    compositor = Compositor(viewport, backdrop, alpha)
     # 1.0 is exactly what _get_mask() yields for an unmasked layer.
     compositor._apply_stroke_effect(layer, 1.0, np.ones_like(alpha), True)
-    assert compositor.finish()[0].shape == (psd.height, psd.width, 3)
+    assert compositor.finish()[0].shape == (height, width, 3)
 
 
 def test_composite_stroke() -> None:

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 import pytest
 
+from psd_tools.api.layers import Group
 from psd_tools.api.psd_image import PSDImage
 from psd_tools.composite import _compat, composite, effects
 from psd_tools.composite.effects import (
@@ -16,7 +17,7 @@ from psd_tools.psd.descriptor import Descriptor, Double, Enumerated
 from psd_tools.terminology import Enum, Key, Klass
 
 from ..utils import full_name
-from .test_composite import check_composite_quality, composite_error
+from .test_composite import _canvas, check_composite_quality, composite_error
 
 logger = logging.getLogger(__name__)
 
@@ -680,3 +681,30 @@ def test_each_stroke_path_names_the_dependency_it_is_missing(
     monkeypatch.setattr(effects, "HAS_SCIPY", False)
     with pytest.raises(ImportError, match="Stroke effects require: scipy"):
         check_composite_quality("effects/outside-stroke.psd", threshold=1.0)
+
+
+def test_a_group_stroke_keeps_the_clipped_copy_outside_the_viewport() -> None:
+    """A group has no coverage to re-read, so its stroke keeps what it had.
+
+    #804 fixed the stroke by reading the layer's own coverage on the box it
+    draws on, which a group does not have: a group's coverage *is* the
+    composite onto the compositor's viewport. Reading it as an object finds
+    no pixel data and no fill, which would place the stroke on an empty
+    canvas and draw nothing at all -- worse than the misplaced stroke. The
+    clipped copy stands instead.
+    """
+    psd = PSDImage.open(full_name("hidden-groups.psd"))
+    group = next(sub for sub in psd if isinstance(sub, Group))
+    covered = np.ones((psd.height, psd.width, 1), dtype=np.float32)
+    compositor = _canvas(psd)
+
+    # A box reaching two pixels off every side of the canvas: the recompute
+    # path, and the one an off-canvas group would take.
+    viewport = (-2, -2, psd.width + 2, psd.height + 2)
+    traced = compositor._trace_shape(group, viewport, covered, traces_mask=False)
+
+    assert traced.shape == (psd.height + 4, psd.width + 4, 1)
+    assert np.array_equal(traced[2:-2, 2:-2], covered)
+    assert compositor._get_object_shape(group, viewport).max() == 0.0, (
+        "the group would read as no coverage at all"
+    )

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from psd_tools.api.psd_image import PSDImage
-from psd_tools.composite import _compat, effects
+from psd_tools.composite import _compat, composite, effects
 from psd_tools.composite.effects import (
     _OUTWARD_REACH,
     _distance_band,
@@ -16,7 +16,7 @@ from psd_tools.psd.descriptor import Descriptor, Double, Enumerated
 from psd_tools.terminology import Enum, Key, Klass
 
 from ..utils import full_name
-from .test_composite import check_composite_quality
+from .test_composite import check_composite_quality, composite_error
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +26,59 @@ logger = logging.getLogger(__name__)
     [
         ("effects/stroke-effects.psd",),
         ("effects/shape-fx2.psd",),
-        ("effects/stroke-effect-transparent-shape.psd",),
     ],
 )
 @pytest.mark.xfail
 def test_stroke_effects_xfail(filename: str) -> None:
     check_composite_quality(filename, threshold=0.01)
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_stroke_traces_the_layer_where_it_runs_off_the_canvas(force: bool) -> None:
+    """A stroke follows the layer's edge, not the edge of the canvas (#804).
+
+    ``stroke-effect-transparent-shape.psd`` is a 32x32 document holding one
+    shape layer with bbox ``(-2, -2, 34, 34)``, a path running ``(-1, -1)`` to
+    ``(33, 33)`` and a 4 px inset stroke, so the rectangle's left edge is a
+    pixel off-canvas. The compositor handed the stroke a copy of the coverage
+    clipped to its own viewport, where that pixel had been zero-filled, and
+    the ring landed on ``0..3`` measured from the canvas edge instead of on
+    ``-1..2`` measured from the layer's.
+
+    Both force modes, because they reach the coverage by different routes:
+    the stored alpha channel, and the vector mask redrawn from the path.
+    """
+    psd = PSDImage.open(full_name("effects/stroke-effect-transparent-shape.psd"))
+    result = composite(psd, force=force)[0]
+
+    # Three columns of stroke and then the layer's green interior. The pixels
+    # rather than the error: at 4 px wide the ring is off by one column, which
+    # a whole-image bound only registers as "smaller".
+    stroke, interior = result[16, 2], result[16, 3]
+    assert np.allclose(stroke, result[16, 0], atol=1 / 255.0)
+    assert not np.allclose(stroke, interior, atol=1 / 255.0)
+    assert np.allclose(interior, result[16, 4], atol=1 / 255.0)
+
+    composite_error(psd, threshold=1e-6, force=force)
+
+
+def test_stroke_ignores_a_viewport_narrower_than_the_layer() -> None:
+    """Asking for less of a layer must not move its stroke (#804).
+
+    No off-canvas geometry needed: a viewport that cuts through the layer used
+    to zero-fill the rest of the coverage the same way, so the stroke was
+    traced down the cut as if the square ended there. The wide render is the
+    reference because it is the one the fixture's own test already pins to
+    Photoshop.
+    """
+    psd = PSDImage.open(full_name("effects/center-stroke-sizes.psd"))
+    layer = next(sub for sub in psd if sub.name == "Size 7")
+    assert layer.bbox == (144, 16, 160, 32)
+
+    wide = composite(layer, viewport=(140, 12, 164, 36), as_layer=True)
+    cut = composite(layer, viewport=(140, 12, 152, 36), as_layer=True)
+    for name, w, c in zip(("color", "shape", "alpha"), wide, cut):
+        assert np.array_equal(c, w[:, :12]), name
 
 
 def test_double_stroke_effects() -> None:

--- a/tests/psd_tools/composite/test_effects.py
+++ b/tests/psd_tools/composite/test_effects.py
@@ -17,7 +17,7 @@ from psd_tools.psd.descriptor import Descriptor, Double, Enumerated
 from psd_tools.terminology import Enum, Key, Klass
 
 from ..utils import full_name
-from .test_composite import _canvas, check_composite_quality, composite_error
+from .test_composite import _canvas, _mse, check_composite_quality
 
 logger = logging.getLogger(__name__)
 
@@ -53,14 +53,16 @@ def test_stroke_traces_the_layer_where_it_runs_off_the_canvas(force: bool) -> No
     result = composite(psd, force=force)[0]
 
     # Three columns of stroke and then the layer's green interior. The pixels
-    # rather than the error: at 4 px wide the ring is off by one column, which
-    # a whole-image bound only registers as "smaller".
+    # rather than the error alone: at 4 px wide the ring is off by one column,
+    # which a whole-image bound only registers as "smaller".
     stroke, interior = result[16, 2], result[16, 3]
     assert np.allclose(stroke, result[16, 0], atol=1 / 255.0)
     assert not np.allclose(stroke, interior, atol=1 / 255.0)
     assert np.allclose(interior, result[16, 4], atol=1 / 255.0)
 
-    composite_error(psd, threshold=1e-6, force=force)
+    # Two orders of magnitude over the 1.3e-11 measured, and eight under the
+    # 0.022 this fixture sat at while it was an xfail.
+    assert _mse(psd.numpy(), result) <= 1e-9
 
 
 def test_stroke_ignores_a_viewport_narrower_than_the_layer() -> None:

--- a/tests/psd_tools/composite/test_vector.py
+++ b/tests/psd_tools/composite/test_vector.py
@@ -5,7 +5,7 @@ import pytest
 
 from psd_tools import PSDImage
 from psd_tools.api.layers import Group
-from psd_tools.composite import composite
+from psd_tools.composite import composite, vector
 from psd_tools.composite.paint import (
     draw_gradient_fill,
     draw_pattern_fill,
@@ -168,3 +168,33 @@ def test_gradient_styles(filename: str) -> None:
 )
 def test_stroke_color(filename: str, threshold: float) -> None:
     check_composite_quality(filename, threshold, force=True)
+
+
+def test_draw_vector_mask_reaches_outside_the_canvas() -> None:
+    """A path is rasterized in document coordinates, not clipped to the canvas.
+
+    ``stroke-effect-transparent-shape.psd`` holds a rectangle whose path runs
+    from (-1, -1) to (33, 33) on a 32x32 canvas, so on the canvas its left
+    edge is not in the picture at all -- every pixel of the row is covered.
+    Asked for a wider box, the rasterizer must place the same path on it and
+    put that edge back, which is what lets a stroke traced from the mask
+    follow the layer rather than the canvas (#804).
+    """
+    psd = PSDImage.open(full_name("effects/stroke-effect-transparent-shape.psd"))
+    layer = psd[1]
+
+    on_canvas = vector.draw_vector_mask(layer)
+    assert np.array_equal(on_canvas[16, :4, 0], np.ones(4, dtype=np.float32)), (
+        "the canvas holds no left edge to find"
+    )
+
+    viewport = (-3, -3, 35, 35)
+    wide = vector.draw_vector_mask(layer, viewport)
+    assert wide.shape == (38, 38, 1)
+    # Row 19 is y = 16, the same row; x = -3 and -2 are outside the path and
+    # x = -1 is the first column it covers.
+    assert wide[19, 0, 0] == 0.0
+    assert wide[19, 2, 0] == 1.0
+    # Placing the path elsewhere would also move it: where the two boxes
+    # overlap the coverage has to be identical.
+    assert np.array_equal(wide[3:35, 3:35], on_canvas)


### PR DESCRIPTION
Fixes #804.

`Compositor._apply_stroke_effect()` traced the layer from
`paste(bbox, self._viewport, shape)`. `shape` only ever covers the compositor's
viewport, so wherever the layer runs past that viewport its coverage was never
read, `paste()` zero-filled it, and every stroke primitive — all of them
anchored to a boundary — measured the **viewport edge** as if it were the
layer's own.

## The change

Read the coverage again on the box the stroke draws on. That box can reach
outside the canvas, so two things had to stop clipping to a viewport that is no
longer the right one:

- `_get_mask()` takes the box to read on, and the object shape is placed on it
  by `_place_object_shape()`, split out of `_get_object()` so both callers state
  once which of the two sources — stored pixels or a redrawn fill — a layer's
  arrays come from.
- `draw_vector_mask()` rasterizes onto that box. Knot coordinates are fractions
  of the document either way, so the symbol is still built against the document
  size and then translated by the box origin, which goes negative for a box
  starting off-canvas.

Where the box stays inside the compositor's viewport — the common case — the
coverage already computed for the layer is the answer, and is used as before.

## Results

`effects/stroke-effect-transparent-shape.psd` is a 32×32 document whose one
shape layer has bbox `(-2, -2, 34, 34)` and a 4 px inset stroke, so its left
edge is a pixel off-canvas:

| | before | after |
| --- | --- | --- |
| force=False | 0.0221353 | 1.27e-11 |
| force=True | 0.0221353 | 1.27e-11 |

It leaves the stroke `xfail` list. The issue's second reproduction — a viewport
narrowed to cut through the layer — now returns exactly the crop of the wide
render.

Over the whole fixture corpus, **596 document renders in both force modes, it
is the only output that changes at all.**

Both halves of the fix are load-bearing and were checked separately: reverting
the `vector.py` half regresses `force=True` back to 0.0221353 and leaves
`force=False` correct; reverting the object-shape half does the reverse.

## Scope of the rendering change

Beyond the two cases in the issue, a vector mask now rasterizes on the box
asked for rather than at document size and cropped. aggdraw is not exactly
translation-invariant, so a layer wholly inside the canvas can shift by 1/255
when the viewport is not the whole canvas — four values on
`layers-minimal/shape-layer.psd`'s `Polygon 1`, for instance. Document
composites are unaffected. `draw_vector_mask()` is documented public API, so
its new parameter gets an `[api]` changelog line alongside the `[fix]`.

## What this does *not* fix

**A stroke effect on a group.** A group's coverage *is* the composite onto the
compositor's viewport and exists nowhere else, so there is nothing to re-read;
reading it as an object finds no pixel data and no fill, which would draw no
stroke at all — worse than a misplaced one. Groups keep the clipped copy, with
a test pinning that. No fixture in the corpus puts a stroke on a group, so
nothing would have caught the regression. Filed as #808, together with the
other group-boundary case a review turned up: `_get_group()`'s viewport is the
group's bbox, which excludes effect coverage, so a child's outset stroke is cut
at the group edge.

One more pre-existing bug found while reviewing and filed as #807:
`_get_stroke()` places the *vector* stroke at the wrong offset whenever the
viewport has the document's dimensions but a different origin —
`composite(viewport=(1, 1, W+1, H+1))` on `stroke.psd` differs from the correct
shift by a full 1.0.

## Tests

Five, each verified to fail with `src/` reverted:

- the fixture against Photoshop, both force modes, plus the ring's column
  positions — at 4 px wide the old ring was off by one column, which a
  whole-image bound only registers as "smaller";
- a narrowed viewport returning the crop of the wide render;
- `draw_vector_mask()` on a box reaching off the canvas, agreeing with the
  canvas-sized raster where they overlap;
- a group's stroke keeping the clipped copy.

`test_composite_stroke_effect_over_a_layer_without_a_mask` (#711) had gone
vacuous under the new code — its layer's stroke box starts outside the canvas
it renders on, so the scalar it exists to guard was never consumed. Its
viewport is grown past the box; with `broadcast_to` neutered the call raises
again on the grown viewport and not on the canvas one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
